### PR TITLE
Use `Path:: methods` instead of Filesystem instance

### DIFF
--- a/config/builder_pdf.php
+++ b/config/builder_pdf.php
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
             service('request_stack'),
             service('twig')->nullOnInvalid(),
@@ -34,7 +34,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
             service('request_stack'),
             service('twig')->nullOnInvalid(),
@@ -49,7 +49,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
             service('request_stack'),
             service('twig')->nullOnInvalid(),
@@ -62,7 +62,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])
@@ -73,7 +73,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])
@@ -84,7 +84,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])

--- a/config/builder_pdf.php
+++ b/config/builder_pdf.php
@@ -95,7 +95,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
         ])
         ->call('setLogger', [service('logger')->nullOnInvalid()])

--- a/config/builder_screenshot.php
+++ b/config/builder_screenshot.php
@@ -17,7 +17,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
             service('request_stack'),
             service('twig')->nullOnInvalid(),
@@ -30,7 +30,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
             service('request_stack'),
             service('twig')->nullOnInvalid(),
@@ -45,7 +45,7 @@ return static function (ContainerConfigurator $container): void {
         ->share(false)
         ->args([
             service('sensiolabs_gotenberg.client'),
-            service('sensiolabs_gotenberg.asset.base_dir_formatter'),
+            service('.sensiolabs_gotenberg.asset.base_dir_formatter'),
             service('.sensiolabs_gotenberg.webhook_configuration_registry'),
             service('request_stack'),
             service('twig')->nullOnInvalid(),

--- a/config/services.php
+++ b/config/services.php
@@ -15,7 +15,6 @@ use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistry;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\Filesystem\Filesystem;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;

--- a/config/services.php
+++ b/config/services.php
@@ -30,12 +30,12 @@ return static function (ContainerConfigurator $container): void {
         ])
         ->alias(GotenbergClientInterface::class, 'sensiolabs_gotenberg.client');
 
-    $services->set('sensiolabs_gotenberg.asset.base_dir_formatter', AssetBaseDirFormatter::class)
+    $services->set('.sensiolabs_gotenberg.asset.base_dir_formatter', AssetBaseDirFormatter::class)
         ->args([
             param('kernel.project_dir'),
             abstract_arg('assets_directory to assets'),
         ])
-        ->alias(AssetBaseDirFormatter::class, 'sensiolabs_gotenberg.asset.base_dir_formatter')
+        ->alias(AssetBaseDirFormatter::class, '.sensiolabs_gotenberg.asset.base_dir_formatter')
     ;
 
     $services->set('sensiolabs_gotenberg.twig.asset_extension', GotenbergAssetExtension::class)

--- a/config/services.php
+++ b/config/services.php
@@ -33,7 +33,6 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set('sensiolabs_gotenberg.asset.base_dir_formatter', AssetBaseDirFormatter::class)
         ->args([
-            service(Filesystem::class),
             param('kernel.project_dir'),
             abstract_arg('assets_directory to assets'),
         ])

--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -122,7 +122,7 @@ class SensiolabsGotenbergExtension extends Extension
 
         $this->processDefaultOptions($container, $config, '.sensiolabs_gotenberg.screenshot_builder.markdown', $config['default_options']['screenshot']['markdown']);
 
-        $definition = $container->getDefinition('sensiolabs_gotenberg.asset.base_dir_formatter');
+        $definition = $container->getDefinition('.sensiolabs_gotenberg.asset.base_dir_formatter');
         $definition->replaceArgument(1, $config['assets_directory']);
     }
 

--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -123,7 +123,7 @@ class SensiolabsGotenbergExtension extends Extension
         $this->processDefaultOptions($container, $config, '.sensiolabs_gotenberg.screenshot_builder.markdown', $config['default_options']['screenshot']['markdown']);
 
         $definition = $container->getDefinition('sensiolabs_gotenberg.asset.base_dir_formatter');
-        $definition->replaceArgument(2, $config['assets_directory']);
+        $definition->replaceArgument(1, $config['assets_directory']);
     }
 
     /**

--- a/src/Formatter/AssetBaseDirFormatter.php
+++ b/src/Formatter/AssetBaseDirFormatter.php
@@ -3,6 +3,7 @@
 namespace Sensiolabs\GotenbergBundle\Formatter;
 
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 final class AssetBaseDirFormatter
 {
@@ -18,14 +19,14 @@ final class AssetBaseDirFormatter
 
     public function resolve(string $path): string
     {
-        if ($this->filesystem->isAbsolutePath($path)) {
+        if (Path::isAbsolute($path)) {
             return $path;
         }
 
-        if ($this->filesystem->isAbsolutePath($this->baseDir)) {
-            return "{$this->baseDir}/{$path}";
+        if (Path::isAbsolute($this->baseDir)) {
+            return Path::join($this->baseDir, $path);
         }
 
-        return "{$this->projectDir}/{$this->baseDir}/{$path}";
+        return Path::join($this->projectDir, $this->baseDir, $path);
     }
 }

--- a/src/Formatter/AssetBaseDirFormatter.php
+++ b/src/Formatter/AssetBaseDirFormatter.php
@@ -2,15 +2,16 @@
 
 namespace Sensiolabs\GotenbergBundle\Formatter;
 
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
+/**
+ * @internal
+ */
 final class AssetBaseDirFormatter
 {
     private readonly string $baseDir;
 
     public function __construct(
-        private readonly Filesystem $filesystem,
         private readonly string $projectDir,
         string $baseDir,
     ) {

--- a/tests/Builder/AbstractBuilderTestCase.php
+++ b/tests/Builder/AbstractBuilderTestCase.php
@@ -10,7 +10,6 @@ use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetExtension;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Mime\Part\DataPart;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;

--- a/tests/Builder/AbstractBuilderTestCase.php
+++ b/tests/Builder/AbstractBuilderTestCase.php
@@ -48,7 +48,7 @@ abstract class AbstractBuilderTestCase extends TestCase
                 return GotenbergAssetRuntime::class === $class ? new GotenbergAssetRuntime() : null;
             }
         });
