### PR TITLE
[Feature] Add ability to generate asynchronously using webhooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/monolog-bundle": "^3.10",
         "symfony/stopwatch": "^6.4 || ^7.0",
         "symfony/twig-bundle": "^6.4 || ^7.0",
-        "symfony/var-dumper": "^6.4 || ^7.0"
+        "symfony/var-dumper": "^6.4 || ^7.0",
+        "symfony/webhook": "^6.4 || ^7.0"
     },
     "config": {
         "allow-plugins": {

--- a/config/builder_pdf.php
+++ b/config/builder_pdf.php
@@ -21,6 +21,7 @@ return static function (ContainerConfigurator $container): void {
             service('sensiolabs_gotenberg.client'),
             service('sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('twig')->nullOnInvalid(),
+            service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])
         ->tag('sensiolabs_gotenberg.pdf_builder')
@@ -33,6 +34,7 @@ return static function (ContainerConfigurator $container): void {
             service('sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('twig')->nullOnInvalid(),
             service('router')->nullOnInvalid(),
+            service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])
         ->call('setRequestContext', [service('.sensiolabs_gotenberg.request_context')->nullOnInvalid()])
@@ -45,6 +47,7 @@ return static function (ContainerConfigurator $container): void {
             service('sensiolabs_gotenberg.client'),
             service('sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('twig')->nullOnInvalid(),
+            service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])
         ->tag('sensiolabs_gotenberg.pdf_builder')
@@ -55,6 +58,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             service('sensiolabs_gotenberg.client'),
             service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])
         ->tag('sensiolabs_gotenberg.pdf_builder')

--- a/src/Builder/AsyncBuilderInterface.php
+++ b/src/Builder/AsyncBuilderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder;
+
+interface AsyncBuilderInterface
+{
+    /**
+     * Generates a file asynchronously.
+     */
+    public function generateAsync(): string;
+}

--- a/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
+++ b/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
@@ -3,6 +3,7 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
+use Sensiolabs\GotenbergBundle\DependencyInjection\WebhookConfigurationRegistry;
 use Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType;
 use Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
@@ -21,8 +22,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         GotenbergClientInterface $gotenbergClient,
         AssetBaseDirFormatter $asset,
         private readonly Environment|null $twig = null,
+        WebhookConfigurationRegistry|null $webhookConfigurationRegistry = null,
     ) {
-        parent::__construct($gotenbergClient, $asset);
+        parent::__construct($gotenbergClient, $asset, $webhookConfigurationRegistry);
     }
 
     /**
@@ -552,6 +554,7 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
             'fail_on_console_exceptions' => $this->failOnConsoleExceptions($value),
             'skip_network_idle_event' => $this->skipNetworkIdleEvent($value),
             'metadata' => $this->metadata($value),
+            'webhook' => null,
             default => throw new InvalidBuilderConfiguration(sprintf('Invalid option "%s": no method does not exist in class "%s" to configured it.', $configurationName, static::class)),
         };
     }

--- a/src/Builder/Pdf/AbstractPdfBuilder.php
+++ b/src/Builder/Pdf/AbstractPdfBuilder.php
@@ -3,8 +3,10 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Psr\Log\LoggerInterface;
+use Sensiolabs\GotenbergBundle\Builder\AsyncBuilderInterface;
 use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
 use Sensiolabs\GotenbergBundle\Client\GotenbergResponse;
+use Sensiolabs\GotenbergBundle\DependencyInjection\WebhookConfigurationRegistry;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
 use Sensiolabs\GotenbergBundle\Exception\JsonEncodingException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
@@ -12,7 +14,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\Mime\Part\DataPart;
 
-abstract class AbstractPdfBuilder implements PdfBuilderInterface
+abstract class AbstractPdfBuilder implements PdfBuilderInterface, AsyncBuilderInterface
 {
     protected LoggerInterface|null $logger = null;
 
@@ -29,10 +31,18 @@ abstract class AbstractPdfBuilder implements PdfBuilderInterface
      * @var array<string, (\Closure(mixed): array<string, array<string|int, mixed>|non-empty-string|\Stringable|int|float|bool|\BackedEnum|DataPart>)>
      */
     private array $normalizers;
+    private string $webhookUrl;
+    private string $errorWebhookUrl;
+    /**
+     * @var array<string, mixed>
+     */
+    private array $webhookExtraHeaders = [];
+    private \Closure $operationIdGenerator;
 
     public function __construct(
         protected readonly GotenbergClientInterface $gotenbergClient,
         protected readonly AssetBaseDirFormatter $asset,
+        protected readonly WebhookConfigurationRegistry|null $webhookConfigurationRegistry = null,
     ) {
         $this->normalizers = [
             'extraHttpHeaders' => function (mixed $value): array {
@@ -60,6 +70,8 @@ abstract class AbstractPdfBuilder implements PdfBuilderInterface
                 return $this->encodeData('metadata', $value);
             },
         ];
+
+        $this->operationIdGenerator = static fn (): string => uniqid('gotenberg_', true);
     }
 
     public function setLogger(LoggerInterface|null $logger): void
@@ -122,6 +134,66 @@ abstract class AbstractPdfBuilder implements PdfBuilderInterface
         }
 
         return $pdfResponse;
