### PR TITLE
fix: use valid type for webhook configuration example

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -756,7 +756,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('route')
                     ->info('Route configuration.')
-                    ->example(['my_route', ['param1' => 'value1', 'param2' => 'value2']])
+                    ->example([['my_route', ['param1' => 'value1', 'param2' => 'value2']]])
                     ->beforeNormalization()
                         ->ifArray()
                             ->then(function (array $v): array {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -752,9 +752,11 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('url')
                     ->info('The URL to call.')
+                    ->example('https://webhook.site/#!/view/{some-token}')
                 ->end()
-                ->variableNode('route')
+                ->arrayNode('route')
                     ->info('Route configuration.')
+                    ->example(['my_route', ['param1' => 'value1', 'param2' => 'value2']])
                     ->beforeNormalization()
                         ->ifArray()
                             ->then(function (array $v): array {
@@ -771,10 +773,7 @@ class Configuration implements ConfigurationInterface
                         })
                         ->thenInvalid('The "route" parameter must be a string or an array containing a string and an array.')
                     ->end()
-                    ->example([
-                        'https://webhook.site/#!/view/{some-token}',
-                        ['my_route', ['param1' => 'value1', 'param2' => 'value2']],
-                    ])
+                    ->variablePrototype()->end()
                 ->end()
                 ->enumNode('method')
                     ->info('HTTP method to use on that endpoint.')

--- a/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
+++ b/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
@@ -513,6 +513,7 @@ final class SensiolabsGotenbergExtensionTest extends TestCase
                 'foo' => [
                     'success' => [
                         'url' => 'https://sensiolabs.com/webhook',
+                        'route' => [],
                         'method' => null,
                     ],
                     'error' => [
@@ -531,6 +532,7 @@ final class SensiolabsGotenbergExtensionTest extends TestCase
                 '.sensiolabs_gotenberg.pdf_builder.markdown.webhook_configuration' => [
                     'success' => [
                         'url' => 'https://sensiolabs.com/webhook-on-the-fly',
+                        'route' => [],
                         'method' => null,
                     ],
                     'error' => [


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? |       |
| Bug fix ?               | yes  |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #142  |

## Description

`example` should be set for `url` and `route` independently. 

Note: `route` example won't be dumped until we specify its children. 