### PR TITLE
Add `GotenbergAssetRuntime` to avoid passing Builder in context

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -11,6 +11,7 @@ use Sensiolabs\GotenbergBundle\GotenbergPdfInterface;
 use Sensiolabs\GotenbergBundle\GotenbergScreenshot;
 use Sensiolabs\GotenbergBundle\GotenbergScreenshotInterface;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetExtension;
+use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistry;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -41,6 +42,9 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set('sensiolabs_gotenberg.twig.asset_extension', GotenbergAssetExtension::class)
         ->tag('twig.extension')
+    ;
+    $services->set('sensiolabs_gotenberg.twig.asset_runtime', GotenbergAssetRuntime::class)
+        ->tag('twig.runtime')
     ;
 
     $services->set('sensiolabs_gotenberg.pdf', GotenbergPdf::class)

--- a/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
+++ b/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
@@ -14,6 +14,7 @@ use Sensiolabs\GotenbergBundle\Enumeration\UserAgent;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Exception\PdfPartRenderingException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
+use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -591,10 +592,14 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
             throw new \LogicException(\sprintf('Twig is required to use "%s" method. Try to run "composer require symfony/twig-bundle".', __METHOD__));
         }
 
+        $this->twig->getRuntime(GotenbergAssetRuntime::class)->setBuilder($this);
+
         try {
-            $html = $this->twig->render($template, array_merge($context, ['_builder' => $this]));
+            $html = $this->twig->render($template, $context);
         } catch (\Throwable $error) {
             throw new PdfPartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $pdfPart->value, $error->getMessage()), previous: $error);
+        } finally {
+            $this->twig->getRuntime(GotenbergAssetRuntime::class)->setBuilder(null);
         }
 
         $this->formFields[$pdfPart->value] = new DataPart($html, $pdfPart->value, 'text/html');

--- a/src/Builder/Screenshot/AbstractChromiumScreenshotBuilder.php
+++ b/src/Builder/Screenshot/AbstractChromiumScreenshotBuilder.php
@@ -11,6 +11,7 @@ use Sensiolabs\GotenbergBundle\Enumeration\UserAgent;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Exception\ScreenshotPartRenderingException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
+use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -386,10 +387,14 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
             throw new \LogicException(\sprintf('Twig is required to use "%s" method. Try to run "composer require symfony/twig-bundle".', __METHOD__));
         }
 
+        $this->twig->getRuntime(GotenbergAssetRuntime::class)->setBuilder($this);
+
         try {
-            $html = $this->twig->render($template, array_merge($context, ['_builder' => $this]));
+            $html = $this->twig->render($template, $context);
         } catch (\Throwable $error) {
             throw new ScreenshotPartRenderingException(\sprintf('Could not render template "%s" into Screenshot part "%s". %s', $template, $screenshotPart->value, $error->getMessage()), previous: $error);
+        } finally {
+            $this->twig->getRuntime(GotenbergAssetRuntime::class)->setBuilder(null);
         }
 
         $this->formFields[$screenshotPart->value] = new DataPart($html, $screenshotPart->value, 'text/html');

--- a/src/Twig/GotenbergAssetExtension.php
+++ b/src/Twig/GotenbergAssetExtension.php
@@ -2,8 +2,6 @@
 
 namespace Sensiolabs\GotenbergBundle\Twig;
 
-use Sensiolabs\GotenbergBundle\Builder\Pdf\AbstractChromiumPdfBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Screenshot\AbstractChromiumScreenshotBuilder;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -12,23 +10,7 @@ final class GotenbergAssetExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('gotenberg_asset', $this->getAssetUrl(...), ['needs_context' => true]),
+            new TwigFunction('gotenberg_asset', [GotenbergAssetRuntime::class, 'getAssetUrl']),
         ];
-    }
-
-    /**
-     * @param array<string, mixed> $context
-     */
-    public function getAssetUrl(array $context, string $path): string
-    {
-        $builder = $context['_builder'];
-
-        if (!$builder instanceof AbstractChromiumPdfBuilder && !$builder instanceof AbstractChromiumScreenshotBuilder) {
-            throw new \LogicException('You need to extend from AbstractChromiumPdfBuilder to use gotenberg_asset function.');
-        }
-
-        $builder->addAsset($path);
-
-        return basename($path);
     }
 }

--- a/src/Twig/GotenbergAssetRuntime.php
+++ b/src/Twig/GotenbergAssetRuntime.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Twig;
+
+use Sensiolabs\GotenbergBundle\Builder\Pdf\AbstractChromiumPdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Screenshot\AbstractChromiumScreenshotBuilder;
+
+/**
+ * @internal
+ */
+final class GotenbergAssetRuntime
+{
+    private AbstractChromiumPdfBuilder|AbstractChromiumScreenshotBuilder|null $builder = null;
+
+    public function setBuilder(AbstractChromiumPdfBuilder|AbstractChromiumScreenshotBuilder|null $builder): void
+    {
+        $this->builder = $builder;
+    }
+
+    /**
+     * This function is used to get the URL of an asset during the rendering
+     * of a PDF or a screenshot with the Gotenberg client.
+     *
+     * It only works if the builder is an instance of AbstractChromiumPdfBuilder
+     * or AbstractChromiumScreenshotBuilder.
+     */
+    public function getAssetUrl(string $path): string
+    {
+        if (null === $this->builder) {
+            throw new \LogicException('You need to extend from AbstractChromiumPdfBuilder to use "gotenberg_asset" function.');
+        }
+
+        $this->builder->addAsset($path);
+
+        return basename($path);
+    }
+}