+    }
+
+    public function generateAsync(): string
+    {
+        $operationId = ($this->operationIdGenerator)();
+        $this->logger?->debug('Generating PDF file async with operation id {sensiolabs_gotenberg.operation_id} using {sensiolabs_gotenberg.builder} builder.', [
+            'sensiolabs_gotenberg.operation_id' => $operationId,
+            'sensiolabs_gotenberg.builder' => $this::class,
+        ]);
+
+        $this->webhookExtraHeaders['X-Gotenberg-Operation-Id'] = $operationId;
+        $headers = [
+            'Gotenberg-Webhook-Url' => $this->webhookUrl,
+            'Gotenberg-Webhook-Error-Url' => $this->errorWebhookUrl,
+            'Gotenberg-Webhook-Extra-Http-Headers' => json_encode($this->webhookExtraHeaders, \JSON_THROW_ON_ERROR),
+        ];
+        if (null !== $this->fileName) {
+            $headers['Gotenberg-Output-Filename'] = basename($this->fileName, '.pdf');
+        }
+        $this->gotenbergClient->call($this->getEndpoint(), $this->getMultipartFormData(), $headers);
+
+        return $operationId;
+    }
+
+    public function withWebhookConfiguration(string $webhook): static
+    {
+        if (null === $this->webhookConfigurationRegistry) {
+            throw new \LogicException('The WebhookConfigurationRegistry is not available.');
+        }
+        $webhookConfiguration = $this->webhookConfigurationRegistry->get($webhook);
+
+        return $this->withWebhookUrls($webhookConfiguration['success'], $webhookConfiguration['error']);
+    }
+
+    public function withWebhookUrls(string $successWebhook, string|null $errorWebhook = null): static
+    {
+        $clone = clone $this;
+        $clone->webhookUrl = $successWebhook;
+        $clone->errorWebhookUrl = $errorWebhook ?? $successWebhook;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, mixed> $extraHeaders
+     */
+    public function withWebhookExtraHeaders(array $extraHeaders): static
+    {
+        $clone = clone $this;
+        $clone->webhookExtraHeaders = array_merge($this->webhookExtraHeaders, $extraHeaders);
+
+        return $clone;
+    }
+
+    public function withOperationIdGenerator(\Closure $operationIdGenerator): static
+    {
+        $clone = clone $this;
+        $clone->operationIdGenerator = $operationIdGenerator;
+
+        return $clone;
     }
 
     /**

--- a/src/Builder/Pdf/UrlPdfBuilder.php
+++ b/src/Builder/Pdf/UrlPdfBuilder.php
@@ -3,6 +3,7 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
+use Sensiolabs\GotenbergBundle\DependencyInjection\WebhookConfigurationRegistry;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -20,8 +21,9 @@ final class UrlPdfBuilder extends AbstractChromiumPdfBuilder
         AssetBaseDirFormatter $asset,
         Environment|null $twig = null,
         private readonly UrlGeneratorInterface|null $urlGenerator = null,
+        WebhookConfigurationRegistry|null $webhookConfigurationRegistry = null,
     ) {
-        parent::__construct($gotenbergClient, $asset, $twig);
+        parent::__construct($gotenbergClient, $asset, $twig, $webhookConfigurationRegistry);
 
         $this->addNormalizer('route', $this->generateUrlFromRoute(...));
     }

--- a/src/Client/GotenbergClient.php
+++ b/src/Client/GotenbergClient.php
@@ -26,7 +26,7 @@ final class GotenbergClient implements GotenbergClientInterface
             ],
         );
 
-        if (200 !== $response->getStatusCode()) {
+        if (!\in_array($response->getStatusCode(), [200, 204], true)) {
             throw new HttpException($response->getStatusCode(), $response->getContent());
         }
 

--- a/src/Debug/Builder/TraceablePdfBuilder.php
+++ b/src/Debug/Builder/TraceablePdfBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Debug\Builder;
 
+use Sensiolabs\GotenbergBundle\Builder\AsyncBuilderInterface;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\PdfBuilderInterface;
 use Sensiolabs\GotenbergBundle\Client\GotenbergResponse;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -62,6 +63,22 @@ final class TraceablePdfBuilder implements PdfBuilderInterface
         ++$this->totalGenerated;
 
         return $response;
+    }
+
+    public function generateAsync(): string
+    {
+        if (!$this->inner instanceof AsyncBuilderInterface) {
+            throw new \LogicException(sprintf('The inner builder of %s must implement %s.', self::class, AsyncBuilderInterface::class));
+        }
+
+        $name = self::$count.'.'.$this->inner::class.'::'.__FUNCTION__;
+        ++self::$count;
+
+        $swEvent = $this->stopwatch->start($name, 'gotenberg.generate_pdf');
+        $gotenbergTrace = $this->inner->generateAsync();
+        $swEvent->stop();
+
+        return $gotenbergTrace;
     }
 
     /**

--- a/src/DependencyInjection/WebhookConfigurationRegistry.php
+++ b/src/DependencyInjection/WebhookConfigurationRegistry.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\DependencyInjection;
+
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * @internal
+ *
+ * @phpstan-type WebhookDefinition array{url?: string, route?: array{0: string, 1: array<string|int, mixed>}, webhook?: string}
+ */
+final class WebhookConfigurationRegistry
+{
+    /**
+     * @var array<string, array{success: string, error: string}>
+     */
+    private array $configurations = [];
+
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly RequestContext|null $requestContext,
+    ) {
+    }
+
+    /**
+     * @param array{success: WebhookDefinition, error?: WebhookDefinition} $configuration
+     */
+    public function add(string $name, array $configuration): void
+    {
+        $requestContext = $this->urlGenerator->getContext();
+        if (null !== $this->requestContext) {
+            $this->urlGenerator->setContext($this->requestContext);
+        }
+
+        try {
+            $success = $this->processWebhookConfiguration($configuration['success']);
+            $error = $success;
+            if (isset($configuration['error'])) {
+                $error = $this->processWebhookConfiguration($configuration['error']);
+            }
+            $this->configurations[$name] = ['success' => $success, 'error' => $error];
+        } finally {
+            $this->urlGenerator->setContext($requestContext);
+        }
+    }
+
+    /**
+     * @return array{success: string, error: string}
+     */
+    public function get(string $name): array
+    {
+        if (!\array_key_exists($name, $this->configurations)) {
+            throw new \InvalidArgumentException(sprintf('Webhook configuration "%s" not found.', $name));
+        }
+
+        return $this->configurations[$name];
+    }
+
+    /**
+     * @param WebhookDefinition $webhookDefinition
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function processWebhookConfiguration(array $webhookDefinition): string
+    {
+        if (isset($webhookDefinition['url'])) {
+            return $webhookDefinition['url'];
+        }
+        if (isset($webhookDefinition['route'])) {
+            return $this->urlGenerator->generate($webhookDefinition['route'][0], $webhookDefinition['route'][1], UrlGeneratorInterface::ABSOLUTE_URL);
+        }
+        if (isset($webhookDefinition['webhook'])) {
+            return $this->urlGenerator->generate('_webhook_controller', ['type' => $webhookDefinition['webhook']], UrlGeneratorInterface::ABSOLUTE_URL);
+        }
+
+        throw new \InvalidArgumentException('Invalid webhook configuration');
+    }
+}

--- a/src/RemoteEvent/ErrorPayloadConverter.php
+++ b/src/RemoteEvent/ErrorPayloadConverter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\RemoteEvent;
+
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\RemoteEvent\PayloadConverterInterface;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+
+class ErrorPayloadConverter implements PayloadConverterInterface
+{
+    /**
+     * @param array{headers?: HeaderBag, content?: string} $payload
+     */
+    public function convert(array $payload): RemoteEvent
+    {
+        if (!isset($payload['headers']) || !isset($payload['content'])) {
+            throw new ParseException('Invalid payload: missing "headers" or "content".');
+        }
+        $headers = $payload['headers'];
+        $content = $payload['content'];
+
+        return new OperationErrorEvent($content, $headers);
+    }
+}