-        self::$assetBaseDirFormatter = new AssetBaseDirFormatter(new Filesystem(), self::FIXTURE_DIR, self::FIXTURE_DIR);
+        self::$assetBaseDirFormatter = new AssetBaseDirFormatter(self::FIXTURE_DIR, self::FIXTURE_DIR);
     }
 
     protected function setUp(): void

--- a/tests/Builder/AsyncBuilderTraitTest.php
+++ b/tests/Builder/AsyncBuilderTraitTest.php
@@ -205,7 +205,7 @@ class AsyncBuilderTraitTest extends TestCase
             {
                 $this->client = new GotenbergClient($httpClient);
                 $this->webhookConfigurationRegistry = $registry;
-                $this->asset = new AssetBaseDirFormatter(new Filesystem(), '', '');
+                $this->asset = new AssetBaseDirFormatter('', '');
             }
 
             protected function getEndpoint(): string

--- a/tests/Builder/AsyncBuilderTraitTest.php
+++ b/tests/Builder/AsyncBuilderTraitTest.php
@@ -13,7 +13,6 @@ use Sensiolabs\GotenbergBundle\Client\GotenbergResponse;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;

--- a/tests/Builder/DefaultBuilderTraitTest.php
+++ b/tests/Builder/DefaultBuilderTraitTest.php
@@ -10,7 +10,6 @@ use Sensiolabs\GotenbergBundle\Builder\DefaultBuilderTrait;
 use Sensiolabs\GotenbergBundle\Enumeration\PdfFormat;
 use Sensiolabs\GotenbergBundle\Exception\JsonEncodingException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[CoversClass(DefaultBuilderTrait::class)]
 #[UsesClass(AssetBaseDirFormatter::class)]

