### PR TITLE
[Hotfix] Fixed optional dependency to Stopwatch

### DIFF
--- a/src/Debug/Builder/TraceableScreenshotBuilder.php
+++ b/src/Debug/Builder/TraceableScreenshotBuilder.php
@@ -72,7 +72,7 @@ final class TraceableScreenshotBuilder implements ScreenshotBuilderInterface
     }
 
     /**
-     * @return list<array{'time': float, 'memory': int, 'size': int<0, max>|null, 'fileName': string|null, 'calls': list<array{'class': class-string<ScreenshotBuilderInterface>, 'method': string, 'arguments': array<mixed>}>}>
+     * @return list<array{'time': float|null, 'memory': int|null, 'size': int<0, max>|null, 'fileName': string|null, 'calls': list<array{'class': class-string<ScreenshotBuilderInterface>, 'method': string, 'arguments': array<mixed>}>}>
      */
     public function getFiles(): array
     {

--- a/src/Debug/Builder/TraceableScreenshotBuilder.php
+++ b/src/Debug/Builder/TraceableScreenshotBuilder.php
@@ -9,7 +9,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 final class TraceableScreenshotBuilder implements ScreenshotBuilderInterface
 {
     /**
-     * @var list<array{'time': float, 'memory': int, 'size': int<0, max>|null, 'fileName': string|null, 'calls': list<array{'method': string, 'class': class-string<ScreenshotBuilderInterface>, 'arguments': array<mixed>}>}>
+     * @var list<array{'time': float|null, 'memory': int|null, 'size': int<0, max>|null, 'fileName': string|null, 'calls': list<array{'method': string, 'class': class-string<ScreenshotBuilderInterface>, 'arguments': array<mixed>}>}>
      */
     private array $screenshots = [];
 

--- a/src/Debug/Builder/TraceableScreenshotBuilder.php
+++ b/src/Debug/Builder/TraceableScreenshotBuilder.php
@@ -24,7 +24,7 @@ final class TraceableScreenshotBuilder implements ScreenshotBuilderInterface
 
     public function __construct(
         private readonly ScreenshotBuilderInterface $inner,
-        private readonly Stopwatch $stopwatch,
+        private readonly Stopwatch|null $stopwatch,
     ) {
     }
 
@@ -33,14 +33,14 @@ final class TraceableScreenshotBuilder implements ScreenshotBuilderInterface
         $name = self::$count.'.'.$this->inner::class.'::'.__FUNCTION__;
         ++self::$count;
 
-        $swEvent = $this->stopwatch->start($name, 'gotenberg.generate_screenshot');
+        $swEvent = $this->stopwatch?->start($name, 'gotenberg.generate_screenshot');
         $response = $this->inner->generate();
-        $swEvent->stop();
+        $swEvent?->stop();
 
         $this->screenshots[] = [
             'calls' => $this->calls,
-            'time' => $swEvent->getDuration(),
-            'memory' => $swEvent->getMemory(),
+            'time' => $swEvent?->getDuration(),
+            'memory' => $swEvent?->getMemory(),
             'status' => $response->getStatusCode(),
             'size' => $response->getContentLength(),
             'fileName' => $response->getFileName(),

--- a/src/DependencyInjection/CompilerPass/GotenbergPass.php
+++ b/src/DependencyInjection/CompilerPass/GotenbergPass.php
@@ -47,7 +47,7 @@ final class GotenbergPass implements CompilerPassInterface
                 ->setShared(false)
                 ->setArguments([
                     '$inner' => new Reference('.inner'),
-                    '$stopwatch' => new Reference('debug.stopwatch'),
+                    '$stopwatch' => new Reference('debug.stopwatch', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 ])
             ;
         }

--- a/templates/Collector/sensiolabs_gotenberg.html.twig
+++ b/templates/Collector/sensiolabs_gotenberg.html.twig
@@ -59,12 +59,20 @@
                 <span class="label">Files generated</span>
             </div>
             <div class="metric">
-                <span class="value">{{ '%.0f'|format(collector.requestTotalTime) }} <span class="unit">ms</span></span>
+                {% if collector.requestTotalTime == 0 %}
+                    <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                {% else %}
+                    <span class="value">{{ '%.0f'|format(collector.requestTotalTime) }} <span class="unit">ms</span></span>
+                {% endif %}
                 <span class="label">Total time</span>
             </div>
             <div class="metric">
-            <span class="value">{{ '%.1f'|format(collector.requestTotalMemory / 1024 / 1024) }} <span
-                        class="unit">MiB</span></span>
+                {% if collector.requestTotalMemory == 0 %}
+                    <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                {% else %}
+                    <span class="value">{{ '%.1f'|format(collector.requestTotalMemory / 1024 / 1024) }} <span
+                                class="unit">MiB</span></span>
+                {% endif %}
                 <span class="label">Total memory</span>
             </div>
             <div class="metric">
@@ -113,16 +121,18 @@
                     </div>
                 </td>
                 <td class="font-normal">
-                    <span class="value">
-                        {{ '%.0f'|format(file.time) }}
-                        <span class="unit">ms</span>
-                    </span>
+                    {% if file.time == 0 %}
+                        <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                    {% else %}
+                        <span class="value">{{ '%.0f'|format(file.time) }} <span class="unit">ms</span></span>
+                    {% endif %}
                 </td>
                 <td class="font-normal">
-                    <span class="value">
-                        {{ '%.1f'|format(file.memory / 1024 / 1024) }}
-                        <span class="unit">MiB</span>
-                    </span>
+                    {% if file.memory == 0 %}
+                        <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
+                    {% else %}
+                        <span class="value">{{ '%.1f'|format(file.memory / 1024 / 1024) }} <span class="unit">MiB</span></span>
+                    {% endif %}
                 </td>
                 <td class="font-normal">
                     {% set size = file.size %}

--- a/templates/Collector/sensiolabs_gotenberg.html.twig
+++ b/templates/Collector/sensiolabs_gotenberg.html.twig
@@ -59,7 +59,7 @@
                 <span class="label">Files generated</span>
             </div>
             <div class="metric">
-                {% if collector.requestTotalTime == 0 %}
+                {% if collector.requestTotalTime is null %}
                     <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                 {% else %}
                     <span class="value">{{ '%.0f'|format(collector.requestTotalTime) }} <span class="unit">ms</span></span>
@@ -67,7 +67,7 @@
                 <span class="label">Total time</span>
             </div>
             <div class="metric">
-                {% if collector.requestTotalMemory == 0 %}
+                {% if collector.requestTotalMemory is null %}
                     <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                 {% else %}
                     <span class="value">{{ '%.1f'|format(collector.requestTotalMemory / 1024 / 1024) }} <span
@@ -121,14 +121,14 @@
                     </div>
                 </td>
                 <td class="font-normal">
-                    {% if file.time == 0 %}
+                    {% if file.time is null %}
                         <span class="value" title="To enable elapsed time tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                     {% else %}
                         <span class="value">{{ '%.0f'|format(file.time) }} <span class="unit">ms</span></span>
                     {% endif %}
                 </td>
                 <td class="font-normal">
-                    {% if file.memory == 0 %}
+                    {% if file.memory is null %}
                         <span class="value" title="To enable memory usage tracking, the Stopwatch component is required. Try running 'composer require symfony/stopwatch'.">n/a</span>
                     {% else %}
                         <span class="value">{{ '%.1f'|format(file.memory / 1024 / 1024) }} <span class="unit">MiB</span></span>


### PR DESCRIPTION
I believe that #92 did not ship with the ability to work without the stopwatch component installed. This should fix it + re-introduce changes that allow a special display of the metrics when stopwatch isn't installed.