--- a/src/RemoteEvent/OperationErrorEvent.php
+++ b/src/RemoteEvent/OperationErrorEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\RemoteEvent;
+
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+
+class OperationErrorEvent extends RemoteEvent
+{
+    public function __construct(string $error, HeaderBag $headers)
+    {
+        parent::__construct('OperationError', $headers->get('X-Gotenberg-Operation-Id', ''), ['error' => $error, 'headers' => $headers]);
+    }
+
+    public function getError(): string
+    {
+        return $this->getPayload()['error'];
+    }
+
+    public function getHeaders(): HeaderBag
+    {
+        return $this->getPayload()['headers'];
+    }
+}

--- a/src/RemoteEvent/OperationSuccessEvent.php
+++ b/src/RemoteEvent/OperationSuccessEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\RemoteEvent;
+
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+
+class OperationSuccessEvent extends RemoteEvent
+{
+    public function __construct(string $fileName, string $fileContent, HeaderBag $headers)
+    {
+        parent::__construct('OperationSuccess', $headers->get('X-Gotenberg-Operation-Id', ''), ['fileName' => $fileName, 'fileContent' => $fileContent, 'headers' => $headers]);
+    }
+
+    public function getFileContent(): string
+    {
+        return $this->getPayload()['fileContent'];
+    }
+
+    public function getFileName(): string
+    {
+        return $this->getPayload()['fileName'];
+    }
+
+    public function getHeaders(): HeaderBag
+    {
+        return $this->getPayload()['headers'];
+    }
+}

--- a/src/RemoteEvent/SuccessPayloadConverter.php
+++ b/src/RemoteEvent/SuccessPayloadConverter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\RemoteEvent;
+
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\RemoteEvent\PayloadConverterInterface;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+
+class SuccessPayloadConverter implements PayloadConverterInterface
+{
+    /**
+     * @param array{headers?: HeaderBag, content?: string} $payload
+     */
+    public function convert(array $payload): RemoteEvent
+    {
+        if (!isset($payload['headers']) || !isset($payload['content'])) {
+            throw new ParseException('Invalid payload: missing "headers" or "content".');
+        }
+        $headers = $payload['headers'];
+        $content = $payload['content'];
+        $matches = [];
+
+        /* @see https://onlinephp.io/c/c2606 */
+        if (!preg_match('#[^;]*;\sfilename="?(?P<fileName>[^"]*)"?#', $headers->get('Content-Disposition', ''), $matches)) {
+            $matches['fileName'] = ($headers->get('X-Gotenberg-Operation-Id') ?? throw new ParseException('Missing filename in headers')).'.pdf';
+        }
+        $fileName = $matches['fileName'];
+
+        return new OperationSuccessEvent($fileName, $content, $headers);
+    }
+}

