### PR TITLE
Make Stopwatch optional

### DIFF
--- a/src/Debug/Builder/TraceablePdfBuilder.php
+++ b/src/Debug/Builder/TraceablePdfBuilder.php
@@ -24,7 +24,7 @@ final class TraceablePdfBuilder implements PdfBuilderInterface
 
     public function __construct(
         private readonly PdfBuilderInterface $inner,
-        private readonly Stopwatch $stopwatch,
+        private readonly Stopwatch|null $stopwatch,
     ) {
     }
 
@@ -33,9 +33,9 @@ final class TraceablePdfBuilder implements PdfBuilderInterface
         $name = self::$count.'.'.$this->inner::class.'::'.__FUNCTION__;
         ++self::$count;
 
-        $swEvent = $this->stopwatch->start($name, 'gotenberg.generate_pdf');
+        $swEvent = $this->stopwatch?->start($name, 'gotenberg.generate_pdf');
         $response = $this->inner->generate();
-        $swEvent->stop();
+        $swEvent?->stop();
 
         $fileName = 'Unknown.pdf';
         if ($response->headers->has('Content-Disposition')) {
@@ -53,8 +53,8 @@ final class TraceablePdfBuilder implements PdfBuilderInterface
 
         $this->pdfs[] = [
             'calls' => $this->calls,
-            'time' => $swEvent->getDuration(),
-            'memory' => $swEvent->getMemory(),
+            'time' => $swEvent?->getDuration() ?? -1,
+            'memory' => $swEvent?->getMemory() ?? -1,
             'size' => $lengthInBytes,
             'fileName' => $fileName,
         ];

--- a/src/Debug/Builder/TraceablePdfBuilder.php
+++ b/src/Debug/Builder/TraceablePdfBuilder.php
@@ -9,7 +9,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 final class TraceablePdfBuilder implements PdfBuilderInterface
 {
     /**
-     * @var list<array{'time': float, 'memory': int, 'size': int<0, max>|null, 'fileName': string, 'calls': list<array{'method': string, 'class': class-string<PdfBuilderInterface>, 'arguments': array<mixed>}>}>
+     * @var list<array{'time': float|null, 'memory': int|null, 'size': int<0, max>|null, 'fileName': string, 'calls': list<array{'method': string, 'class': class-string<PdfBuilderInterface>, 'arguments': array<mixed>}>}>
      */
     private array $pdfs = [];
 
@@ -53,8 +53,8 @@ final class TraceablePdfBuilder implements PdfBuilderInterface
 
         $this->pdfs[] = [
             'calls' => $this->calls,
-            'time' => $swEvent?->getDuration() ?? -1,
-            'memory' => $swEvent?->getMemory() ?? -1,
+            'time' => $swEvent?->getDuration(),
+            'memory' => $swEvent?->getMemory(),
             'size' => $lengthInBytes,
             'fileName' => $fileName,
         ];
@@ -85,7 +85,7 @@ final class TraceablePdfBuilder implements PdfBuilderInterface
     }
 
     /**
-     * @return list<array{'time': float, 'memory': int, 'size': int<0, max>|null, 'fileName': string, 'calls': list<array{'class': class-string<PdfBuilderInterface>, 'method': string, 'arguments': array<mixed>}>}>
+     * @return list<array{'time': float|null, 'memory': int|null, 'size': int<0, max>|null, 'fileName': string, 'calls': list<array{'class': class-string<PdfBuilderInterface>, 'method': string, 'arguments': array<mixed>}>}>
      */
     public function getPdfs(): array
     {

--- a/src/DependencyInjection/CompilerPass/GotenbergPass.php
+++ b/src/DependencyInjection/CompilerPass/GotenbergPass.php
@@ -6,6 +6,7 @@ use Sensiolabs\GotenbergBundle\Debug\Builder\TraceablePdfBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Stopwatch\Stopwatch;
 
 final class GotenbergPass implements CompilerPassInterface
 {
@@ -15,13 +16,16 @@ final class GotenbergPass implements CompilerPassInterface
             return;
         }
 
+        $stopwatch = ContainerBuilder::willBeAvailable('symfony/stopwatch', Stopwatch::class, ['symfony/framework-bundle'])
+            ? new Reference('debug.stopwatch') : null;
+
         foreach ($container->findTaggedServiceIds('sensiolabs_gotenberg.pdf_builder') as $serviceId => $tags) {
             $container->register('.debug.'.ltrim($serviceId, '.'), TraceablePdfBuilder::class)
                 ->setDecoratedService($serviceId)
                 ->setShared(false)
                 ->setArguments([
                     '$inner' => new Reference('.inner'),
-                    '$stopwatch' => new Reference('debug.stopwatch'),
+                    '$stopwatch' => $stopwatch,
                 ])
             ;
         }

--- a/src/DependencyInjection/CompilerPass/GotenbergPass.php
+++ b/src/DependencyInjection/CompilerPass/GotenbergPass.php
@@ -5,8 +5,8 @@ namespace Sensiolabs\GotenbergBundle\DependencyInjection\CompilerPass;
 use Sensiolabs\GotenbergBundle\Debug\Builder\TraceablePdfBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Stopwatch\Stopwatch;
 
 final class GotenbergPass implements CompilerPassInterface
 {
@@ -16,16 +16,13 @@ final class GotenbergPass implements CompilerPassInterface
             return;
         }
 
-        $stopwatch = ContainerBuilder::willBeAvailable('symfony/stopwatch', Stopwatch::class, ['symfony/framework-bundle'])
-            ? new Reference('debug.stopwatch') : null;
-
         foreach ($container->findTaggedServiceIds('sensiolabs_gotenberg.pdf_builder') as $serviceId => $tags) {
             $container->register('.debug.'.ltrim($serviceId, '.'), TraceablePdfBuilder::class)
                 ->setDecoratedService($serviceId)
                 ->setShared(false)
                 ->setArguments([
                     '$inner' => new Reference('.inner'),
-                    '$stopwatch' => $stopwatch,
+                    '$stopwatch' => new Reference('debug.stopwatch', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 ])
             ;
         }

--- a/templates/Collector/sensiolabs_gotenberg.html.twig
+++ b/templates/Collector/sensiolabs_gotenberg.html.twig
@@ -102,7 +102,7 @@
                     <span class="label">PDFs generated</span>
                 </div>
                 <div class="metric">
-                    {% if collector.requestTotalTime < 0 %}
+                    {% if collector.requestTotalTime == 0 %}
                         <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                     {% else %}
                         <span class="value">{{ '%.0f'|format(collector.requestTotalTime) }} <span class="unit">ms</span></span>
@@ -110,7 +110,7 @@
                     <span class="label">Total time</span>
                 </div>
                 <div class="metric">
-                    {% if collector.requestTotalMemory < 0 %}
+                    {% if collector.requestTotalMemory == 0 %}
                         <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                     {% else %}
                         <span class="value">{{ '%.1f'|format(collector.requestTotalMemory / 1024 / 1024) }} <span class="unit">MiB</span></span>
@@ -150,7 +150,7 @@
                                 <div class="metrics">
                                     <div class="metric-group">
                                         <div class="metric">
-                                            {% if request.time < 0 %}
+                                            {% if request.time == 0 %}
                                                 <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                                             {% else %}
                                                 <span class="value">{{ '%.0f'|format(request.time) }} <span class="unit">ms</span></span>
@@ -158,7 +158,7 @@
                                             <span class="label">Generation time</span>
                                         </div>
                                         <div class="metric">
-                                            {% if request.memory < 0 %}
+                                            {% if request.memory == 0 %}
                                                 <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                                             {% else %}
                                                 <span class="value">{{ '%.1f'|format(request.memory / 1024 / 1024) }} <span class="unit">MiB</span></span>

--- a/templates/Collector/sensiolabs_gotenberg.html.twig
+++ b/templates/Collector/sensiolabs_gotenberg.html.twig
@@ -102,11 +102,19 @@
                     <span class="label">PDFs generated</span>
                 </div>
                 <div class="metric">
-                    <span class="value">{{ '%.0f'|format(collector.requestTotalTime) }} <span class="unit">ms</span></span>
+                    {% if collector.requestTotalTime < 0 %}
+                        <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                    {% else %}
+                        <span class="value">{{ '%.0f'|format(collector.requestTotalTime) }} <span class="unit">ms</span></span>
+                    {% endif %}
                     <span class="label">Total time</span>
                 </div>
                 <div class="metric">
-                    <span class="value">{{ '%.1f'|format(collector.requestTotalMemory / 1024 / 1024) }} <span class="unit">MiB</span></span>
+                    {% if collector.requestTotalMemory < 0 %}
+                        <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                    {% else %}
+                        <span class="value">{{ '%.1f'|format(collector.requestTotalMemory / 1024 / 1024) }} <span class="unit">MiB</span></span>
+                    {% endif %}
                     <span class="label">Total memory</span>
                 </div>
                 <div class="metric">
@@ -142,11 +150,19 @@
                                 <div class="metrics">
                                     <div class="metric-group">
                                         <div class="metric">
-                                            <span class="value">{{ '%.0f'|format(request.time) }} <span class="unit">ms</span></span>
+                                            {% if request.time < 0 %}
+                                                <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                                            {% else %}
+                                                <span class="value">{{ '%.0f'|format(request.time) }} <span class="unit">ms</span></span>
+                                            {% endif %}
                                             <span class="label">Generation time</span>
                                         </div>
                                         <div class="metric">
-                                            <span class="value">{{ '%.1f'|format(request.memory / 1024 / 1024) }} <span class="unit">MiB</span></span>
+                                            {% if request.memory < 0 %}
+                                                <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                                            {% else %}
+                                                <span class="value">{{ '%.1f'|format(request.memory / 1024 / 1024) }} <span class="unit">MiB</span></span>
+                                            {% endif %}
                                             <span class="label">Memory</span>
                                         </div>
                                         <div class="metric">


### PR DESCRIPTION
Closes #75 

`symfony/stopwatch` is a dev requirement, though debug might be enabled while dependencies are installed with `--no-dev`. 

This PR allows running the debug features without the stopwatch component, displaying 'n/a' on time and memory metrics. On hover, a tooltip indicates that these metrics are only available with stopwatch installed, and suggests running `composer require symfony/stopwatch`.

![image](https://github.com/sensiolabs/GotenbergBundle/assets/11990607/4f6b7782-f07e-482a-8698-ef69d72dc4c3)