--- a/tests/Builder/DefaultBuilderTraitTest.php
+++ b/tests/Builder/DefaultBuilderTraitTest.php
@@ -119,7 +119,6 @@ class DefaultBuilderTraitTest extends TestCase
             public function __construct()
             {
                 $this->asset = new AssetBaseDirFormatter(
-                    new Filesystem(),
                     __DIR__.'/../Fixtures',
                     'files',
                 );

--- a/tests/Formatter/AssetBaseDirFormatterTest.php
+++ b/tests/Formatter/AssetBaseDirFormatterTest.php
@@ -12,8 +12,8 @@ use Symfony\Component\Filesystem\Filesystem;
 #[CoversClass(AssetBaseDirFormatter::class)]
 final class AssetBaseDirFormatterTest extends TestCase
 {
-    private const BASE_PATH = "/var/www/project";
-    
+    private const BASE_PATH = '/var/www/project';
+
     /**
      * @return iterable<string, array<int, string>>
      */

--- a/tests/Formatter/AssetBaseDirFormatterTest.php
+++ b/tests/Formatter/AssetBaseDirFormatterTest.php
@@ -12,16 +12,18 @@ use Symfony\Component\Filesystem\Filesystem;
 #[CoversClass(AssetBaseDirFormatter::class)]
 final class AssetBaseDirFormatterTest extends TestCase
 {
+    private const BASE_PATH = "/var/www/project";
+    
     /**
      * @return iterable<string, array<int, string>>
      */
     public static function generateBaseDirectoryAndPath(): iterable
     {
-        yield 'absolute path and absolute base dir' => [__DIR__.'/../Fixtures/assets/file.md', __DIR__.'/../Fixtures/assets', __DIR__.'/../Fixtures/assets/file.md'];
-        yield 'absolute path and relative base dir' => [__DIR__.'/../Fixtures/assets/logo.png', '/assets', __DIR__.'/../Fixtures/assets/logo.png'];
-        yield 'relative path and relative base dir' => ['document.odt', 'assets/office', __DIR__.'/../Fixtures/assets/office/document.odt'];
-        yield 'relative path and relative base dir with end slash' => ['document.odt', 'assets/office/', __DIR__.'/../Fixtures/assets/office/document.odt'];
-        yield 'relative path and absolute base dir' => ['office/document_1.docx', __DIR__.'/../Fixtures/assets', __DIR__.'/../Fixtures/assets/office/document_1.docx'];
+        yield 'absolute path and absolute base dir' => [self::BASE_PATH.'/foo/file.md', self::BASE_PATH.'/bar', self::BASE_PATH.'/foo/file.md'];
+        yield 'absolute path and relative base dir' => [self::BASE_PATH.'/foo/logo.png', '/bar', self::BASE_PATH.'/foo/logo.png'];
+        yield 'relative path and relative base dir' => ['document.odt', 'bar/baz', self::BASE_PATH.'/bar/baz/document.odt'];
+        yield 'relative path and absolute base dir' => ['foo/document.odt', self::BASE_PATH.'/bar/baz', self::BASE_PATH.'/bar/baz/foo/document.odt'];
+        yield 'relative path and relative base dir with end slash' => ['document.odt', 'bar/baz/', self::BASE_PATH.'/bar/baz/document.odt'];
     }
 
     #[DataProvider('generateBaseDirectoryAndPath')]
@@ -29,7 +31,7 @@ final class AssetBaseDirFormatterTest extends TestCase
     public function testResolvePathCorrectly(string $path, string $baseDirectory, string $expectedResult): void
     {
         $filesystem = new Filesystem();
-        $assetBaseDirFormatter = new AssetBaseDirFormatter($filesystem, __DIR__.'/../Fixtures', $baseDirectory);
+        $assetBaseDirFormatter = new AssetBaseDirFormatter($filesystem, self::BASE_PATH, $baseDirectory);
         $resolvedPath = $assetBaseDirFormatter->resolve($path);
         self::assertSame($expectedResult, $resolvedPath);
     }

--- a/tests/Formatter/AssetBaseDirFormatterTest.php
+++ b/tests/Formatter/AssetBaseDirFormatterTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[CoversClass(AssetBaseDirFormatter::class)]
 final class AssetBaseDirFormatterTest extends TestCase

--- a/tests/Formatter/AssetBaseDirFormatterTest.php
+++ b/tests/Formatter/AssetBaseDirFormatterTest.php
@@ -11,25 +11,23 @@ use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 #[CoversClass(AssetBaseDirFormatter::class)]
 final class AssetBaseDirFormatterTest extends TestCase
 {
-    private const BASE_PATH = '/var/www/project';
-
     /**
      * @return iterable<string, array<int, string>>
      */
     public static function generateBaseDirectoryAndPath(): iterable
     {
-        yield 'absolute path and absolute base dir' => [self::BASE_PATH.'/foo/file.md', self::BASE_PATH.'/bar', self::BASE_PATH.'/foo/file.md'];
-        yield 'absolute path and relative base dir' => [self::BASE_PATH.'/foo/logo.png', '/bar', self::BASE_PATH.'/foo/logo.png'];
-        yield 'relative path and relative base dir' => ['document.odt', 'bar/baz', self::BASE_PATH.'/bar/baz/document.odt'];
-        yield 'relative path and absolute base dir' => ['foo/document.odt', self::BASE_PATH.'/bar/baz', self::BASE_PATH.'/bar/baz/foo/document.odt'];
-        yield 'relative path and relative base dir with end slash' => ['document.odt', 'bar/baz/', self::BASE_PATH.'/bar/baz/document.odt'];
+        yield 'absolute path and absolute base dir' => ['/mock/foo/file.md', '/mock/bar', '/mock/foo/file.md'];
+        yield 'absolute path and relative base dir' => ['/mock/foo/logo.png', '/bar', '/mock/foo/logo.png'];
+        yield 'relative path and relative base dir' => ['document.odt', 'bar/baz', '/mock/bar/baz/document.odt'];
+        yield 'relative path and absolute base dir' => ['foo/document.odt', '/mock/bar/baz', '/mock/bar/baz/foo/document.odt'];
+        yield 'relative path and relative base dir with end slash' => ['document.odt', 'bar/baz/', '/mock/bar/baz/document.odt'];
     }
 
     #[DataProvider('generateBaseDirectoryAndPath')]
     #[TestDox('Resolve path when "$_dataName"')]
     public function testResolvePathCorrectly(string $path, string $baseDirectory, string $expectedResult): void
     {
-        $assetBaseDirFormatter = new AssetBaseDirFormatter(self::BASE_PATH, $baseDirectory);
+        $assetBaseDirFormatter = new AssetBaseDirFormatter('/mock', $baseDirectory);
         $resolvedPath = $assetBaseDirFormatter->resolve($path);
         self::assertSame($expectedResult, $resolvedPath);
     }

--- a/tests/Formatter/AssetBaseDirFormatterTest.php
+++ b/tests/Formatter/AssetBaseDirFormatterTest.php
@@ -30,8 +30,7 @@ final class AssetBaseDirFormatterTest extends TestCase
     #[TestDox('Resolve path when "$_dataName"')]
     public function testResolvePathCorrectly(string $path, string $baseDirectory, string $expectedResult): void
     {
-        $filesystem = new Filesystem();
-        $assetBaseDirFormatter = new AssetBaseDirFormatter($filesystem, self::BASE_PATH, $baseDirectory);
+        $assetBaseDirFormatter = new AssetBaseDirFormatter(self::BASE_PATH, $baseDirectory);
         $resolvedPath = $assetBaseDirFormatter->resolve($path);
         self::assertSame($expectedResult, $resolvedPath);
     }


### PR DESCRIPTION
`Filesystem->isAbsolutePath` does not check if the file exists and just make quick checks on the string.

So here the Path utility methods seem a better choice as they are platform-agnostic and allow safe operations like `::join`  handle `../../` in paths and handle full path canonicalization.

And the tests can be done on any strings, independently on the Fixtures files here.

I think this method is used before calling `new File()`, so maybe the whole thing could be replaced by some factory/provider returning an Asset or something like that?

I've not touched the constructor (BC) or the DI for now, depending on your feedback & vision on this.