--- a/src/Webhook/ErrorWebhookRequestParser.php
+++ b/src/Webhook/ErrorWebhookRequestParser.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Webhook;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use Sensiolabs\GotenbergBundle\RemoteEvent\ErrorPayloadConverter;
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\HeaderRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+class ErrorWebhookRequestParser extends AbstractRequestParser implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    public function __construct(
+        private readonly ErrorPayloadConverter $payloadConverter,
+    ) {
+        $this->logger = new NullLogger();
+    }
+
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        $requestMatchers = [
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ];
+        // Class introduced in Symfony 7.1
+        if (class_exists(HeaderRequestMatcher::class)) {
+            $requestMatchers[] = new HeaderRequestMatcher('Gotenberg-Trace');
+            $requestMatchers[] = new HeaderRequestMatcher('X-Gotenberg-Operation-Id');
+        }
+
+        return new ChainRequestMatcher($requestMatchers);
+    }
+
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|null
+    {
+        if (!$request->headers->has('Gotenberg-Trace')) {
+            throw new RejectWebhookException(406, 'Missing "Gotenberg-Trace" header');
+        }
+        if (!$request->headers->has('X-Gotenberg-Operation-Id')) {
+            throw new RejectWebhookException(406, 'Missing "X-Gotenberg-Operation-Id" header');
+        }
+
+        $this->logger?->debug('Error request matched', ['headers' => $request->headers->all(), 'content' => $request->getContent()]);
+
+        return $this->payloadConverter->convert(['headers' => $request->headers, 'content' => $request->getContent()]);
+    }
+}