--- a/src/Twig/GotenbergAssetRuntime.php
+++ b/src/Twig/GotenbergAssetRuntime.php
@@ -27,7 +27,7 @@ final class GotenbergAssetRuntime
     public function getAssetUrl(string $path): string
     {
         if (null === $this->builder) {
-            throw new \LogicException('You need to extend from AbstractChromiumPdfBuilder to use "gotenberg_asset" function.');
+            throw new \LogicException('The gotenberg_asset function must be used in a Gotenberg context.');
         }
 
         $this->builder->addAsset($path);

--- a/tests/Builder/AbstractBuilderTestCase.php
+++ b/tests/Builder/AbstractBuilderTestCase.php
@@ -2,17 +2,22 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Builder;
 
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetExtension;
+use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Mime\Part\DataPart;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
+#[UsesClass(GotenbergAssetExtension::class)]
+#[UsesClass(GotenbergAssetRuntime::class)]
 abstract class AbstractBuilderTestCase extends TestCase
 {
     protected const FIXTURE_DIR = __DIR__.'/../Fixtures';
@@ -37,6 +42,12 @@ abstract class AbstractBuilderTestCase extends TestCase
             'strict_variables' => true,
         ]);
         self::$twig->addExtension(new GotenbergAssetExtension());
+        self::$twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
+            public function load(string $class): object|null
+            {
+                return GotenbergAssetRuntime::class === $class ? new GotenbergAssetRuntime() : null;
+            }
+        });
         self::$assetBaseDirFormatter = new AssetBaseDirFormatter(new Filesystem(), self::FIXTURE_DIR, self::FIXTURE_DIR);
     }
 

--- a/tests/Twig/GotenbergAssetRuntimeTest.php
+++ b/tests/Twig/GotenbergAssetRuntimeTest.php
@@ -14,7 +14,7 @@ class GotenbergAssetRuntimeTest extends TestCase
     public function testGetAssetThrowsPerDefault(): void
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('You need to extend from AbstractChromiumPdfBuilder to use "gotenberg_asset" function.');
+        $this->expectExceptionMessage('The gotenberg_asset function must be used in a Gotenberg context.');
         $runtime = new GotenbergAssetRuntime();
         $runtime->getAssetUrl('foo');
     }
@@ -22,7 +22,7 @@ class GotenbergAssetRuntimeTest extends TestCase
     public function testGetAssetThrowsWhenBuilderIsNotSet(): void
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('You need to extend from AbstractChromiumPdfBuilder to use "gotenberg_asset" function.');
+        $this->expectExceptionMessage('The gotenberg_asset function must be used in a Gotenberg context.');
         $runtime = new GotenbergAssetRuntime();
         $runtime->setBuilder(null);
         $runtime->getAssetUrl('foo');

--- a/tests/Twig/GotenbergAssetRuntimeTest.php
+++ b/tests/Twig/GotenbergAssetRuntimeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Twig;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\AbstractChromiumPdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Screenshot\AbstractChromiumScreenshotBuilder;
+use Sensiolabs\GotenbergBundle\Twig\GotenbergAssetRuntime;
+
+#[CoversClass(GotenbergAssetRuntime::class)]
+class GotenbergAssetRuntimeTest extends TestCase
+{
+    public function testGetAssetThrowsPerDefault(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You need to extend from AbstractChromiumPdfBuilder to use "gotenberg_asset" function.');
+        $runtime = new GotenbergAssetRuntime();
+        $runtime->getAssetUrl('foo');
+    }
+
+    public function testGetAssetThrowsWhenBuilderIsNotSet(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You need to extend from AbstractChromiumPdfBuilder to use "gotenberg_asset" function.');
+        $runtime = new GotenbergAssetRuntime();
+        $runtime->setBuilder(null);
+        $runtime->getAssetUrl('foo');
+    }
+
+    public function testGetAssetCallChromiumPdfBuilder(): void
+    {
+        $runtime = new GotenbergAssetRuntime();
+        $builder = $this->createMock(AbstractChromiumPdfBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('addAsset')
+            ->with('foo')
+        ;
+        $runtime->setBuilder($builder);
+        $this->assertSame('foo', $runtime->getAssetUrl('foo'));
+    }
+
+    public function testGetAssetCallChromiumScreenshotBuilder(): void
+    {
+        $runtime = new GotenbergAssetRuntime();
+        $builder = $this->createMock(AbstractChromiumScreenshotBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('addAsset')
+            ->with('foo')
+        ;
+        $runtime->setBuilder($builder);
+        $this->assertSame('foo', $runtime->getAssetUrl('foo'));
+    }
+}


### PR DESCRIPTION
Passing the builder in the Twig context is a bit fragile. 

It won't work when template uses any of Twig layout features (includes, embed, macros, ...) without passing the full context.

Also, starting with Twig 4.0, the `include` function won't pass the full context per default, with no "boolean" to do so automatically, encouraging template isolation and composition.

This PR introduce a Twig Runtime, lowering the impact of the Extension on the global scope, and allowing to create a time-limited "scope", during which the `gotenberg_asset` will work as expected.