### PR TITLE
fix: doc generator builder case

### DIFF
--- a/docs/generate.php
+++ b/docs/generate.php
@@ -20,7 +20,7 @@ require_once \dirname(__DIR__).'/vendor/autoload.php';
  * @var array<string, non-empty-list<class-string>>
  */
 const BUILDERS = [
-    'Pdf' => [
+    'pdf' => [
         HtmlPdfBuilder::class,
         UrlPdfBuilder::class,
         MarkdownPdfBuilder::class,
@@ -28,7 +28,7 @@ const BUILDERS = [
         MergePdfBuilder::class,
         ConvertPdfBuilder::class,
     ],
-    'Screenshot' => [
+    'screenshot' => [
         HtmlScreenshotBuilder::class,
         UrlScreenshotBuilder::class,
         MarkdownScreenshotBuilder::class,


### PR DESCRIPTION
Case of 'Pdf' and 'Screenshot' causes broken links in generated documentation