--- a/src/Webhook/SuccessWebhookRequestParser.php
+++ b/src/Webhook/SuccessWebhookRequestParser.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Webhook;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use Sensiolabs\GotenbergBundle\RemoteEvent\SuccessPayloadConverter;
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\HeaderRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+class SuccessWebhookRequestParser extends AbstractRequestParser implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    public function __construct(
+        private readonly SuccessPayloadConverter $payloadConverter,
+    ) {
+        $this->logger = new NullLogger();
+    }
+
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        $requestMatchers = [
+            new MethodRequestMatcher('POST'),
+        ];
+        // Class introduced in Symfony 7.1
+        if (class_exists(HeaderRequestMatcher::class)) {
+            $requestMatchers[] = new HeaderRequestMatcher('Gotenberg-Trace');
+            $requestMatchers[] = new HeaderRequestMatcher('X-Gotenberg-Operation-Id');
+            $requestMatchers[] = new HeaderRequestMatcher('Content-Disposition');
+        }
+
+        return new ChainRequestMatcher($requestMatchers);
+    }
+
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|null
+    {
+        if (!class_exists(HeaderRequestMatcher::class)) {
+            $this->checkForHeaders($request, ['Gotenberg-Trace', 'X-Gotenberg-Operation-Id', 'Content-Disposition']);
+        }
+
+        $this->logger?->debug('Success request matched', ['headers' => $request->headers->all(), 'content' => $request->getContent()]);
+
+        return $this->payloadConverter->convert(['headers' => $request->headers, 'content' => $request->getContent()]);
+    }
+
+    /**
+     * @param list<string> $headers
+     */
+    private function checkForHeaders(Request $request, array $headers): void
+    {
+        foreach ($headers as $header) {
+            if (!$request->headers->has($header)) {
+                throw new RejectWebhookException(406, sprintf('Missing "%s" header.', $header));
+            }
+        }
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -66,8 +66,55 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
+     * @return \Generator<string, array{array{array<string, array<string|int, mixed>>}}>
+     */
+    public static function invalidWebhookConfigurationProvider(): \Generator
+    {
+        yield 'webhook definition without "success" and "error" keys' => [
+            [['webhook' => ['foo' => ['some_key' => ['url' => 'http://example.com']]]]],
+        ];
+        yield 'webhook definition without "success" key' => [
+            [['webhook' => ['foo' => ['error' => ['url' => 'http://example.com']]]]],
+        ];
+        yield 'webhook definition without name' => [
+            [['webhook' => [['success' => ['url' => 'http://example.com']], ['error' => ['url' => 'http://example.com/error']]]]],
+        ];
+        yield 'webhook definition with invalid "url" key' => [
+            [['webhook' => ['foo' => ['success' => ['url' => ['array_element']]]]]],
+        ];
+        yield 'webhook definition with array of string as "route" key' => [
+            [['webhook' => ['foo' => ['success' => ['route' => ['array_element']]]]]],
+        ];
+        yield 'webhook definition with array of two strings as "route" key' => [
+            [['webhook' => ['foo' => ['success' => ['route' => ['array_element', 'array_element_2']]]]]],
+        ];
+        yield 'webhook definition in default webhook declaration' => [
+            [['default_options' => ['webhook' => ['success' => ['url' => 'http://example.com']]]]],
+        ];
+    }
+
+    /**
+     * @param array<array<string, mixed>> $config
+     *
+     * @dataProvider invalidWebhookConfigurationProvider
+     */
+    #[DataProvider('invalidWebhookConfigurationProvider')]
+    public function testInvalidWebhookConfiguration(array $config): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $processor = new Processor();
+        $processor->processConfiguration(
+            new Configuration(),
+            $config,
+        );
+    }
+
+    /**
      * @return array{
      *     'base_uri': string,
+     *     'assets_directory': string,
+     *     'http_client': string,
+     *     'webhook': array<void>,
      *     'default_options': array{
      *         'pdf': array{
      *              'html': array<string, mixed>,
@@ -85,6 +132,7 @@ final class ConfigurationTest extends TestCase
             'base_uri' => 'http://localhost:3000',
             'assets_directory' => '%kernel.project_dir%/assets',
             'http_client' => 'http_client',
+            'webhook' => [],
             'default_options' => [
                 'pdf' => [
                     'html' => [

--- a/tests/DependencyInjection/WebhookConfigurationRegistryTest.php
+++ b/tests/DependencyInjection/WebhookConfigurationRegistryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\DependencyInjection\WebhookConfigurationRegistry;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * @phpstan-type WebhookDefinition array{url?: string, route?: array{0: string, 1: array<string|int, mixed>}, webhook?: string}
+ */
+#[CoversClass(WebhookConfigurationRegistry::class)]
+final class WebhookConfigurationRegistryTest extends TestCase
+{
+    public function testGetUndefinedConfiguration(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Webhook configuration "undefined" not found.');
+
+        $registry = new WebhookConfigurationRegistry($this->createMock(UrlGeneratorInterface::class), null);
+        $registry->get('undefined');
+    }
+
+    public function testAddConfigurationUsingCustomContext(): void
+    {
+        $requestContext = $this->createMock(RequestContext::class);
+        $urlGenerator = $this->getUrlGenerator($requestContext);
+        $registry = new WebhookConfigurationRegistry($urlGenerator, $requestContext);
+        $registry->add('test', ['success' => ['url' => 'http://example.com/success']]);
+    }
+
+    public function testOverrideConfiguration(): void
+    {
+        $registry = new WebhookConfigurationRegistry($this->createMock(UrlGeneratorInterface::class), null);
+        $registry->add('test', ['success' => ['url' => 'http://example.com/success']]);
+        $this->assertSame(['success' => 'http://example.com/success', 'error' => 'http://example.com/success'], $registry->get('test'));
+        $registry->add('test', ['success' => ['url' => 'http://example.com/override']]);
+        $this->assertSame(['success' => 'http://example.com/override', 'error' => 'http://example.com/override'], $registry->get('test'));
+    }
+
+    /**
+     * @return \Generator<string, array{0: array{success: WebhookDefinition, error?: WebhookDefinition}, 1: array{success: string, error: string}}>
+     */
+    public static function configurationProvider(): \Generator
+    {
+        yield 'full definition with urls' => [
+            ['success' => ['url' => 'http://example.com/success'], 'error' => ['url' => 'http://example.com/error']],
+            ['success' => 'http://example.com/success', 'error' => 'http://example.com/error'],
+        ];
+        yield 'full definition with routes' => [
+            ['success' => ['route' => ['test_route_success', ['param' => 'value']]], 'error' => ['route' => ['test_route_error', ['param' => 'value']]]],
+            ['success' => 'http://localhost/test_route?param=value', 'error' => 'http://localhost/test_route?param=value'],
+        ];
+        yield 'full definition with webhook' => [
+            ['success' => ['webhook' => 'my_success_webhook'], 'error' => ['webhook' => 'my_error_webhook']],
+            ['success' => 'http://localhost/webhook/success', 'error' => 'http://localhost/webhook/error'],
+        ];
+        yield 'partial definition with urls' => [
+            ['success' => ['url' => 'http://example.com/success']],
+            ['success' => 'http://example.com/success', 'error' => 'http://example.com/success'],
+        ];
+        yield 'partial definition with routes' => [
+            ['success' => ['route' => ['test_route_success', ['param' => 'value']]],
+                'error' => ['route' => ['test_route_error', ['param' => 'value']]],
+            ],
+            ['success' => 'http://localhost/test_route?param=value', 'error' => 'http://localhost/test_route?param=value'],
+        ];
+        yield 'partial definition with webhook' => [
+            ['success' => ['webhook' => 'my_success_webhook']],
+            ['success' => 'http://localhost/webhook/success', 'error' => 'http://localhost/webhook/success'],
+        ];
+        yield 'mixed definition with url and route' => [
+            ['success' => ['url' => 'http://example.com/success'], 'error' => ['route' => ['test_route_error', ['param' => 'value']]],
+            ],
+            ['success' => 'http://example.com/success', 'error' => 'http://localhost/test_route?param=value'],
+        ];
+        yield 'mixed definition with url and webhook' => [
+            ['success' => ['url' => 'http://example.com/success'], 'error' => ['webhook' => 'my_error_webhook']],
+            ['success' => 'http://example.com/success', 'error' => 'http://localhost/webhook/error'],
+        ];
+        yield 'mixed definition with route and webhook' => [
+            ['success' => ['route' => ['test_route_success', ['param' => 'value']]], 'error' => ['webhook' => 'my_error_webhook']],
+            ['success' => 'http://localhost/test_route?param=value', 'error' => 'http://localhost/webhook/error'],
+        ];
+    }
+
+    /**
+     * @param array{success: WebhookDefinition, error?: WebhookDefinition} $configuration
+     * @param array{success: string, error: string}                        $expectedUrls
+     *
+     * @throws Exception
+     */
+    #[DataProvider('configurationProvider')]
+    public function testAddConfiguration(array $configuration, array $expectedUrls): void
+    {
+        $registry = new WebhookConfigurationRegistry($this->getUrlGenerator(), null);
+        $registry->add('test', $configuration);
+
+        $this->assertSame($expectedUrls, $registry->get('test'));
+    }
+
+    private function getUrlGenerator(RequestContext|null $requestContext = null): UrlGeneratorInterface&MockObject
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $originalContext = $this->createMock(RequestContext::class);
+        $urlGenerator->expects(self::once())->method('getContext')->willReturn($originalContext);
+        $urlGenerator->expects(self::exactly(null !== $requestContext ? 2 : 1))
+            ->method('setContext')
+            ->willReturnCallback(function (RequestContext $context) use ($originalContext, $requestContext): void {
+                match ($context) {
+                    $requestContext, $originalContext => null,
+                    default => self::fail('setContext was called with an unexpected context.'),
+                };
+            });
+        $urlGenerator->method('generate')->willReturnMap([
+            ['test_route_success', ['param' => 'value'], UrlGeneratorInterface::ABSOLUTE_URL, 'http://localhost/test_route?param=value'],
+            ['test_route_error', ['param' => 'value'], UrlGeneratorInterface::ABSOLUTE_URL, 'http://localhost/test_route?param=value'],
+            ['_webhook_controller', ['type' => 'my_success_webhook'], UrlGeneratorInterface::ABSOLUTE_URL, 'http://localhost/webhook/success'],
+            ['_webhook_controller', ['type' => 'my_error_webhook'], UrlGeneratorInterface::ABSOLUTE_URL, 'http://localhost/webhook/error'],
+        ]);
+
+        return $urlGenerator;
+    }
+}

