### PR TITLE
Draft: feat: add trace handling

### DIFF
--- a/src/Builder/DefaultBuilderTrait.php
+++ b/src/Builder/DefaultBuilderTrait.php
@@ -215,7 +215,8 @@ trait DefaultBuilderTrait
 
     public function generate(): GotenbergFileResult
     {
-        $trace = ($this->traceGenerator ?? self::defaultTraceGenerator(...))();
+        $this->traceGenerator ??= $this::defaultTraceGenerator(...);
+        $trace = ($this->traceGenerator)();
         $headers = ['Gotenberg-Trace' => $trace];
 
         $this->logger?->debug('Processing file with trace "{sensiolabs_gotenberg.trace}" using {sensiolabs_gotenberg.builder} builder.', [

--- a/src/Builder/DefaultBuilderTrait.php
+++ b/src/Builder/DefaultBuilderTrait.php
@@ -37,6 +37,11 @@ trait DefaultBuilderTrait
     /** @var ProcessorInterface<mixed>|null */
     private ProcessorInterface|null $processor;
 
+    /**
+     * @var \Closure(): string
+     */
+    private \Closure $traceGenerator;
+
     public function setLogger(LoggerInterface|null $logger): void
     {
         $this->logger = $logger;
@@ -210,17 +215,38 @@ trait DefaultBuilderTrait
 
     public function generate(): GotenbergFileResult
     {
-        $this->logger?->debug('Processing file using {sensiolabs_gotenberg.builder} builder.', [
+        $trace = ($this->traceGenerator ?? self::defaultTraceGenerator(...))();
+        $headers = ['Gotenberg-Trace' => $trace];
+
+        $this->logger?->debug('Processing file with trace "{sensiolabs_gotenberg.trace}" using {sensiolabs_gotenberg.builder} builder.', [
+            'sensiolabs_gotenberg.trace' => $trace,
             'sensiolabs_gotenberg.builder' => $this::class,
         ]);
 
         $processor = $this->processor ?? new NullProcessor();
 
         return new GotenbergFileResult(
-            $this->client->call($this->getEndpoint(), $this->getMultipartFormData()),
+            $this->client->call($this->getEndpoint(), $this->getMultipartFormData(), $headers),
             $processor($this->fileName),
             $this->headerDisposition,
             $this->fileName,
         );
+    }
+
+    /**
+     * Sets the callable that will generate the trace ID for each operation.
+     *
+     * @param \Closure(): string $traceGenerator
+     */
+    public function traceGenerator(\Closure $traceGenerator): static
+    {
+        $this->traceGenerator = $traceGenerator;
+
+        return $this;
+    }
+
+    protected static function defaultTraceGenerator(): string
+    {
+        return bin2hex(random_bytes(16)).microtime(true);
     }
 }

--- a/src/Builder/GotenbergFileResult.php
+++ b/src/Builder/GotenbergFileResult.php
@@ -45,6 +45,11 @@ class GotenbergFileResult
         return $this->response->getContentLength();
     }
 
+    public function getTrace(): string
+    {
+        return $this->response->getHeaders()->get('Gotenberg-Trace', '');
+    }
+
     public function process(): mixed
     {
         if (!$this->response->getStream()->valid()) {

--- a/tests/Builder/DefaultBuilderTraitTest.php
+++ b/tests/Builder/DefaultBuilderTraitTest.php
@@ -107,6 +107,13 @@ class DefaultBuilderTraitTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testTraceGeneration(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->traceGenerator(fn () => 'foo');
+        $this->assertSame('foo', $builder->generate());
+    }
+
     private function getBuilder(): object
     {
         return new class {

--- a/tests/Builder/DefaultBuilderTraitTest.php
+++ b/tests/Builder/DefaultBuilderTraitTest.php
@@ -107,13 +107,6 @@ class DefaultBuilderTraitTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testTraceGeneration(): void
-    {
-        $builder = $this->getBuilder();
-        $builder->traceGenerator(fn () => 'foo');
-        $this->assertSame('foo', $builder->generate());
-    }
-
     private function getBuilder(): object
     {
         return new class {


### PR DESCRIPTION
# Description :

Gotenberg allow overiding it's internal trace https://gotenberg.dev/docs/routes#request-tracing. This PR adds the possiblity to set our own trace to allow debuging and tracing requests.

```php
// ...
$invoice = $invoiceRepository->find(/* ... */);

$response = $this->gotenberg->html()
  ->content('invoice_template.html.twig', ['invoice' => $invoice],
  ->traceGenerator(fn () => 'invoice_'.$invoice->getId().'_'.bin2hex(random_bytes(8))),
  ->generate()
;

echo $response->getTrace(); // 'invoice_5_dza4...'
// ...
```

As suggested by @Neirda24 , the trace could also hold a ressource URI with a unique hash as a query parameter, or anything that could be useful to the user.  

This will especially be useful to trace the asynchronous generation webhook calls because the request made by gotenberg to the webhook endpoint will hold the trace in its headers.

# TODO: 

- [ ] Docs
- [ ] Tests