--- a/tests/RemoteEvent/ErrorPayloadConverterTest.php
+++ b/tests/RemoteEvent/ErrorPayloadConverterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\RemoteEvent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\RemoteEvent\ErrorPayloadConverter;
+use Sensiolabs\GotenbergBundle\RemoteEvent\OperationErrorEvent;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+
+#[CoversClass(ErrorPayloadConverter::class)]
+#[UsesClass(OperationErrorEvent::class)]
+class ErrorPayloadConverterTest extends TestCase
+{
+    public function testConvertValidPayload(): void
+    {
+        $payload = [
+            'headers' => new HeaderBag(['Gotenberg-Trace' => '123456789', 'X-Gotenberg-Operation-Id' => '987654321']),
+            'content' => '{"error": "An error occurred."}',
+        ];
+        $expectedEvent = new OperationErrorEvent('{"error": "An error occurred."}', new HeaderBag([
+            'Gotenberg-Trace' => '123456789',
+            'X-Gotenberg-Operation-Id' => '987654321',
+        ]));
+        $converter = new ErrorPayloadConverter();
+        $event = $converter->convert($payload);
+
+        $this->assertEquals($expectedEvent, $event);
+    }
+
+    /**
+     * @return \Generator<string, array{0: array{headers?: HeaderBag, content?: string}, 1: class-string<\Throwable>}, void, void>
+     */
+    public static function invalidPayloadProvider(): \Generator
+    {
+        yield 'missing headers' => [
+            [
+                'content' => 'content',
+            ],
+            ParseException::class,
+        ];
+        yield 'missing content' => [
+            [
+                'headers' => new HeaderBag(['Gotenberg-Trace' => '123456789', 'X-Gotenberg-Operation-Id' => '987654321', 'Content-Disposition' => 'attachement; filename="file.pdf"']),
+            ],
+            ParseException::class,
+        ];
+    }
+
+    /**
+     * @param array{headers: HeaderBag, content: string} $payload
+     * @param class-string<\Throwable>                   $expectedThrowable
+     */
+    #[DataProvider('invalidPayloadProvider')]
+    public function testConvertInvalidPayload(array $payload, string $expectedThrowable): void
+    {
+        $this->expectException($expectedThrowable);
+        $converter = new ErrorPayloadConverter();
+        $converter->convert($payload);
+    }
+}

--- a/tests/RemoteEvent/OperationErrorEventTest.php
+++ b/tests/RemoteEvent/OperationErrorEventTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\RemoteEvent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\RemoteEvent\OperationErrorEvent;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+#[CoversClass(OperationErrorEvent::class)]
+class OperationErrorEventTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: OperationErrorEvent, 1: string, 2: HeaderBag, 3: string, 4: string}, void, void>
+     */
+    public static function validPayloadProvider(): \Generator
+    {
+        yield 'Simple payload' => [
+            new OperationErrorEvent('{"error": "An error occurred."}', new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'X-Gotenberg-Operation-Id' => '987654321',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ])),
+            '{"error": "An error occurred."}',
+            new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'X-Gotenberg-Operation-Id' => '987654321',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ]),
+            'OperationError',
+            '987654321',
+        ];
+        yield 'Missing "X-Gotenberg-Operation-Id" header' => [
+            new OperationErrorEvent('{"error": "An error occurred."}', new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ])),
+            '{"error": "An error occurred."}',
+            new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ]),
+            'OperationError',
+            '',
+        ];
+    }
+
+    #[DataProvider('validPayloadProvider')]
+    public function testOperationErrorEvent(OperationErrorEvent $event, string $expectedError, HeaderBag $expectedHeaders, string $expectedEventName, string $expectedEventId): void
+    {
+        $this->assertEquals($expectedError, $event->getError());
+        $this->assertEquals($expectedHeaders, $event->getHeaders());
+        $this->assertEquals($expectedEventName, $event->getName());
+        $this->assertEquals($expectedEventId, $event->getId());
+    }
+}

--- a/tests/RemoteEvent/OperationSuccessEventTest.php
+++ b/tests/RemoteEvent/OperationSuccessEventTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\RemoteEvent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\RemoteEvent\OperationSuccessEvent;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+#[CoversClass(OperationSuccessEvent::class)]
+class OperationSuccessEventTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: OperationSuccessEvent, 1: string, 2: string, 3: HeaderBag, 4: string, 5: string}, void, void>
+     */
+    public static function validPayloadProvider(): \Generator
+    {
+        yield 'Simple payload' => [
+            new OperationSuccessEvent('file.pdf', 'content', new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'X-Gotenberg-Operation-Id' => '987654321',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ])),
+            'file.pdf',
+            'content',
+            new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'X-Gotenberg-Operation-Id' => '987654321',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ]),
+            'OperationSuccess',
+            '987654321',
+        ];
+        yield 'Missing "X-Gotenberg-Operation-Id" header' => [
+            new OperationSuccessEvent('file.pdf', 'content', new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ])),
+            'file.pdf',
+            'content',
+            new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ]),
+            'OperationSuccess',
+            '',
+        ];
+    }
+
+    #[DataProvider('validPayloadProvider')]
+    public function testOperationSuccessEvent(OperationSuccessEvent $event, string $expectedFileName, string $expectedFileContent, HeaderBag $expectedHeaders, string $expectedEventName, string $expectedEventId): void
+    {
+        $this->assertEquals($expectedFileName, $event->getFileName());
+        $this->assertEquals($expectedFileContent, $event->getFileContent());
+        $this->assertEquals($expectedHeaders, $event->getHeaders());
+        $this->assertEquals($expectedEventName, $event->getName());
+        $this->assertEquals($expectedEventId, $event->getId());
+    }
+}

--- a/tests/RemoteEvent/SuccessPayloadConverterTest.php
+++ b/tests/RemoteEvent/SuccessPayloadConverterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\RemoteEvent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\RemoteEvent\OperationSuccessEvent;
+use Sensiolabs\GotenbergBundle\RemoteEvent\SuccessPayloadConverter;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+
+#[CoversClass(SuccessPayloadConverter::class)]
+#[UsesClass(OperationSuccessEvent::class)]
+class SuccessPayloadConverterTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: array{headers: HeaderBag, content: string}, 1: OperationSuccessEvent}, void, void>
+     */
+    public static function validPayloadProvider(): \Generator
+    {
+        yield 'Simple payload' => [
+            [
+                'headers' => new HeaderBag(['Gotenberg-Trace' => '123456789', 'X-Gotenberg-Operation-Id' => '987654321', 'Content-Disposition' => 'attachement; filename="file.pdf"']),
+                'content' => 'content',
+            ],
+            new OperationSuccessEvent('file.pdf', 'content', new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'X-Gotenberg-Operation-Id' => '987654321',
+                'Content-Disposition' => 'attachement; filename="file.pdf"',
+            ])),
+        ];
+        yield 'Missing "Content-Disposition" header' => [
+            [
+                'headers' => new HeaderBag(['Gotenberg-Trace' => '123456789', 'X-Gotenberg-Operation-Id' => '987654321']),
+                'content' => 'content',
+            ],
+            new OperationSuccessEvent('987654321.pdf', 'content', new HeaderBag([
+                'Gotenberg-Trace' => '123456789',
+                'X-Gotenberg-Operation-Id' => '987654321',
+            ])),
+        ];
+    }
+
+    /**
+     * @param array{headers: HeaderBag, content: string} $payload
+     */
+    #[DataProvider('validPayloadProvider')]
+    public function testConvertValidPayload(array $payload, OperationSuccessEvent $expectedEvent): void
+    {
+        $converter = new SuccessPayloadConverter();
+        $event = $converter->convert($payload);
+
+        $this->assertEquals($expectedEvent, $event);
+    }
+
+    /**
+     * @return \Generator<string, array{0: array{headers?: HeaderBag, content?: string}, 1: class-string<\Throwable>}, void, void>
+     */
+    public static function invalidPayloadProvider(): \Generator
+    {
+        yield 'missing headers' => [
+            [
+                'content' => 'content',
+            ],
+            ParseException::class,
+        ];
+        yield 'missing content' => [
+            [
+                'headers' => new HeaderBag(['Gotenberg-Trace' => '123456789', 'X-Gotenberg-Operation-Id' => '987654321', 'Content-Disposition' => 'attachement; filename="file.pdf"']),
+            ],
+            ParseException::class,
+        ];
+        yield 'missing Content-Disposition and X-Gotenberg-Operation-Id' => [
+            [
+                'headers' => new HeaderBag(['Gotenberg-Trace' => '123456789']),
+                'content' => 'content',
+            ],
+            ParseException::class,
+        ];
+    }
+
+    /**
+     * @param array{headers: HeaderBag, content: string} $payload
+     * @param class-string<\Throwable>                   $expectedThrowable
+     */
+    #[DataProvider('invalidPayloadProvider')]
+    public function testConvertInvalidPayload(array $payload, string $expectedThrowable): void
+    {
+        $this->expectException($expectedThrowable);
+        $converter = new SuccessPayloadConverter();
+        $converter->convert($payload);
+    }
+}

--- a/tests/Webhook/ErrorWebhookRequestParserTest.php
+++ b/tests/Webhook/ErrorWebhookRequestParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Webhook;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\RemoteEvent\ErrorPayloadConverter;
+use Sensiolabs\GotenbergBundle\RemoteEvent\OperationErrorEvent;
+use Sensiolabs\GotenbergBundle\Webhook\ErrorWebhookRequestParser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+#[CoversClass(ErrorWebhookRequestParser::class)]
+class ErrorWebhookRequestParserTest extends TestCase
+{
+    private ErrorPayloadConverter&MockObject $payloadConverter;
+    private ErrorWebhookRequestParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->payloadConverter = $this->createMock(ErrorPayloadConverter::class);
+        $this->parser = new ErrorWebhookRequestParser($this->payloadConverter);
+    }
+
+    /**
+     * @return \Generator<string, list{Request}, void, void>
+     */
+    public static function invalidRequestProvider(): \Generator
+    {
+        yield 'non-POST request' => [Request::create('/', 'GET', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_X-Gotenberg-Operation-Id' => '987654321'], 'content')];
+        yield 'non-JSON content' => [Request::create('/', 'POST', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_X-Gotenberg-Operation-Id' => '987654321'], 'content')];
+        yield 'missing Gotenberg-Trace header' => [Request::create('/', 'POST', [], [], [], ['HTTP_X-Gotenberg-Operation-Id' => '987654321'], '"content"')];
+        yield 'missing X-Gotenberg-Operation-Id header' => [Request::create('/', 'POST', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789'], '"content"')];
+    }
+
+    #[DataProvider('invalidRequestProvider')]
+    public function testRequestNotMatch(Request $request): void
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->parser->parse($request, 'secret');
+    }
+
+    public function testParse(): void
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_X-Gotenberg-Operation-Id' => '987654321'], '"content"');
+        $successRemoteEvent = $this->createMock(OperationErrorEvent::class);
+        $this->payloadConverter->expects($this->once())
+            ->method('convert')
+            ->willReturn($successRemoteEvent);
+
+        $event = $this->parser->parse($request, '');
+
+        $this->assertSame($successRemoteEvent, $event);
+    }
+}

--- a/tests/Webhook/SuccessWebhookRequestParserTest.php
+++ b/tests/Webhook/SuccessWebhookRequestParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Webhook;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\RemoteEvent\OperationSuccessEvent;
+use Sensiolabs\GotenbergBundle\RemoteEvent\SuccessPayloadConverter;
+use Sensiolabs\GotenbergBundle\Webhook\SuccessWebhookRequestParser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+#[CoversClass(SuccessWebhookRequestParser::class)]
+class SuccessWebhookRequestParserTest extends TestCase
+{
+    private SuccessPayloadConverter&MockObject $payloadConverter;
+    private SuccessWebhookRequestParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->payloadConverter = $this->createMock(SuccessPayloadConverter::class);
+        $this->parser = new SuccessWebhookRequestParser($this->payloadConverter);
+    }
+
+    /**
+     * @return \Generator<string, list{Request}, void, void>
+     */
+    public static function invalidRequestProvider(): \Generator
+    {
+        yield 'non-POST request' => [Request::create('/', 'GET', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_X-Gotenberg-Operation-Id' => '987654321', 'HTTP_Content-Disposition' => 'attachement; filename="file.pdf"'], 'content')];
+        yield 'missing Gotenberg-Trace header' => [Request::create('/', 'POST', [], [], [], ['HTTP_X-Gotenberg-Operation-Id' => '987654321', 'HTTP_Content-Disposition' => 'attachement; filename="file.pdf"'], 'content')];
+        yield 'missing X-Gotenberg-Operation-Id header' => [Request::create('/', 'POST', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_Content-Disposition' => 'attachement; filename="file.pdf"'], 'content')];
+        yield 'missing Content-Disposition header' => [Request::create('/', 'POST', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_X-Gotenberg-Operation-Id' => '987654321'], 'content')];
+    }
+
+    #[DataProvider('invalidRequestProvider')]
+    public function testParseInvalidRequest(Request $request): void
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->parser->parse($request, 'secret');
+    }
+
+    public function testParseValidRequest(): void
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['HTTP_Gotenberg-Trace' => '123456789', 'HTTP_X-Gotenberg-Operation-Id' => '987654321', 'HTTP_Content-Disposition' => 'attachement; filename="file.pdf"'], 'content');
+        $successRemoteEvent = $this->createMock(OperationSuccessEvent::class);
+        $this->payloadConverter->expects($this->once())
+            ->method('convert')
+            ->willReturn($successRemoteEvent);
+
+        $event = $this->parser->parse($request, '');
+
+        $this->assertSame($successRemoteEvent, $event);
+    }
+}


### PR DESCRIPTION
Closes #46 

Gotenberg allows async generation of files by passing webhooks urls in dedicated headers. Doing this, the request to Gotenberg server returns a 204 immediately, and once the file is generated, a call will be made by Gotenberg server on the specified endpoint to upload the generated file. This PR aims at enabling easy integration of this feature with the bundle.

The base of the feature is a new interface `AsyncBuilderInterface` that defines a `generateAsync` method. The `AbstractPdfBuilder` and `AbstractScreenshotBuilder` now implement this interface.
Another important addition is the `withWebhookUrls(string $successWebhook, string|null $errorWebhook)` that allows directly setting the webhooks url to use with the builders.

To make things easier when not working directly with urls (if you'd like to generate the url from a route, or if using the Webhook component), a some new configuration options are available :
```yaml
# packages/sensiolabs_gotenberg.yaml

sensiolabs_gotenberg:  
    # ...
    webhook:  
        # Here you can define any number of webhook configuration so that you can reuse them in builder configs or to switch configuration at runtime
        my_config_name:  
            success:  
                url: 'http://example.com/webhook'
                # route: ['my_route_name', ['param1', 'param2']]
                # webhook: 'invoice'  
            # This "error" entry is optional. If not set, the "success" configuration will be used for both success and error.
            error:  
                url: 'http://example.com/webhook-error'
                # route: ['my_route_name', ['param1', 'param2']]
                # webhook: 'invoice'  
    default_options:
        # Here you can define wich webhook config to use by default
        webhook: 'my_config_name'
        pdf:
    	    html:
    	        webhook: 'my_config_name'
                # Or you can define a specific configuration directly from here
                # webhook:
                #    success:
                #	    url: 'http://example.com/custom-webhook'
    #...
```

If using the Webhook component, two `RequestParsers`  are available for "success" and "error" webhooks. If you want to use them, just configure your webhooks :

```yaml
# packages/webhook.yaml

framework:
    webhook:
        routing:
    	    my-success-webhook:
    	        service: 'sensiolabs_gotenberg.webhook.success_request_parser'
    	    my-error-webhook:
    	        service: 'sensiolabs_gotenberg.webhook.error_request_parser'
```

Then you would just have to create two `EventConsumers` to consume the `OperationSuccessEvent` and `OperationErrorEvent` dispatched by the Webhook component.

If you prefer, you can still create your own `RequestParsers` to handle the webhooks.


TODO:
- [ ] Write documentation
- [ ] Add example config to flex recipe
- [ ] See how we could handle secrets when using the webhook component (reading the webhook component conf ?)