### PR TITLE
Update doc generation

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,6 +26,7 @@ return (new PhpCsFixer\Config())
         'nullable_type_declaration' => [
             'syntax' => 'union',
         ],
+        'phpdoc_no_package' => false,
         'return_assignment' => true,
         'strict_param' => true,
         'trailing_comma_in_multiline' => [

--- a/docs/builders_api.md
+++ b/docs/builders_api.md
@@ -2,17 +2,17 @@
 
 ## Pdf
 
-* [HtmlPdfBuilder](./pdf/builders_api/HtmlPdfBuilder.md)
-* [UrlPdfBuilder](./pdf/builders_api/UrlPdfBuilder.md)
-* [MarkdownPdfBuilder](./pdf/builders_api/MarkdownPdfBuilder.md)
-* [LibreOfficePdfBuilder](./pdf/builders_api/LibreOfficePdfBuilder.md)
-* [MergePdfBuilder](./pdf/builders_api/MergePdfBuilder.md)
 * [ConvertPdfBuilder](./pdf/builders_api/ConvertPdfBuilder.md)
+* [HtmlPdfBuilder](./pdf/builders_api/HtmlPdfBuilder.md)
+* [LibreOfficePdfBuilder](./pdf/builders_api/LibreOfficePdfBuilder.md)
+* [MarkdownPdfBuilder](./pdf/builders_api/MarkdownPdfBuilder.md)
+* [MergePdfBuilder](./pdf/builders_api/MergePdfBuilder.md)
 * [SplitPdfBuilder](./pdf/builders_api/SplitPdfBuilder.md)
+* [UrlPdfBuilder](./pdf/builders_api/UrlPdfBuilder.md)
 
 ## Screenshot
 
 * [HtmlScreenshotBuilder](./screenshot/builders_api/HtmlScreenshotBuilder.md)
-* [UrlScreenshotBuilder](./screenshot/builders_api/UrlScreenshotBuilder.md)
 * [MarkdownScreenshotBuilder](./screenshot/builders_api/MarkdownScreenshotBuilder.md)
+* [UrlScreenshotBuilder](./screenshot/builders_api/UrlScreenshotBuilder.md)
 

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -187,15 +187,15 @@ class BuilderParser
 
             foreach ($methods as $methodName => $parts) {
 //                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
-                $markdown .= '<details>';
-                $markdown .= "<summary>`{$this->methodsSignature[$methodName]}`</summary>";
+                $markdown .= "<details>\n";
+                $markdown .= "<summary>{$this->methodsSignature[$methodName]}</summary>\n";
 
                 $renderedParts =  $renderParts($parts);
                 if ('' !== $renderedParts) {
                     $markdown .= "\n{$renderedParts}";
                 }
 
-                $markdown .= '</details>';
+                $markdown .= "\n</details>";
             }
         }
 

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -187,15 +187,14 @@ class BuilderParser
 
             foreach ($methods as $methodName => $parts) {
 //                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
-                $markdown .= "<details>\n";
-                $markdown .= "<summary>{$this->methodsSignature[$methodName]}</summary>\n";
+                $markdown .= "### {$this->methodsSignature[$methodName]}";
 
                 $renderedParts =  $renderParts($parts);
                 if ('' !== $renderedParts) {
                     $markdown .= "\n{$renderedParts}";
                 }
 
-                $markdown .= "\n</details>";
+                $markdown .= "\n";
             }
         }
 

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -21,10 +21,19 @@ require_once \dirname(__DIR__).'/vendor/autoload.php';
 
 class Summary
 {
+    /**
+     * @var array<string, array<string, ReflectionClass<PdfBuilderInterface|ScreenshotBuilderInterface>>>
+     */
     private array $builders = [];
 
+    /**
+     * @var array<string, string>
+     */
     private array $filenames = [];
 
+    /**
+     * @param ReflectionClass<PdfBuilderInterface|ScreenshotBuilderInterface> $class
+     */
     public function register(string $type, ReflectionClass $class): void
     {
         $this->builders[$type] ??= [];
@@ -58,7 +67,7 @@ class Summary
 }
 
 /**
- * @phpstan-type ParsedDocBlock array{package: string|null, description: list<string>, tags: array{param: array<string, array{type: string, description: string}>, see: list<string>, example: list<string>}
+ * @phpstan-type ParsedDocBlock array{package: string|null, description: list<string>, tags: array{param: array<string, array{type: string, description: string}>, see: list<string>, example: list<string>}}
  */
 class BuilderParser
 {
@@ -101,7 +110,9 @@ class BuilderParser
      *     'methods': array<string, array<string, ParsedDocBlock>>,
      * }
      */
-    private array $parts = [];
+    private array $parts = [
+        'methods' => [],
+    ];
 
     /**
      * @var array<string, string>

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -140,12 +140,11 @@ class BuilderParser
          * @param list<string> $seeList
          */
         $renderSee = static function (array $seeList): string {
-            $markdown = '';
-
-            if (\count($seeList) > 0) {
-                $markdown .= '> [!TIP]';
+            if ([] === $seeList) {
+                return '';
             }
 
+            $markdown = '> [!TIP]';
             foreach ($seeList as $see) {
                 $markdown .= "\n> See: [{$see}]({$see})";
             }

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -186,8 +186,13 @@ class BuilderParser
             ksort($methods);
 
             foreach ($methods as $methodName => $parts) {
-                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n\n";
-                $markdown .= $renderParts($parts);
+                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
+
+                $renderedParts =  $renderParts($parts);
+                if ('' !== $renderedParts) {
+                    $markdown .= "\n{$renderedParts}";
+                }
+
                 $markdown .= "\n";
             }
         }

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -186,7 +186,6 @@ class BuilderParser
             ksort($methods);
 
             foreach ($methods as $methodName => $parts) {
-//                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
                 $markdown .= "### {$this->methodsSignature[$methodName]}";
 
                 $renderedParts =  $renderParts($parts);

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -123,7 +123,7 @@ class BuilderParser
     public function extract(): string
     {
         $markdown = "# {$this->name}\n\n";
-        $renderDescription = static fn(array $parts) => trim(implode("\n", $parts), "\ \n\r\t\v\0");
+        $renderDescription = static fn (array $parts) => trim(implode("\n", $parts), "\ \n\r\t\v\0");
 
         /**
          * @param list<string> $seeList
@@ -171,11 +171,11 @@ class BuilderParser
         }
 
         uksort($this->parts['methods'], static function ($a, $b) {
-            if ($a === '@') {
+            if ('@' === $a) {
                 return -1;
             }
 
-            if ($b === '@') {
+            if ('@' === $b) {
                 return +1;
             }
 
@@ -221,11 +221,11 @@ class BuilderParser
         }
     }
 
-    private function prepareBuilderFromClass(ReflectionClass $class)
+    private function prepareBuilderFromClass(ReflectionClass $class): void
     {
         $parentClass = $class->getParentClass();
 
-        if ($parentClass !== false) {
+        if (false !== $parentClass) {
             $this->prepareBuilderFromClass($parentClass);
         }
 
@@ -259,7 +259,7 @@ class BuilderParser
                 $currentPackage = $this->parts['methods']['@'][$method->getShortName()]['package'] ?? '@';
                 $newPackage = $parsedDocBlock['package'] ?? null;
 
-                if ($newPackage !== null && $currentPackage !== $newPackage) {
+                if (null !== $newPackage && $currentPackage !== $newPackage) {
                     $this->parts['methods']['@'][$method->getShortName()]['package'] = $newPackage;
                 }
 
@@ -382,7 +382,7 @@ $application->register('generate')
                 $builderParser->prepare($summary, $type, $builder);
 
                 $filename = $summary->getFilename($builder);
-                $directory = __DIR__.'/'.dirname($filename);
+                $directory = __DIR__.'/'.\dirname($filename);
 
                 if (!@mkdir($directory, recursive: true) && !is_dir($directory)) {
                     throw new RuntimeException(\sprintf('Directory "%s" was not created', $directory));
@@ -391,7 +391,7 @@ $application->register('generate')
                 file_put_contents(__DIR__.'/'.$filename, $builderParser->extract());
             }
         }
-        file_put_contents( __DIR__.'/builders_api.md', $summary->extract());
+        file_put_contents(__DIR__.'/builders_api.md', $summary->extract());
 
         return Command::SUCCESS;
     })

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -186,7 +186,7 @@ class BuilderParser
             ksort($methods);
 
             foreach ($methods as $methodName => $parts) {
-                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
+                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n\n";
                 $markdown .= $renderParts($parts);
                 $markdown .= "\n";
             }

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -123,7 +123,7 @@ class BuilderParser
     public function extract(): string
     {
         $markdown = "# {$this->name}\n\n";
-        $renderDescription = static fn (array $parts) => trim(implode("\n", $parts), "\ \n\r\t\v\0");
+        $renderDescription = static fn (array $parts) => trim(implode("\n\n", $parts), "\ \n\r\t\v\0");
 
         /**
          * @param list<string> $seeList

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -186,14 +186,16 @@ class BuilderParser
             ksort($methods);
 
             foreach ($methods as $methodName => $parts) {
-                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
+//                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
+                $markdown .= '<details>';
+                $markdown .= "<summary>`{$this->methodsSignature[$methodName]}`</summary>";
 
                 $renderedParts =  $renderParts($parts);
                 if ('' !== $renderedParts) {
                     $markdown .= "\n{$renderedParts}";
                 }
 
-                $markdown .= "\n";
+                $markdown .= '</details>';
             }
         }
 

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -6,10 +6,12 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\PdfBuilderInterface;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\HtmlScreenshotBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\MarkdownScreenshotBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Screenshot\ScreenshotBuilderInterface;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\UrlScreenshotBuilder;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -66,31 +68,87 @@ function parseMethodSignature(ReflectionMethod $method): string
 
 function parseDocComment(string $rawDocComment): string
 {
-    $result = '';
+    $lines = preg_split("/\r\n|\n|\r/", trim($rawDocComment, "/** \t\n\r"));
 
-    $lines = explode("\n", trim($rawDocComment, "\n"));
-    array_shift($lines);
-    array_pop($lines);
-
-    foreach ($lines as $line) {
-        $line = trim($line);
-        $line = ltrim($line, '*');
-        $line = ltrim($line);
-
-        if ('' === $line) {
-            continue;
-        }
-
-        if (str_starts_with($line, '@')) {
-            continue;
-        }
-
-        $result .= $line."\n";
+    if (false === $lines) {
+        throw new LogicException('Unable to parse doc comment.');
     }
 
-    return $result;
+    $description = [];
+    $tags = [
+        'param' => [],
+    ];
+    $currentTag = null;
+    $currentParam = null;
+
+    foreach ($lines as $line) {
+        $line = trim($line, " *");
+
+        if (str_starts_with($line, '@')) {
+            $tagFound = preg_match('/^@(\S+)\s*(.*)$/', $line, $matches);
+            if (false !== $tagFound && count($matches) > 0) {
+                $currentTag = $matches[1];
+                $value = $matches[2] ?? '';
+
+                if ($currentTag === 'param') {
+                    $paramTagFound = preg_match('/^(\S+)\s+(\$\S+)\s*(.*)$/', $value, $paramMatches);
+                    if (false !== $paramTagFound && count($paramMatches) > 0) {
+                        [$type, $name, $desc] = $paramMatches;
+
+                        $tags['param'][$name] = [
+                            'type' => $type,
+                            'description' => $desc
+                        ];
+                        $currentParam = $name;
+                    }
+                } else {
+                    $tags[$currentTag][] = $value;
+                    $currentParam = null;
+                }
+            }
+        } elseif ($currentTag === 'param' && $currentParam !== null) {
+            $tags['param'][$currentParam]['description'] .= ' ' . $line;
+        } elseif ($currentTag !== null) {
+            if (null === array_key_last($tags[$currentTag])) {
+                $tags[$currentTag][] = $line;
+            } else {
+                $tags[$currentTag][array_key_last($tags[$currentTag])] .= ' ' . $line;
+            }
+        } else {
+            $description[] = $line;
+        }
+    }
+
+    $description = implode("\n", $description);
+
+    $tags['see'] ??= [];
+
+    $description = trim($description, "\ \n\r\t\v\0") . "\n";
+
+    if (count($tags['see']) > 0) {
+        $description .= "\n";
+        $description .= "> [!TIP]";
+    }
+
+    foreach ($tags['see'] as $see) {
+        $description .= "\n> See: [{$see}]({$see})";
+    }
+
+
+    if (count($tags['see']) > 0) {
+        $description .= "\n";
+    }
+
+    if (trim($description, "\ \n\r\t\v\0") === '') {
+        return '';
+    }
+
+    return $description;
 }
 
+/**
+ * @param ReflectionClass<PdfBuilderInterface|ScreenshotBuilderInterface> $builder
+ */
 function parseBuilder(ReflectionClass $builder): string
 {
     $markdown = '';
@@ -107,8 +165,9 @@ function parseBuilder(ReflectionClass $builder): string
     $methods = [];
     foreach ($builder->getInterfaces() as $interface) {
         foreach ($interface->getMethods() as $method) {
-            if ('' !== ($method->getDocComment() ?: '')) {
-                $methods[$method->getName()] = parseDocComment($method->getDocComment());
+            $methodDocComment = $method->getDocComment() ?: '';
+            if ('' !== $methodDocComment) {
+                $methods[$method->getName()] = parseDocComment($methodDocComment);
             }
         }
     }

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -209,21 +209,6 @@ class BuilderParser
             $this->parts['@'] = $this->parsePhpDoc($classDocComment);
         }
 
-        foreach ($class->getInterfaces() as $interface) {
-            foreach ($interface->getMethods() as $method) {
-                if (\in_array($method->getName(), self::EXCLUDED_METHODS, true) === true) {
-                    continue;
-                }
-
-                $methodDocComment = $method->getDocComment() ?: '';
-                if ('' !== $methodDocComment) {
-                    $this->parts['methods'] ??= [];
-
-                    $this->parts['methods']['@'][$method->getShortName()] = $this->parsePhpDoc($methodDocComment);
-                }
-            }
-        }
-
         $this->prepareBuilderFromClass($class);
 
         foreach ($this->parts['methods']['@'] as $methodName => $parts) {
@@ -242,6 +227,10 @@ class BuilderParser
 
         if ($parentClass !== false) {
             $this->prepareBuilderFromClass($parentClass);
+        }
+
+        foreach ($class->getInterfaces() as $interface) {
+            $this->prepareBuilderFromClass($interface);
         }
 
         foreach ($class->getTraits() as $trait) {

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -82,22 +82,22 @@ function parseDocComment(string $rawDocComment): string
     $currentParam = null;
 
     foreach ($lines as $line) {
-        $line = trim($line, " *");
+        $line = trim($line, ' *');
 
         if (str_starts_with($line, '@')) {
             $tagFound = preg_match('/^@(\S+)\s*(.*)$/', $line, $matches);
-            if (false !== $tagFound && count($matches) > 0) {
+            if (false !== $tagFound && \count($matches) > 0) {
                 $currentTag = $matches[1];
                 $value = $matches[2] ?? '';
 
-                if ($currentTag === 'param') {
+                if ('param' === $currentTag) {
                     $paramTagFound = preg_match('/^(\S+)\s+(\$\S+)\s*(.*)$/', $value, $paramMatches);
-                    if (false !== $paramTagFound && count($paramMatches) > 0) {
+                    if (false !== $paramTagFound && \count($paramMatches) > 0) {
                         [$type, $name, $desc] = $paramMatches;
 
                         $tags['param'][$name] = [
                             'type' => $type,
-                            'description' => $desc
+                            'description' => $desc,
                         ];
                         $currentParam = $name;
                     }
@@ -106,13 +106,13 @@ function parseDocComment(string $rawDocComment): string
                     $currentParam = null;
                 }
             }
-        } elseif ($currentTag === 'param' && $currentParam !== null) {
-            $tags['param'][$currentParam]['description'] .= ' ' . $line;
-        } elseif ($currentTag !== null) {
+        } elseif ('param' === $currentTag && null !== $currentParam) {
+            $tags['param'][$currentParam]['description'] .= ' '.$line;
+        } elseif (null !== $currentTag) {
             if (null === array_key_last($tags[$currentTag])) {
                 $tags[$currentTag][] = $line;
             } else {
-                $tags[$currentTag][array_key_last($tags[$currentTag])] .= ' ' . $line;
+                $tags[$currentTag][array_key_last($tags[$currentTag])] .= ' '.$line;
             }
         } else {
             $description[] = $line;
@@ -123,19 +123,18 @@ function parseDocComment(string $rawDocComment): string
 
     $tags['see'] ??= [];
 
-    $description = trim($description, "\ \n\r\t\v\0") . "\n";
+    $description = trim($description, "\ \n\r\t\v\0")."\n";
 
-    if (count($tags['see']) > 0) {
+    if (\count($tags['see']) > 0) {
         $description .= "\n";
-        $description .= "> [!TIP]";
+        $description .= '> [!TIP]';
     }
 
     foreach ($tags['see'] as $see) {
         $description .= "\n> See: [{$see}]({$see})";
     }
 
-
-    if (count($tags['see']) > 0) {
+    if (\count($tags['see']) > 0) {
         $description .= "\n";
     }
 

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -123,7 +123,7 @@ class BuilderParser
     public function extract(): string
     {
         $markdown = "# {$this->name}\n\n";
-        $renderDescription = static fn (array $parts) => trim(implode("\n\n", $parts), "\ \n\r\t\v\0");
+        $renderDescription = static fn (array $parts) => trim(implode('<br />', $parts), "\ \n\r\t\v\0");
 
         /**
          * @param list<string> $seeList

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -19,208 +19,332 @@ use Symfony\Component\Console\Input\InputInterface;
 
 require_once \dirname(__DIR__).'/vendor/autoload.php';
 
-/**
- * @var array<string, non-empty-list<class-string>>
- */
-const BUILDERS = [
-    'pdf' => [
-        HtmlPdfBuilder::class,
-        UrlPdfBuilder::class,
-        MarkdownPdfBuilder::class,
-        LibreOfficePdfBuilder::class,
-        MergePdfBuilder::class,
-        ConvertPdfBuilder::class,
-        SplitPdfBuilder::class,
-    ],
-    'screenshot' => [
-        HtmlScreenshotBuilder::class,
-        UrlScreenshotBuilder::class,
-        MarkdownScreenshotBuilder::class,
-    ],
-];
-
-const EXCLUDED_METHODS = [
-    '__construct',
-    'setLogger',
-    'setConfigurations',
-    'generate',
-    'generateAsync',
-    'getMultipartFormData',
-    'fileName',
-    'processor',
-];
-
-function parseMethodSignature(ReflectionMethod $method): string
+class Summary
 {
-    $methodName = $method->getName();
+    private array $builders = [];
 
-    $parameters = [];
+    private array $filenames = [];
 
-    foreach ($method->getParameters() as $parameter) {
-        $parameterName = $parameter->getName();
-        $parameterType = $parameter->getType();
+    public function register(string $type, ReflectionClass $class): void
+    {
+        $this->builders[$type] ??= [];
+        $this->builders[$type][$class->getShortName()] = $class;
 
-        $parameters[] = "{$parameterType} \${$parameterName}";
+        $this->filenames[$class->getName()] = "{$type}/builders_api/{$class->getShortName()}.md";
     }
 
-    return $methodName.'('.implode(', ', $parameters).')';
+    public function extract(): string
+    {
+        $summary = "# Builders API\n\n";
+        ksort($this->builders);
+
+        foreach ($this->builders as $type => $builders) {
+            $summary .= '## '.ucfirst($type)."\n\n";
+            ksort($builders);
+
+            foreach ($builders as $builder) {
+                $summary .= "* [{$builder->getShortName()}](./{$this->getFilename($builder->getName())})\n";
+            }
+            $summary .= "\n";
+        }
+
+        return $summary;
+    }
+
+    public function getFilename(string $className): string
+    {
+        return $this->filenames[$className];
+    }
 }
 
-function parseDocComment(string $rawDocComment): string
+/**
+ * @phpstan-type ParsedDocBlock array{package: string, description: list<string>, tags: array{param: array<string, array{type: string, description: string}>, see: list<string>, example: list<string>}
+ */
+class BuilderParser
 {
-    $lines = preg_split("/\r\n|\n|\r/", trim($rawDocComment, "/** \t\n\r"));
+    /**
+     * @var array<string, non-empty-list<class-string>>
+     */
+    public const BUILDERS = [
+        'pdf' => [
+            HtmlPdfBuilder::class,
+            UrlPdfBuilder::class,
+            MarkdownPdfBuilder::class,
+            LibreOfficePdfBuilder::class,
+            MergePdfBuilder::class,
+            ConvertPdfBuilder::class,
+            SplitPdfBuilder::class,
+        ],
+        'screenshot' => [
+            HtmlScreenshotBuilder::class,
+            UrlScreenshotBuilder::class,
+            MarkdownScreenshotBuilder::class,
+        ],
+    ];
 
-    if (false === $lines) {
-        throw new LogicException('Unable to parse doc comment.');
+    private const EXCLUDED_METHODS = [
+        '__construct',
+        'setLogger',
+        'setConfigurations',
+        'generate',
+        'generateAsync',
+        'getMultipartFormData',
+        'fileName',
+        'processor',
+    ];
+
+    private string $name;
+
+    /**
+     * @var array{
+     *     '@'?: ParsedDocBlock,
+     *     'methods': array<string, array<string, array{'parts': ParsedDocBlock}>>,
+     * }
+     */
+    private array $parts = [];
+
+    /**
+     * @var array<string, string>
+     */
+    private array $methodsSignature = [];
+
+    /**
+     * @param class-string<PdfBuilderInterface|ScreenshotBuilderInterface> $builder
+     */
+    public function prepare(Summary $summary, string $type, string $builder): void
+    {
+        $class = new ReflectionClass($builder);
+        $summary->register($type, $class);
+
+        $this->name = $class->getShortName();
+        $this->prepareBuilder($class);
     }
 
-    $description = [];
-    $tags = [
-        'param' => [],
-    ];
-    $currentTag = null;
-    $currentParam = null;
+    public function extract(): string
+    {
+        $markdown = "# {$this->name}\n\n";
+        $renderDescription = static fn(array $parts) => trim(implode("\n", $parts), "\ \n\r\t\v\0");
 
-    foreach ($lines as $line) {
-        $line = trim($line, ' *');
+        /**
+         * @param list<string> $seeList
+         */
+        $renderSee = static function (array $seeList): string {
+            $markdown = '';
 
-        if (str_starts_with($line, '@')) {
-            $tagFound = preg_match('/^@(\S+)\s*(.*)$/', $line, $matches);
-            if (false !== $tagFound && \count($matches) > 0) {
-                $currentTag = $matches[1];
-                $value = $matches[2] ?? '';
+            if (\count($seeList) > 0) {
+                $markdown .= '> [!TIP]';
+            }
 
-                if ('param' === $currentTag) {
-                    $paramTagFound = preg_match('/^(\S+)\s+(\$\S+)\s*(.*)$/', $value, $paramMatches);
-                    if (false !== $paramTagFound && \count($paramMatches) > 0) {
-                        [$type, $name, $desc] = $paramMatches;
+            foreach ($seeList as $see) {
+                $markdown .= "\n> See: [{$see}]({$see})";
+            }
 
-                        $tags['param'][$name] = [
-                            'type' => $type,
-                            'description' => $desc,
-                        ];
-                        $currentParam = $name;
-                    }
-                } else {
-                    $tags[$currentTag][] = $value;
-                    $currentParam = null;
+            return $markdown;
+        };
+
+        /**
+         * @param ParsedDocBlock $parts
+         */
+        $renderParts = static function (array $parts) use ($renderDescription, $renderSee): string {
+            $markdown = '';
+
+            $description = $renderDescription($parts['description']);
+            if ('' !== $description) {
+                $markdown .= $description."\n";
+            }
+
+            $see = $renderSee($parts['tags']['see'] ?? []);
+            if ('' !== $see) {
+                if ('' !== $markdown) {
+                    $markdown .= "\n";
+                }
+
+                $markdown .= $see."\n";
+            }
+
+            return $markdown;
+        };
+
+        if (isset($this->parts['@'])) {
+            $markdown .= $renderParts($this->parts['@']);
+        }
+
+        ksort($this->parts['methods']);
+        foreach ($this->parts['methods'] as $package => $methods) {
+            ksort($methods);
+
+            foreach ($methods as $methodName => $parts) {
+                $markdown .= "* `{$this->methodsSignature[$methodName]}`:\n";
+                $markdown .= $renderParts($parts['parts']);
+                $markdown .= "\n";
+            }
+        }
+
+        return $markdown;
+    }
+
+    /**
+     * @param ReflectionClass<PdfBuilderInterface|ScreenshotBuilderInterface> $class
+     */
+    private function prepareBuilder(ReflectionClass $class): void
+    {
+        $this->parts = [
+            'methods' => [],
+        ];
+
+        $classDocComment = $class->getDocComment() ?: '';
+        if ('' !== $classDocComment) {
+            $this->parts['@'] = $this->parsePhpDoc($classDocComment);
+        }
+
+        foreach ($class->getInterfaces() as $interface) {
+            foreach ($interface->getMethods() as $method) {
+                if (\in_array($method->getName(), self::EXCLUDED_METHODS, true) === true) {
+                    continue;
+                }
+
+                $methodDocComment = $method->getDocComment() ?: '';
+                if ('' !== $methodDocComment) {
+                    $methodParts = $this->parsePhpDoc($methodDocComment);
+                    $package = $methodParts['package'] ?? '@';
+
+                    $this->parts['methods'][$package] ??= [];
+
+                    $this->parts['methods'][$package][$method->getShortName()] = [
+                        'parts' => $this->parsePhpDoc($methodDocComment)
+                    ];
                 }
             }
-        } elseif ('param' === $currentTag && null !== $currentParam) {
-            $tags['param'][$currentParam]['description'] .= ' '.$line;
-        } elseif (null !== $currentTag) {
-            if (null === array_key_last($tags[$currentTag])) {
-                $tags[$currentTag][] = $line;
-            } else {
-                $tags[$currentTag][array_key_last($tags[$currentTag])] .= ' '.$line;
-            }
-        } else {
-            $description[] = $line;
         }
-    }
 
-    $description = implode("\n", $description);
+        foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if (\in_array($method->getName(), self::EXCLUDED_METHODS, true) === true) {
+                continue;
+            }
 
-    $tags['see'] ??= [];
+            $this->methodsSignature[$method->getName()] = $this->parseMethodSignature($method);
 
-    $description = trim($description, "\ \n\r\t\v\0")."\n";
-
-    if (\count($tags['see']) > 0) {
-        $description .= "\n";
-        $description .= '> [!TIP]';
-    }
-
-    foreach ($tags['see'] as $see) {
-        $description .= "\n> See: [{$see}]({$see})";
-    }
-
-    if (\count($tags['see']) > 0) {
-        $description .= "\n";
-    }
-
-    if (trim($description, "\ \n\r\t\v\0") === '') {
-        return '';
-    }
-
-    return $description;
-}
-
-/**
- * @param ReflectionClass<PdfBuilderInterface|ScreenshotBuilderInterface> $builder
- */
-function parseBuilder(ReflectionClass $builder): string
-{
-    $markdown = '';
-
-    $builderName = $builder->getShortName();
-    $markdown .= "# {$builderName}\n\n";
-
-    $builderComment = $builder->getDocComment();
-
-    if (false !== $builderComment) {
-        $markdown .= parseDocComment($builderComment)."\n";
-    }
-
-    $methods = [];
-    foreach ($builder->getInterfaces() as $interface) {
-        foreach ($interface->getMethods() as $method) {
             $methodDocComment = $method->getDocComment() ?: '';
             if ('' !== $methodDocComment) {
-                $methods[$method->getName()] = parseDocComment($methodDocComment);
+                $methodParts = $this->parsePhpDoc($methodDocComment);
+                $package = $methodParts['package'] ?? '@';
+
+                $this->parts['methods'][$package][$method->getShortName()] ??= [];
+                $this->parts['methods'][$package][$method->getShortName()]['parts'] = $methodParts;
             }
         }
     }
 
-    foreach ($builder->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-        if (\in_array($method->getName(), EXCLUDED_METHODS, true) === true) {
-            continue;
+    /**
+     * @return ParsedDocBlock
+     *
+     * @throws LogicException
+     */
+    private function parsePhpDoc(string $rawPhpDoc)
+    {
+        $lines = preg_split("/\r\n|\n|\r/", trim($rawPhpDoc, "/** \t\n\r"));
+
+        if (false === $lines) {
+            throw new LogicException('Unable to parse doc comment.');
         }
 
-        $methodSignature = parseMethodSignature($method);
-        $docComment = parseDocComment($methods[$method->getShortName()] ?? $method->getDocComment() ?: '');
+        $description = [];
+        $tags = [
+            'param' => [],
+        ];
+        $currentPackage = null;
+        $currentTag = null;
+        $currentParam = null;
 
-        $markdown .= <<<"MARKDOWN"
-        * `{$methodSignature}`:
-        {$docComment}
+        foreach ($lines as $line) {
+            $line = trim($line, ' *');
 
-        MARKDOWN;
+            if (str_starts_with($line, '@')) {
+                $tagFound = preg_match('/^@(\S+)\s*(.*)$/', $line, $matches);
+                if (false !== $tagFound && \count($matches) > 0) {
+                    $currentTag = $matches[1];
+                    $value = $matches[2] ?? '';
+
+                    if ('package' === $currentTag) {
+                        $currentPackage = $value;
+                    } elseif ('param' === $currentTag) {
+                        $paramTagFound = preg_match('/^(\S+)\s+(\$\S+)\s*(.*)$/', $value, $paramMatches);
+                        if (false !== $paramTagFound && \count($paramMatches) > 0) {
+                            [$type, $name, $desc] = $paramMatches;
+
+                            $tags['param'][$name] = [
+                                'type' => $type,
+                                'description' => $desc,
+                            ];
+                            $currentParam = $name;
+                        }
+                    } else {
+                        $tags[$currentTag][] = $value;
+                        $currentParam = null;
+                    }
+                }
+            } elseif ('param' === $currentTag && null !== $currentParam) {
+                $tags['param'][$currentParam]['description'] .= ' '.$line;
+            } elseif (null !== $currentTag) {
+                if (null === array_key_last($tags[$currentTag])) {
+                    $tags[$currentTag][] = $line;
+                } else {
+                    $tags[$currentTag][array_key_last($tags[$currentTag])] .= ' '.$line;
+                }
+            } else {
+                $description[] = $line;
+            }
+        }
+
+        return [
+            'package' => $currentPackage,
+            'description' => $description,
+            'tags' => $tags,
+        ];
     }
 
-    return $markdown;
-}
+    public function parseMethodSignature(ReflectionMethod $method): string
+    {
+        $methodName = $method->getName();
 
-function saveFile(InputInterface $input, string $filename, string $contents): void
-{
-    file_put_contents($filename, $contents);
+        $parameters = [];
+
+        foreach ($method->getParameters() as $parameter) {
+            $parameterName = $parameter->getName();
+            $parameterType = $parameter->getType();
+
+            $parameters[] = "{$parameterType} \${$parameterName}";
+        }
+
+        return $methodName.'('.implode(', ', $parameters).')';
+    }
 }
 
 $application = new Application();
 $application->register('generate')
     ->setCode(function (InputInterface $input) {
-        $summary = "# Builders API\n\n";
+        $summary = new Summary();
 
-        foreach (BUILDERS as $type => $builderClasses) {
-            $subDirectory = "{$type}/builders_api";
-            $directory = __DIR__.'/'.$subDirectory;
+        $buildersByType = BuilderParser::BUILDERS;
+        krsort($buildersByType);
 
-            if (!@mkdir($directory, recursive: true) && !is_dir($directory)) {
-                throw new RuntimeException(\sprintf('Directory "%s" was not created', $directory));
+        foreach ($buildersByType as $type => $builders) {
+            krsort($builders);
+            foreach ($builders as $builder) {
+                $builderParser = new BuilderParser();
+                $builderParser->prepare($summary, $type, $builder);
+
+                $filename = $summary->getFilename($builder);
+                $directory = __DIR__.'/'.dirname($filename);
+
+                if (!@mkdir($directory, recursive: true) && !is_dir($directory)) {
+                    throw new RuntimeException(\sprintf('Directory "%s" was not created', $directory));
+                }
+
+                file_put_contents(__DIR__.'/'.$filename, $builderParser->extract());
             }
-
-            $summary .= '## '.ucfirst($type)."\n\n";
-
-            foreach ($builderClasses as $pdfBuilder) {
-                $reflectionClass = new ReflectionClass($pdfBuilder);
-
-                $markdown = parseBuilder($reflectionClass);
-                saveFile($input, "{$directory}/{$reflectionClass->getShortName()}.md", $markdown);
-
-                $summary .= "* [{$reflectionClass->getShortName()}](./{$subDirectory}/{$reflectionClass->getShortName()}.md)\n";
-            }
-            $summary .= "\n";
-
-            saveFile($input, __DIR__.'/builders_api.md', $summary);
         }
+        file_put_contents( __DIR__.'/builders_api.md', $summary->extract());
 
         return Command::SUCCESS;
     })

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -198,7 +198,7 @@ class BuilderParser
             foreach ($methods as $methodName => $parts) {
                 $markdown .= "### {$this->methodsSignature[$methodName]}";
 
-                $renderedParts =  $renderParts($parts);
+                $renderedParts = $renderParts($parts);
                 if ('' !== $renderedParts) {
                     $markdown .= "\n{$renderedParts}";
                 }

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -1,39 +1,24 @@
 # ConvertPdfBuilder
 
-* `downloadFrom(array $downloadFrom)`:
-
+<details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `files(string $paths)`:
-
-* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-
+</details><details><summary>`files(string $paths)`</summary></details><details><summary>`pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
 Convert the resulting PDF into the given PDF/A format.
-
-* `pdfUniversalAccess(bool $bool)`:
-
+</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
 Enable PDF for Universal Access for optimal accessibility.
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
+</details>

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -1,6 +1,8 @@
 # ConvertPdfBuilder
 
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -1,10 +1,12 @@
 # ConvertPdfBuilder
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -13,19 +15,25 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 * `files(string $paths)`:
 
+
 * `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+
 Convert the resulting PDF into the given PDF/A format.
 
 * `pdfUniversalAccess(bool $bool)`:
+
 Enable PDF for Universal Access for optimal accessibility.
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -4,7 +4,7 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-### files(string $paths)
+### files(Stringable|string $paths)
 ### pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
 

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -1,24 +1,6 @@
 # ConvertPdfBuilder
 
-* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-Convert the resulting PDF into the given PDF/A format.
-
-* `pdfUniversalAccess(bool $bool)`:
-Enable PDF for Universal Access for optimal accessibility.
-
-* `files(Stringable|string $paths)`:
-
 * `downloadFrom(array $downloadFrom)`:
-
-* `webhookConfiguration(string $name)`:
-Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookUrl(string $url, ?string $method)`:
-Sets the webhook for cases of success.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
@@ -27,6 +9,22 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
+* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+Convert the resulting PDF into the given PDF/A format.
+
+* `pdfUniversalAccess(bool $bool)`:
+Enable PDF for Universal Access for optimal accessibility.
+
+* `webhookConfiguration(string $name)`:
+Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+
+* `webhookUrl(string $url, ?string $method)`:
+Sets the webhook for cases of success.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -1,48 +1,31 @@
 # ConvertPdfBuilder
 
-<details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>files(string $paths)</summary>
-
-</details><details>
-<summary>pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
-
+### files(string $paths)
+### pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
 
-</details><details>
-<summary>pdfUniversalAccess(bool $bool)</summary>
-
+### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility.
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details>

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -18,6 +18,7 @@ Enable PDF for Universal Access for optimal accessibility.
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -34,6 +35,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -11,6 +11,8 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
+* `files(string $paths)`:
+
 * `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 Convert the resulting PDF into the given PDF/A format.
 

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -5,14 +5,6 @@
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `files(string $paths)`:
 
 * `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
@@ -22,6 +14,14 @@ Convert the resulting PDF into the given PDF/A format.
 * `pdfUniversalAccess(bool $bool)`:
 
 Enable PDF for Universal Access for optimal accessibility.
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookConfiguration(string $name)`:
 

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -17,9 +17,7 @@ Enable PDF for Universal Access for optimal accessibility.
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -30,13 +28,11 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -1,24 +1,48 @@
 # ConvertPdfBuilder
 
-<details><summary>`downloadFrom(array $downloadFrom)`</summary>
+<details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`files(string $paths)`</summary></details><details><summary>`pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
+
+</details><details>
+<summary>files(string $paths)</summary>
+
+</details><details>
+<summary>pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
+
 Convert the resulting PDF into the given PDF/A format.
-</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
+
+</details><details>
+<summary>pdfUniversalAccess(bool $bool)</summary>
+
 Enable PDF for Universal Access for optimal accessibility.
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 </details>

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -17,9 +17,15 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.

--- a/docs/pdf/builders_api/ConvertPdfBuilder.md
+++ b/docs/pdf/builders_api/ConvertPdfBuilder.md
@@ -15,7 +15,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 * `files(string $paths)`:
 
-
 * `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
 Convert the resulting PDF into the given PDF/A format.

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -7,6 +7,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 * `addExtraHttpHeaders(array $headers)`:
 
 Adds extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None).
 
 > [!TIP]
@@ -41,6 +42,7 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None). (overrides any previous headers).
 
 > [!TIP]
@@ -49,6 +51,7 @@ document. (default None). (overrides any previous headers).
 * `failOnConsoleExceptions(bool $bool)`:
 
 Forces GotenbergPdf to return a 409 Conflict response if there are
+
 exceptions in the Chromium console. (default false).
 
 > [!TIP]
@@ -57,6 +60,7 @@ exceptions in the Chromium console. (default false).
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from
+
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
 > [!TIP]
@@ -65,6 +69,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
+
 (default None). (overrides any previous configuration).
 
 > [!TIP]
@@ -73,6 +78,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 * `failOnResourceLoadingFailed(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions load at least one resource. (default false).
 
 > [!TIP]
@@ -137,6 +143,7 @@ Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
 * `omitBackground(bool $bool)`:
 
 Hides default white background and allows generating PDFs with
+
 transparency. (Default false).
 
 > [!TIP]
@@ -148,18 +155,32 @@ transparency. (Default false).
 
 Overrides the default paper size, in inches.
 
+
+
 Examples of paper size (width x height):
 
+
+
 Letter - 8.5 x 11 (default)
+
 Legal - 8.5 x 14
+
 Tabloid - 11 x 17
+
 Ledger - 17 x 11
+
 A0 - 33.1 x 46.8
+
 A1 - 23.4 x 33.1
+
 A2 - 16.54 x 23.4
+
 A3 - 11.7 x 16.54
+
 A4 - 8.27 x 11.7
+
 A5 - 5.83 x 8.27
+
 A6 - 4.13 x 5.83
 
 > [!TIP]
@@ -202,6 +223,8 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 Define whether to print the entire content in one single page.
 
+
+
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
@@ -237,6 +260,7 @@ Override the default User-Agent HTTP header. (default None).
 * `waitDelay(string $delay)`:
 
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+
 document before converting it to PDF. (default None).
 
 > [!TIP]
@@ -245,7 +269,10 @@ document before converting it to PDF. (default None).
 * `waitForExpression(string $expression)`:
 
 Sets the JavaScript expression to wait before converting an HTML
+
 document to PDF until it returns true. (default None).
+
+
 
 For instance: "window.status === 'ready'".
 
@@ -255,6 +282,7 @@ For instance: "window.status === 'ready'".
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -271,6 +299,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -3,12 +3,6 @@
 * `addAsset(string $path)`:
 Adds a file, like an image, font, stylesheet, and so on.
 
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
@@ -27,9 +21,9 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 * `contentFile(string $path)`:
 The HTML file to convert into PDF.
 
-* `cookies(array $cookies)`:
-
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -171,8 +165,6 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
 
@@ -230,4 +222,20 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `cookies(array $cookies)`:
+Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `forwardCookie(string $name)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -1,267 +1,164 @@
 # HtmlPdfBuilder
 
-* `addAsset(string $path)`:
-
+<details><summary>`addAsset(string $path)`</summary>
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addExtraHttpHeaders(array $headers)`:
-
+</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-* `addMetadata(string $key, string $value)`:
-
+</details><details><summary>`addMetadata(string $key, string $value)`</summary>
 The metadata to write.
-
-* `assets(string $paths)`:
-
+</details><details><summary>`assets(string $paths)`</summary>
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `content(string $template, array $context)`:
-
-* `contentFile(string $path)`:
-
+</details><details><summary>`content(string $template, array $context)`</summary></details><details><summary>`contentFile(string $path)`</summary>
 The HTML file to convert into PDF.
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
-
+</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `extraHttpHeaders(array $headers)`:
-
+</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-* `failOnConsoleExceptions(bool $bool)`:
-
+</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `failOnHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceLoadingFailed(bool $bool)`:
-
+</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-* `footer(string $template, array $context)`:
-
-* `footerFile(string $path)`:
-
+</details><details><summary>`footer(string $template, array $context)`</summary></details><details><summary>`footerFile(string $path)`</summary>
 HTML file containing the footer. (default None).
-
-* `generateDocumentOutline(bool $bool)`:
-
+</details><details><summary>`generateDocumentOutline(bool $bool)`</summary>
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `header(string $template, array $context)`:
-
-* `headerFile(string $path)`:
-
+</details><details><summary>`header(string $template, array $context)`</summary></details><details><summary>`headerFile(string $path)`</summary>
 HTML file containing the header. (default None).
-
-* `landscape(bool $bool)`:
-
+</details><details><summary>`landscape(bool $bool)`</summary>
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
+</details><details><summary>`marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `metadata(array $metadata)`:
-
+</details><details><summary>`metadata(array $metadata)`</summary>
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-* `nativePageRanges(string $range)`:
-
+</details><details><summary>`nativePageRanges(string $range)`</summary>
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `omitBackground(bool $bool)`:
-
+</details><details><summary>`omitBackground(bool $bool)`</summary>
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
+</details><details><summary>`paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
-
-* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-
+</details><details><summary>`paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`</summary></details><details><summary>`paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
 Sets the PDF format of the resulting PDF. (default None).<br />
-
-* `pdfUniversalAccess(bool $bool)`:
-
+</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
-
-* `preferCssPageSize(bool $bool)`:
-
+</details><details><summary>`preferCssPageSize(bool $bool)`</summary>
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `printBackground(bool $bool)`:
-
+</details><details><summary>`printBackground(bool $bool)`</summary>
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `scale(float $scale)`:
-
+</details><details><summary>`scale(float $scale)`</summary>
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `singlePage(bool $bool)`:
-
+</details><details><summary>`singlePage(bool $bool)`</summary>
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-* `skipNetworkIdleEvent(bool $bool)`:
-
-* `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
-
+</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `splitSpan(string $splitSpan)`:
-
+</details><details><summary>`splitSpan(string $splitSpan)`</summary>
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `splitUnify(bool $bool)`:
-
+</details><details><summary>`splitUnify(bool $bool)`</summary>
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `userAgent(string $userAgent)`:
-
+</details><details><summary>`userAgent(string $userAgent)`</summary>
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-* `waitDelay(string $delay)`:
-
+</details><details><summary>`waitDelay(string $delay)`</summary>
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-
+</details><details><summary>`waitForExpression(string $expression)`</summary>
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `addCookies(array $cookies)`:
-
+</details><details><summary>`addCookies(array $cookies)`</summary>
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `cookies(array $cookies)`:
-
+</details><details><summary>`cookies(array $cookies)`</summary>
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `forwardCookie(string $name)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
+</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -13,11 +13,14 @@ The HTML file to convert into PDF.
 
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
+
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default paper size, in inches.
+
 Examples of paper size (width x height):
+
 Letter - 8.5 x 11 (default)
 Legal - 8.5 x 14
 Tabloid - 11 x 17
@@ -30,6 +33,9 @@ A4 - 8.27 x 11.7
 A5 - 5.83 x 8.27
 A6 - 4.13 x 5.83
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
@@ -38,6 +44,9 @@ A6 - 4.13 x 5.83
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default margins (e.g., 0.39), in inches.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
@@ -50,24 +59,45 @@ Overrides the default margins (e.g., 0.39), in inches.
 * `preferCssPageSize(bool $bool)`:
 Define whether to prefer page size as defined by CSS. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `generateDocumentOutline(bool $bool)`:
 Define whether the document outline should be embedded into the PDF. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `printBackground(bool $bool)`:
 Prints the background graphics. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
 Hides default white background and allows generating PDFs with
 transparency. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `landscape(bool $bool)`:
 Sets the paper orientation to landscape. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `nativePageRanges(string $range)`:
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `header(string $template, array $context)`:
 
@@ -89,40 +119,71 @@ Adds a file, like an image, font, stylesheet, and so on.
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to PDF. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
 * `waitForExpression(string $expression)`:
 Sets the JavaScript expression to wait before converting an HTML
 document to PDF until it returns true. (default None).
+
 For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
 * `failOnConsoleExceptions(bool $bool)`:
 Forces GotenbergPdf to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
@@ -135,17 +196,30 @@ Enable PDF for Universal Access for optimal accessibility. (default false).
 * `metadata(array $metadata)`:
 Resets the metadata.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
+
 * `splitSpan(string $splitSpan)`:
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
+
 * `splitUnify(bool $bool)`:
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `downloadFrom(array $downloadFrom)`:
 
@@ -156,13 +230,22 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `addCookies(array $cookies)`:
 Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -1,9 +1,11 @@
 # HtmlPdfBuilder
 
 * `addAsset(string $path)`:
+
 Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
+
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
 
@@ -11,27 +13,34 @@ document. (default None).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `addMetadata(string $key, string $value)`:
+
 The metadata to write.
 
 * `assets(string $paths)`:
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `content(string $template, array $context)`:
 
+
 * `contentFile(string $path)`:
+
 The HTML file to convert into PDF.
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -39,6 +48,7 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
+
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
@@ -46,6 +56,7 @@ document. (default None). (overrides any previous headers).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
+
 Forces GotenbergPdf to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
 
@@ -53,6 +64,7 @@ exceptions in the Chromium console. (default false).
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
@@ -60,6 +72,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
 
@@ -67,6 +80,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
@@ -75,10 +89,13 @@ exceptions load at least one resource. (default false).
 
 * `footer(string $template, array $context)`:
 
+
 * `footerFile(string $path)`:
+
 HTML file containing the footer. (default None).
 
 * `generateDocumentOutline(bool $bool)`:
+
 Define whether the document outline should be embedded into the PDF. (Default false).
 
 > [!TIP]
@@ -86,10 +103,13 @@ Define whether the document outline should be embedded into the PDF. (Default fa
 
 * `header(string $template, array $context)`:
 
+
 * `headerFile(string $path)`:
+
 HTML file containing the header. (default None).
 
 * `landscape(bool $bool)`:
+
 Sets the paper orientation to landscape. (Default false).
 
 > [!TIP]
@@ -97,19 +117,25 @@ Sets the paper orientation to landscape. (Default false).
 
 * `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 
 * `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 Overrides the default margins (e.g., 0.39), in inches.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
+
 Resets the metadata.
 
 > [!TIP]
@@ -117,12 +143,14 @@ Resets the metadata.
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 * `nativePageRanges(string $range)`:
+
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
+
 Hides default white background and allows generating PDFs with
 transparency. (Default false).
 
@@ -131,7 +159,9 @@ transparency. (Default false).
 
 * `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 Overrides the default paper size, in inches.
 
 Examples of paper size (width x height):
@@ -153,64 +183,78 @@ A6 - 4.13 x 5.83
 
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
+
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+
 Sets the PDF format of the resulting PDF. (default None).
 
 * `pdfUniversalAccess(bool $bool)`:
+
 Enable PDF for Universal Access for optimal accessibility. (default false).
 
 * `preferCssPageSize(bool $bool)`:
+
 Define whether to prefer page size as defined by CSS. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `printBackground(bool $bool)`:
+
 Prints the background graphics. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
+
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `singlePage(bool $bool)`:
+
 Define whether to print the entire content in one single page.
 
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
+
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
+
 Either intervals or pages. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitSpan(string $splitSpan)`:
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitUnify(bool $bool)`:
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `userAgent(string $userAgent)`:
+
 Override the default User-Agent HTTP header. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to PDF. (default None).
 
@@ -218,6 +262,7 @@ document before converting it to PDF. (default None).
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
+
 Sets the JavaScript expression to wait before converting an HTML
 document to PDF until it returns true. (default None).
 
@@ -227,12 +272,15 @@ For instance: "window.status === 'ready'".
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -240,12 +288,14 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
+
 Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
+
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 > [!TIP]
@@ -253,5 +303,7 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 * `forwardCookie(string $name)`:
 
+
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -6,9 +6,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
 
-Adds extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None).
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
@@ -34,52 +32,42 @@ The HTML file to convert into PDF.
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `extraHttpHeaders(array $headers)`:
 
-Sets extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None). (overrides any previous headers).
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
 
-Forces GotenbergPdf to return a 409 Conflict response if there are
-
-exceptions in the Chromium console. (default false).
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from
-
-the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
-
-(default None). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions load at least one resource. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
@@ -92,7 +80,7 @@ HTML file containing the footer. (default None).
 
 * `generateDocumentOutline(bool $bool)`:
 
-Define whether the document outline should be embedded into the PDF. (Default false).
+Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -105,7 +93,7 @@ HTML file containing the header. (default None).
 
 * `landscape(bool $bool)`:
 
-Sets the paper orientation to landscape. (Default false).
+Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -120,14 +108,14 @@ Sets the paper orientation to landscape. (Default false).
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-Overrides the default margins (e.g., 0.39), in inches.
+Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
 
-Resets the metadata.
+Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
@@ -135,16 +123,14 @@ Resets the metadata.
 
 * `nativePageRanges(string $range)`:
 
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
 
-Hides default white background and allows generating PDFs with
-
-transparency. (Default false).
+Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -153,35 +139,7 @@ transparency. (Default false).
 
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-Overrides the default paper size, in inches.
-
-
-
-Examples of paper size (width x height):
-
-
-
-Letter - 8.5 x 11 (default)
-
-Legal - 8.5 x 14
-
-Tabloid - 11 x 17
-
-Ledger - 17 x 11
-
-A0 - 33.1 x 46.8
-
-A1 - 23.4 x 33.1
-
-A2 - 16.54 x 23.4
-
-A3 - 11.7 x 16.54
-
-A4 - 8.27 x 11.7
-
-A5 - 5.83 x 8.27
-
-A6 - 4.13 x 5.83
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -192,98 +150,84 @@ A6 - 4.13 x 5.83
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
-Sets the PDF format of the resulting PDF. (default None).
+Sets the PDF format of the resulting PDF. (default None).<br />
 
 * `pdfUniversalAccess(bool $bool)`:
 
-Enable PDF for Universal Access for optimal accessibility. (default false).
+Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
 * `preferCssPageSize(bool $bool)`:
 
-Define whether to prefer page size as defined by CSS. (Default false).
+Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `printBackground(bool $bool)`:
 
-Prints the background graphics. (Default false).
+Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
 
-The scale of the page rendering (e.g., 1.0). (Default 1.0).
+The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `singlePage(bool $bool)`:
 
-Define whether to print the entire content in one single page.
-
-
-
-If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
-Either intervals or pages. (default None).
+Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitSpan(string $splitSpan)`:
 
-Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
+Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitUnify(bool $bool)`:
 
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `userAgent(string $userAgent)`:
 
-Override the default User-Agent HTTP header. (default None).
+Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
 
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-
-document before converting it to PDF. (default None).
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
 
-Sets the JavaScript expression to wait before converting an HTML
-
-document to PDF until it returns true. (default None).
-
-
-
-For instance: "window.status === 'ready'".
+Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -294,27 +238,25 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
 
-Add cookies to store in the Chromium cookie jar.
+Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
 
-Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
+Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -1,320 +1,215 @@
 # HtmlPdfBuilder
 
-<details>
-<summary>addAsset(string $path)</summary>
-
+### addAsset(string $path)
 Adds a file, like an image, font, stylesheet, and so on.
 
-</details><details>
-<summary>addExtraHttpHeaders(array $headers)</summary>
-
+### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-</details><details>
-<summary>addMetadata(string $key, string $value)</summary>
-
+### addMetadata(string $key, string $value)
 The metadata to write.
 
-</details><details>
-<summary>assets(string $paths)</summary>
-
+### assets(string $paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-</details><details>
-<summary>content(string $template, array $context)</summary>
-
-</details><details>
-<summary>contentFile(string $path)</summary>
-
+### content(string $template, array $context)
+### contentFile(string $path)
 The HTML file to convert into PDF.
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
-
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>extraHttpHeaders(array $headers)</summary>
-
+### extraHttpHeaders(array $headers)
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-</details><details>
-<summary>failOnConsoleExceptions(bool $bool)</summary>
-
+### failOnConsoleExceptions(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceLoadingFailed(bool $bool)</summary>
-
+### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-</details><details>
-<summary>footer(string $template, array $context)</summary>
-
-</details><details>
-<summary>footerFile(string $path)</summary>
-
+### footer(string $template, array $context)
+### footerFile(string $path)
 HTML file containing the footer. (default None).
 
-</details><details>
-<summary>generateDocumentOutline(bool $bool)</summary>
-
+### generateDocumentOutline(bool $bool)
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>header(string $template, array $context)</summary>
-
-</details><details>
-<summary>headerFile(string $path)</summary>
-
+### header(string $template, array $context)
+### headerFile(string $path)
 HTML file containing the header. (default None).
 
-</details><details>
-<summary>landscape(bool $bool)</summary>
-
+### landscape(bool $bool)
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
+### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>metadata(array $metadata)</summary>
-
+### metadata(array $metadata)
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-</details><details>
-<summary>nativePageRanges(string $range)</summary>
-
+### nativePageRanges(string $range)
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>omitBackground(bool $bool)</summary>
-
+### omitBackground(bool $bool)
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
+### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)</summary>
-
-</details><details>
-<summary>paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
-
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Sets the PDF format of the resulting PDF. (default None).<br />
 
-</details><details>
-<summary>pdfUniversalAccess(bool $bool)</summary>
-
+### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
-</details><details>
-<summary>preferCssPageSize(bool $bool)</summary>
-
+### preferCssPageSize(bool $bool)
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>printBackground(bool $bool)</summary>
-
+### printBackground(bool $bool)
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>scale(float $scale)</summary>
-
+### scale(float $scale)
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>singlePage(bool $bool)</summary>
-
+### singlePage(bool $bool)
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
-</details><details>
-<summary>skipNetworkIdleEvent(bool $bool)</summary>
-
-</details><details>
-<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
-
+### skipNetworkIdleEvent(bool $bool)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>splitSpan(string $splitSpan)</summary>
-
+### splitSpan(string $splitSpan)
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>splitUnify(bool $bool)</summary>
-
+### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>userAgent(string $userAgent)</summary>
-
+### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-</details><details>
-<summary>waitDelay(string $delay)</summary>
-
+### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>waitForExpression(string $expression)</summary>
-
+### waitForExpression(string $expression)
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>addCookies(array $cookies)</summary>
-
+### addCookies(array $cookies)
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>cookies(array $cookies)</summary>
-
+### cookies(array $cookies)
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>forwardCookie(string $name)</summary>
-
-</details><details>
-<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
-
-</details>
+### forwardCookie(string $name)
+### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -1,5 +1,27 @@
 # HtmlPdfBuilder
 
+* `addAsset(string $path)`:
+Adds a file, like an image, font, stylesheet, and so on.
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `addExtraHttpHeaders(array $headers)`:
+Adds extra HTTP headers that Chromium will send when loading the HTML
+document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+* `addMetadata(string $key, string $value)`:
+The metadata to write.
+
+* `assets(string $paths)`:
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+
 * `content(string $template, array $context)`:
 
 * `contentFile(string $path)`:
@@ -7,129 +29,7 @@ The HTML file to convert into PDF.
 
 * `cookies(array $cookies)`:
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
-* `forwardCookie(string $name)`:
-
-* `singlePage(bool $bool)`:
-Define whether to print the entire content in one single page.
-
-If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-Overrides the default paper size, in inches.
-
-Examples of paper size (width x height):
-
-Letter - 8.5 x 11 (default)
-Legal - 8.5 x 14
-Tabloid - 11 x 17
-Ledger - 17 x 11
-A0 - 33.1 x 46.8
-A1 - 23.4 x 33.1
-A2 - 16.54 x 23.4
-A3 - 11.7 x 16.54
-A4 - 8.27 x 11.7
-A5 - 5.83 x 8.27
-A6 - 4.13 x 5.83
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
-
-* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-Overrides the default margins (e.g., 0.39), in inches.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `preferCssPageSize(bool $bool)`:
-Define whether to prefer page size as defined by CSS. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `generateDocumentOutline(bool $bool)`:
-Define whether the document outline should be embedded into the PDF. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `printBackground(bool $bool)`:
-Prints the background graphics. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `omitBackground(bool $bool)`:
-Hides default white background and allows generating PDFs with
-transparency. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `landscape(bool $bool)`:
-Sets the paper orientation to landscape. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `scale(float $scale)`:
-The scale of the page rendering (e.g., 1.0). (Default 1.0).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `nativePageRanges(string $range)`:
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `header(string $template, array $context)`:
-
-* `footer(string $template, array $context)`:
-
-* `headerFile(string $path)`:
-HTML file containing the header. (default None).
-
-* `footerFile(string $path)`:
-HTML file containing the footer. (default None).
-
-* `assets(string $paths)`:
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `addAsset(string $path)`:
-Adds a file, like an image, font, stylesheet, and so on.
-
-* `waitDelay(string $delay)`:
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-document before converting it to PDF. (default None).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-Sets the JavaScript expression to wait before converting an HTML
-document to PDF until it returns true. (default None).
-
-For instance: "window.status === 'ready'".
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+* `downloadFrom(array $downloadFrom)`:
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -137,11 +37,12 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `userAgent(string $userAgent)`:
-Override the default User-Agent HTTP header. (default None).
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -150,12 +51,12 @@ document. (default None). (overrides any previous headers).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-* `addExtraHttpHeaders(array $headers)`:
-Adds extra HTTP headers that Chromium will send when loading the HTML
-document. (default None).
+* `failOnConsoleExceptions(bool $bool)`:
+Forces GotenbergPdf to return a 409 Conflict response if there are
+exceptions in the Chromium console. (default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
@@ -178,20 +79,33 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-* `failOnConsoleExceptions(bool $bool)`:
-Forces GotenbergPdf to return a 409 Conflict response if there are
-exceptions in the Chromium console. (default false).
+* `footer(string $template, array $context)`:
+
+* `footerFile(string $path)`:
+HTML file containing the footer. (default None).
+
+* `generateDocumentOutline(bool $bool)`:
+Define whether the document outline should be embedded into the PDF. (Default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-* `skipNetworkIdleEvent(bool $bool)`:
+* `header(string $template, array $context)`:
 
-* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-Sets the PDF format of the resulting PDF. (default None).
+* `headerFile(string $path)`:
+HTML file containing the header. (default None).
 
-* `pdfUniversalAccess(bool $bool)`:
-Enable PDF for Universal Access for optimal accessibility. (default false).
+* `landscape(bool $bool)`:
+Sets the paper orientation to landscape. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+Overrides the default margins (e.g., 0.39), in inches.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
 Resets the metadata.
@@ -200,8 +114,69 @@ Resets the metadata.
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-* `addMetadata(string $key, string $value)`:
-The metadata to write.
+* `nativePageRanges(string $range)`:
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `omitBackground(bool $bool)`:
+Hides default white background and allows generating PDFs with
+transparency. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+Overrides the default paper size, in inches.
+
+Examples of paper size (width x height):
+
+Letter - 8.5 x 11 (default)
+Legal - 8.5 x 14
+Tabloid - 11 x 17
+Ledger - 17 x 11
+A0 - 33.1 x 46.8
+A1 - 23.4 x 33.1
+A2 - 16.54 x 23.4
+A3 - 11.7 x 16.54
+A4 - 8.27 x 11.7
+A5 - 5.83 x 8.27
+A6 - 4.13 x 5.83
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+Sets the PDF format of the resulting PDF. (default None).
+
+* `pdfUniversalAccess(bool $bool)`:
+Enable PDF for Universal Access for optimal accessibility. (default false).
+
+* `preferCssPageSize(bool $bool)`:
+Define whether to prefer page size as defined by CSS. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `printBackground(bool $bool)`:
+Prints the background graphics. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `scale(float $scale)`:
+The scale of the page rendering (e.g., 1.0). (Default 1.0).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
+* `singlePage(bool $bool)`:
+Define whether to print the entire content in one single page.
+
+If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
@@ -221,10 +196,33 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-* `downloadFrom(array $downloadFrom)`:
+* `userAgent(string $userAgent)`:
+Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+
+* `waitDelay(string $delay)`:
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+document before converting it to PDF. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `waitForExpression(string $expression)`:
+Sets the JavaScript expression to wait before converting an HTML
+document to PDF until it returns true. (default None).
+
+For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -232,20 +230,4 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
-
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -22,7 +22,6 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 
 * `content(string $template, array $context)`:
 
-
 * `contentFile(string $path)`:
 
 The HTML file to convert into PDF.
@@ -89,7 +88,6 @@ exceptions load at least one resource. (default false).
 
 * `footer(string $template, array $context)`:
 
-
 * `footerFile(string $path)`:
 
 HTML file containing the footer. (default None).
@@ -102,7 +100,6 @@ Define whether the document outline should be embedded into the PDF. (Default fa
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `header(string $template, array $context)`:
-
 
 * `headerFile(string $path)`:
 
@@ -117,15 +114,11 @@ Sets the paper orientation to landscape. (Default false).
 
 * `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
@@ -159,7 +152,6 @@ transparency. (Default false).
 
 * `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 Overrides the default paper size, in inches.
@@ -183,9 +175,7 @@ A6 - 4.13 x 5.83
 
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
-
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
@@ -223,7 +213,6 @@ Define whether to print the entire content in one single page.
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
-
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
@@ -303,7 +292,5 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 * `forwardCookie(string $name)`:
 
-
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -1,93 +1,11 @@
 # HtmlPdfBuilder
 
-### addAsset(string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
 ### addMetadata(string $key, string $value)
 The metadata to write.
-
-### assets(string $paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into PDF.
 
 ### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### footer(string $template, array $context)
-### footerFile(string $path)
-HTML file containing the footer. (default None).
-
-### generateDocumentOutline(bool $bool)
-Define whether the document outline should be embedded into the PDF. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### header(string $template, array $context)
-### headerFile(string $path)
-HTML file containing the header. (default None).
-
-### landscape(bool $bool)
-Sets the paper orientation to landscape. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default margins (e.g., 0.39), in inches.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 ### metadata(array $metadata)
 Resets the metadata.<br />
@@ -96,55 +14,12 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-### nativePageRanges(string $range)
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
-### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Sets the PDF format of the resulting PDF. (default None).<br />
 
 ### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
-### preferCssPageSize(bool $bool)
-Define whether to prefer page size as defined by CSS. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### printBackground(bool $bool)
-Prints the background graphics. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### scale(float $scale)
-The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### singlePage(bool $bool)
-Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-### skipNetworkIdleEvent(bool $bool)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
@@ -163,23 +38,11 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header. (default None).<br />
+### addAsset(string $path)
+Adds a file, like an image, font, stylesheet, and so on.<br />
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+### assets(string $paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br />
 
 ### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
@@ -213,3 +76,140 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<b
 
 ### forwardCookie(string $name)
 ### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### generateDocumentOutline(bool $bool)
+Define whether the document outline should be embedded into the PDF. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### landscape(bool $bool)
+Sets the paper orientation to landscape. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default margins (e.g., 0.39), in inches.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### nativePageRanges(string $range)
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### preferCssPageSize(bool $bool)
+Define whether to prefer page size as defined by CSS. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### printBackground(bool $bool)
+Prints the background graphics. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### scale(float $scale)
+The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### singlePage(bool $bool)
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.<br />
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into PDF.<br />
+
+### footer(string $template, array $context)
+### footerFile(string $path)
+HTML file containing the footer. (default None).<br />
+
+### header(string $template, array $context)
+### headerFile(string $path)
+HTML file containing the header. (default None).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium ](https://gotenberg.dev/docs/routes#network-errors-chromium )
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -38,14 +38,6 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -259,6 +251,14 @@ For instance: "window.status === 'ready'".
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookConfiguration(string $name)`:
 

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -95,6 +95,14 @@ Sets the paper orientation to landscape. (Default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
+* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default margins (e.g., 0.39), in inches.
 
@@ -121,6 +129,8 @@ transparency. (Default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
+* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default paper size, in inches.
 
@@ -140,6 +150,10 @@ A6 - 4.13 x 5.83
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
+
+* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 Sets the PDF format of the resulting PDF. (default None).
@@ -169,6 +183,8 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 Define whether to print the entire content in one single page.
 
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+* `skipNetworkIdleEvent(bool $bool)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).

--- a/docs/pdf/builders_api/HtmlPdfBuilder.md
+++ b/docs/pdf/builders_api/HtmlPdfBuilder.md
@@ -1,164 +1,320 @@
 # HtmlPdfBuilder
 
-<details><summary>`addAsset(string $path)`</summary>
+<details>
+<summary>addAsset(string $path)</summary>
+
 Adds a file, like an image, font, stylesheet, and so on.
-</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>addExtraHttpHeaders(array $headers)</summary>
+
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-</details><details><summary>`addMetadata(string $key, string $value)`</summary>
+
+</details><details>
+<summary>addMetadata(string $key, string $value)</summary>
+
 The metadata to write.
-</details><details><summary>`assets(string $paths)`</summary>
+
+</details><details>
+<summary>assets(string $paths)</summary>
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-</details><details><summary>`content(string $template, array $context)`</summary></details><details><summary>`contentFile(string $path)`</summary>
+
+</details><details>
+<summary>content(string $template, array $context)</summary>
+
+</details><details>
+<summary>contentFile(string $path)</summary>
+
 The HTML file to convert into PDF.
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
+
+</details><details>
+<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>extraHttpHeaders(array $headers)</summary>
+
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnConsoleExceptions(bool $bool)</summary>
+
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnResourceLoadingFailed(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-</details><details><summary>`footer(string $template, array $context)`</summary></details><details><summary>`footerFile(string $path)`</summary>
+
+</details><details>
+<summary>footer(string $template, array $context)</summary>
+
+</details><details>
+<summary>footerFile(string $path)</summary>
+
 HTML file containing the footer. (default None).
-</details><details><summary>`generateDocumentOutline(bool $bool)`</summary>
+
+</details><details>
+<summary>generateDocumentOutline(bool $bool)</summary>
+
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`header(string $template, array $context)`</summary></details><details><summary>`headerFile(string $path)`</summary>
+
+</details><details>
+<summary>header(string $template, array $context)</summary>
+
+</details><details>
+<summary>headerFile(string $path)</summary>
+
 HTML file containing the header. (default None).
-</details><details><summary>`landscape(bool $bool)`</summary>
+
+</details><details>
+<summary>landscape(bool $bool)</summary>
+
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
+
+</details><details>
+<summary>marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`metadata(array $metadata)`</summary>
+
+</details><details>
+<summary>metadata(array $metadata)</summary>
+
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-</details><details><summary>`nativePageRanges(string $range)`</summary>
+
+</details><details>
+<summary>nativePageRanges(string $range)</summary>
+
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`omitBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>omitBackground(bool $bool)</summary>
+
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
+
+</details><details>
+<summary>paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`</summary></details><details><summary>`paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
+
+</details><details>
+<summary>paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)</summary>
+
+</details><details>
+<summary>paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
+
 Sets the PDF format of the resulting PDF. (default None).<br />
-</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
+
+</details><details>
+<summary>pdfUniversalAccess(bool $bool)</summary>
+
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
-</details><details><summary>`preferCssPageSize(bool $bool)`</summary>
+
+</details><details>
+<summary>preferCssPageSize(bool $bool)</summary>
+
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`printBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>printBackground(bool $bool)</summary>
+
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`scale(float $scale)`</summary>
+
+</details><details>
+<summary>scale(float $scale)</summary>
+
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`singlePage(bool $bool)`</summary>
+
+</details><details>
+<summary>singlePage(bool $bool)</summary>
+
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
+
+</details><details>
+<summary>skipNetworkIdleEvent(bool $bool)</summary>
+
+</details><details>
+<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
+
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`splitSpan(string $splitSpan)`</summary>
+
+</details><details>
+<summary>splitSpan(string $splitSpan)</summary>
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`splitUnify(bool $bool)`</summary>
+
+</details><details>
+<summary>splitUnify(bool $bool)</summary>
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`userAgent(string $userAgent)`</summary>
+
+</details><details>
+<summary>userAgent(string $userAgent)</summary>
+
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-</details><details><summary>`waitDelay(string $delay)`</summary>
+
+</details><details>
+<summary>waitDelay(string $delay)</summary>
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`waitForExpression(string $expression)`</summary>
+
+</details><details>
+<summary>waitForExpression(string $expression)</summary>
+
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`addCookies(array $cookies)`</summary>
+
+</details><details>
+<summary>addCookies(array $cookies)</summary>
+
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`cookies(array $cookies)`</summary>
+
+</details><details>
+<summary>cookies(array $cookies)</summary>
+
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>
+
+</details><details>
+<summary>forwardCookie(string $name)</summary>
+
+</details><details>
+<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
+
+</details>

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -1,28 +1,36 @@
 # LibreOfficePdfBuilder
 
 * `addMetadata(string $key, string $value)`:
+
 The metadata to write.
 
 * `addOriginalDocumentAsStream(bool $bool)`:
+
 Specify that a stream is inserted to the PDF file which contains the original document for archiving purposes.
 
 * `allowDuplicateFieldNames(bool $bool)`:
+
 Specify whether multiple form fields exported are allowed to have the same field name.
 
 * `convertOooTargetToPdfTarget(bool $bool)`:
+
 Specify that the target documents with .od[tpgs] extension, will have that extension changed to .pdf when the link is exported to PDF. The source document remains untouched.
 
 * `doNotExportBookmarks(bool $bool)`:
+
 Specify if bookmarks are exported to PDF.
 
 * `doNotExportFormFields(bool $bool)`:
+
 Set whether to export the form fields or to use the inputted/selected content of the fields.
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -30,45 +38,59 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `exportBookmarksToPdfDestination(bool $bool)`:
+
 Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
 
 * `exportHiddenSlides(bool $bool)`:
+
 Export, for LibreOffice Impress, slides that are not included in slide shows.
 
 * `exportLinksRelativeFsys(bool $bool)`:
+
 Specify that the file system related hyperlinks (file:// protocol) present in the document will be exported as relative to the source document location.
 
 * `exportNotes(bool $bool)`:
+
 Specify if notes are exported to PDF.
 
 * `exportNotesInMargin(bool $bool)`:
+
 Specify if notes in margin are exported to PDF.
 
 * `exportNotesPages(bool $bool)`:
+
 Specify if notes pages are exported to PDF. Notes pages are available in Impress documents only.
 
 * `exportOnlyNotesPages(bool $bool)`:
+
 Specify, if the form field exportNotesPages is set to true, if only notes pages are exported to PDF.
 
 * `exportPlaceholders(bool $bool)`:
+
 Export the placeholders fields visual markings only. The exported placeholder is ineffective.
 
-* `files(Stringable|string $paths)`:
+* `files(string $paths)`:
+
 Adds office files to convert (overrides any previous files).
 
 * `landscape(bool $bool)`:
+
 Sets the paper orientation to landscape.
 
 * `losslessImageCompression(bool $bool)`:
+
 Specify if images are exported to PDF using a lossless compression format like PNG or compressed using the JPEG format.
 
 * `maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)`:
+
 If the form field reduceImageResolution is set to true, tell if all images will be reduced to the given value in DPI. Possible values are: 75, 150, 300, 600 and 1200.
 
 * `merge(bool $bool)`:
+
 Merge alphanumerically the resulting PDFs.
 
 * `metadata(array $metadata)`:
+
 Resets the metadata.
 
 > [!TIP]
@@ -76,56 +98,70 @@ Resets the metadata.
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 * `nativePageRanges(string $range)`:
+
 Page ranges to print, e.g., '1-4' - empty means all pages.
 
 If multiple files are provided, the page ranges will be applied independently to each file.
 
 * `password(string $password)`:
+
 Set the password for opening the source file.
 
 * `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+
 Convert the resulting PDF into the given PDF/A format.
 
 * `pdfUniversalAccess(bool $bool)`:
+
 Enable PDF for Universal Access for optimal accessibility.
 
 * `quality(int $quality)`:
+
 Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.
 
 * `reduceImageResolution(bool $bool)`:
+
 Specify if the resolution of each image is reduced to the resolution specified by the form field maxImageResolution.
 
 * `singlePageSheets(bool $bool)`:
+
 Set whether to render the entire spreadsheet as a single page.
 
 * `skipEmptyPages(bool $bool)`:
+
 Specify that automatically inserted empty pages are suppressed. This option is active only if storing Writer documents.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
+
 Either intervals or pages. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `splitSpan(string $splitSpan)`:
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `splitUnify(bool $bool)`:
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -1,203 +1,130 @@
 # LibreOfficePdfBuilder
 
-<details>
-<summary>addMetadata(string $key, string $value)</summary>
-
+### addMetadata(string $key, string $value)
 The metadata to write.
 
-</details><details>
-<summary>addOriginalDocumentAsStream(bool $bool)</summary>
-
+### addOriginalDocumentAsStream(bool $bool)
 Specify that a stream is inserted to the PDF file which contains the original document for archiving purposes.
 
-</details><details>
-<summary>allowDuplicateFieldNames(bool $bool)</summary>
-
+### allowDuplicateFieldNames(bool $bool)
 Specify whether multiple form fields exported are allowed to have the same field name.
 
-</details><details>
-<summary>convertOooTargetToPdfTarget(bool $bool)</summary>
-
+### convertOooTargetToPdfTarget(bool $bool)
 Specify that the target documents with .od[tpgs] extension, will have that extension changed to .pdf when the link is exported to PDF. The source document remains untouched.
 
-</details><details>
-<summary>doNotExportBookmarks(bool $bool)</summary>
-
+### doNotExportBookmarks(bool $bool)
 Specify if bookmarks are exported to PDF.
 
-</details><details>
-<summary>doNotExportFormFields(bool $bool)</summary>
-
+### doNotExportFormFields(bool $bool)
 Set whether to export the form fields or to use the inputted/selected content of the fields.
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>exportBookmarksToPdfDestination(bool $bool)</summary>
-
+### exportBookmarksToPdfDestination(bool $bool)
 Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
 
-</details><details>
-<summary>exportHiddenSlides(bool $bool)</summary>
-
+### exportHiddenSlides(bool $bool)
 Export, for LibreOffice Impress, slides that are not included in slide shows.
 
-</details><details>
-<summary>exportLinksRelativeFsys(bool $bool)</summary>
-
+### exportLinksRelativeFsys(bool $bool)
 Specify that the file system related hyperlinks (file:// protocol) present in the document will be exported as relative to the source document location.
 
-</details><details>
-<summary>exportNotes(bool $bool)</summary>
-
+### exportNotes(bool $bool)
 Specify if notes are exported to PDF.
 
-</details><details>
-<summary>exportNotesInMargin(bool $bool)</summary>
-
+### exportNotesInMargin(bool $bool)
 Specify if notes in margin are exported to PDF.
 
-</details><details>
-<summary>exportNotesPages(bool $bool)</summary>
-
+### exportNotesPages(bool $bool)
 Specify if notes pages are exported to PDF. Notes pages are available in Impress documents only.
 
-</details><details>
-<summary>exportOnlyNotesPages(bool $bool)</summary>
-
+### exportOnlyNotesPages(bool $bool)
 Specify, if the form field exportNotesPages is set to true, if only notes pages are exported to PDF.
 
-</details><details>
-<summary>exportPlaceholders(bool $bool)</summary>
-
+### exportPlaceholders(bool $bool)
 Export the placeholders fields visual markings only. The exported placeholder is ineffective.
 
-</details><details>
-<summary>files(string $paths)</summary>
-
+### files(string $paths)
 Adds office files to convert (overrides any previous files).
 
-</details><details>
-<summary>landscape(bool $bool)</summary>
-
+### landscape(bool $bool)
 Sets the paper orientation to landscape.
 
-</details><details>
-<summary>losslessImageCompression(bool $bool)</summary>
-
+### losslessImageCompression(bool $bool)
 Specify if images are exported to PDF using a lossless compression format like PNG or compressed using the JPEG format.
 
-</details><details>
-<summary>maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)</summary>
-
+### maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)
 If the form field reduceImageResolution is set to true, tell if all images will be reduced to the given value in DPI. Possible values are: 75, 150, 300, 600 and 1200.
 
-</details><details>
-<summary>merge(bool $bool)</summary>
-
+### merge(bool $bool)
 Merge alphanumerically the resulting PDFs.
 
-</details><details>
-<summary>metadata(array $metadata)</summary>
-
+### metadata(array $metadata)
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-</details><details>
-<summary>nativePageRanges(string $range)</summary>
-
+### nativePageRanges(string $range)
 Page ranges to print, e.g., '1-4' - empty means all pages.<br /><br />If multiple files are provided, the page ranges will be applied independently to each file.
 
-</details><details>
-<summary>password(string $password)</summary>
-
+### password(string $password)
 Set the password for opening the source file.
 
-</details><details>
-<summary>pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
-
+### pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
 
-</details><details>
-<summary>pdfUniversalAccess(bool $bool)</summary>
-
+### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility.
 
-</details><details>
-<summary>quality(int $quality)</summary>
-
+### quality(int $quality)
 Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.<br />
 
-</details><details>
-<summary>reduceImageResolution(bool $bool)</summary>
-
+### reduceImageResolution(bool $bool)
 Specify if the resolution of each image is reduced to the resolution specified by the form field maxImageResolution.
 
-</details><details>
-<summary>singlePageSheets(bool $bool)</summary>
-
+### singlePageSheets(bool $bool)
 Set whether to render the entire spreadsheet as a single page.
 
-</details><details>
-<summary>skipEmptyPages(bool $bool)</summary>
-
+### skipEmptyPages(bool $bool)
 Specify that automatically inserted empty pages are suppressed. This option is active only if storing Writer documents.
 
-</details><details>
-<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
-
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
-</details><details>
-<summary>splitSpan(string $splitSpan)</summary>
-
+### splitSpan(string $splitSpan)
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
-</details><details>
-<summary>splitUnify(bool $bool)</summary>
-
+### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details>

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -1,33 +1,70 @@
 # LibreOfficePdfBuilder
 
-* `password(string $password)`:
-Set the password for opening the source file.
+* `addMetadata(string $key, string $value)`:
+The metadata to write.
 
-* `landscape(bool $bool)`:
-Sets the paper orientation to landscape.
+* `addOriginalDocumentAsStream(bool $bool)`:
+Specify that a stream is inserted to the PDF file which contains the original document for archiving purposes.
 
-* `nativePageRanges(string $range)`:
-Page ranges to print, e.g., '1-4' - empty means all pages.
+* `allowDuplicateFieldNames(bool $bool)`:
+Specify whether multiple form fields exported are allowed to have the same field name.
 
-If multiple files are provided, the page ranges will be applied independently to each file.
+* `convertOooTargetToPdfTarget(bool $bool)`:
+Specify that the target documents with .od[tpgs] extension, will have that extension changed to .pdf when the link is exported to PDF. The source document remains untouched.
+
+* `doNotExportBookmarks(bool $bool)`:
+Specify if bookmarks are exported to PDF.
 
 * `doNotExportFormFields(bool $bool)`:
 Set whether to export the form fields or to use the inputted/selected content of the fields.
 
-* `singlePageSheets(bool $bool)`:
-Set whether to render the entire spreadsheet as a single page.
+* `downloadFrom(array $downloadFrom)`:
 
-* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-Convert the resulting PDF into the given PDF/A format.
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
-* `pdfUniversalAccess(bool $bool)`:
-Enable PDF for Universal Access for optimal accessibility.
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-* `merge(bool $bool)`:
-Merge alphanumerically the resulting PDFs.
+* `exportBookmarksToPdfDestination(bool $bool)`:
+Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
+
+* `exportHiddenSlides(bool $bool)`:
+Export, for LibreOffice Impress, slides that are not included in slide shows.
+
+* `exportLinksRelativeFsys(bool $bool)`:
+Specify that the file system related hyperlinks (file:// protocol) present in the document will be exported as relative to the source document location.
+
+* `exportNotes(bool $bool)`:
+Specify if notes are exported to PDF.
+
+* `exportNotesInMargin(bool $bool)`:
+Specify if notes in margin are exported to PDF.
+
+* `exportNotesPages(bool $bool)`:
+Specify if notes pages are exported to PDF. Notes pages are available in Impress documents only.
+
+* `exportOnlyNotesPages(bool $bool)`:
+Specify, if the form field exportNotesPages is set to true, if only notes pages are exported to PDF.
+
+* `exportPlaceholders(bool $bool)`:
+Export the placeholders fields visual markings only. The exported placeholder is ineffective.
 
 * `files(Stringable|string $paths)`:
 Adds office files to convert (overrides any previous files).
+
+* `landscape(bool $bool)`:
+Sets the paper orientation to landscape.
+
+* `losslessImageCompression(bool $bool)`:
+Specify if images are exported to PDF using a lossless compression format like PNG or compressed using the JPEG format.
+
+* `maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)`:
+If the form field reduceImageResolution is set to true, tell if all images will be reduced to the given value in DPI. Possible values are: 75, 150, 300, 600 and 1200.
+
+* `merge(bool $bool)`:
+Merge alphanumerically the resulting PDFs.
 
 * `metadata(array $metadata)`:
 Resets the metadata.
@@ -36,50 +73,19 @@ Resets the metadata.
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-* `addMetadata(string $key, string $value)`:
-The metadata to write.
+* `nativePageRanges(string $range)`:
+Page ranges to print, e.g., '1-4' - empty means all pages.
 
-* `allowDuplicateFieldNames(bool $bool)`:
-Specify whether multiple form fields exported are allowed to have the same field name.
+If multiple files are provided, the page ranges will be applied independently to each file.
 
-* `doNotExportBookmarks(bool $bool)`:
-Specify if bookmarks are exported to PDF.
+* `password(string $password)`:
+Set the password for opening the source file.
 
-* `exportBookmarksToPdfDestination(bool $bool)`:
-Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
+* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+Convert the resulting PDF into the given PDF/A format.
 
-* `exportPlaceholders(bool $bool)`:
-Export the placeholders fields visual markings only. The exported placeholder is ineffective.
-
-* `exportNotes(bool $bool)`:
-Specify if notes are exported to PDF.
-
-* `exportNotesPages(bool $bool)`:
-Specify if notes pages are exported to PDF. Notes pages are available in Impress documents only.
-
-* `exportOnlyNotesPages(bool $bool)`:
-Specify, if the form field exportNotesPages is set to true, if only notes pages are exported to PDF.
-
-* `exportNotesInMargin(bool $bool)`:
-Specify if notes in margin are exported to PDF.
-
-* `convertOooTargetToPdfTarget(bool $bool)`:
-Specify that the target documents with .od[tpgs] extension, will have that extension changed to .pdf when the link is exported to PDF. The source document remains untouched.
-
-* `exportLinksRelativeFsys(bool $bool)`:
-Specify that the file system related hyperlinks (file:// protocol) present in the document will be exported as relative to the source document location.
-
-* `exportHiddenSlides(bool $bool)`:
-Export, for LibreOffice Impress, slides that are not included in slide shows.
-
-* `skipEmptyPages(bool $bool)`:
-Specify that automatically inserted empty pages are suppressed. This option is active only if storing Writer documents.
-
-* `addOriginalDocumentAsStream(bool $bool)`:
-Specify that a stream is inserted to the PDF file which contains the original document for archiving purposes.
-
-* `losslessImageCompression(bool $bool)`:
-Specify if images are exported to PDF using a lossless compression format like PNG or compressed using the JPEG format.
+* `pdfUniversalAccess(bool $bool)`:
+Enable PDF for Universal Access for optimal accessibility.
 
 * `quality(int $quality)`:
 Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.
@@ -87,8 +93,11 @@ Specify the quality of the JPG export. A higher value produces a higher-quality 
 * `reduceImageResolution(bool $bool)`:
 Specify if the resolution of each image is reduced to the resolution specified by the form field maxImageResolution.
 
-* `maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)`:
-If the form field reduceImageResolution is set to true, tell if all images will be reduced to the given value in DPI. Possible values are: 75, 150, 300, 600 and 1200.
+* `singlePageSheets(bool $bool)`:
+Set whether to render the entire spreadsheet as a single page.
+
+* `skipEmptyPages(bool $bool)`:
+Specify that automatically inserted empty pages are suppressed. This option is active only if storing Writer documents.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
@@ -108,10 +117,11 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
-* `downloadFrom(array $downloadFrom)`:
-
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -119,14 +129,4 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -93,6 +93,8 @@ Resets the metadata.
 
 Page ranges to print, e.g., '1-4' - empty means all pages.
 
+
+
 If multiple files are provided, the page ranges will be applied independently to each file.
 
 * `password(string $password)`:
@@ -147,6 +149,7 @@ Specify whether to put extracted pages into a single file or as many files as th
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -163,6 +166,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -1,95 +1,203 @@
 # LibreOfficePdfBuilder
 
-<details><summary>`addMetadata(string $key, string $value)`</summary>
+<details>
+<summary>addMetadata(string $key, string $value)</summary>
+
 The metadata to write.
-</details><details><summary>`addOriginalDocumentAsStream(bool $bool)`</summary>
+
+</details><details>
+<summary>addOriginalDocumentAsStream(bool $bool)</summary>
+
 Specify that a stream is inserted to the PDF file which contains the original document for archiving purposes.
-</details><details><summary>`allowDuplicateFieldNames(bool $bool)`</summary>
+
+</details><details>
+<summary>allowDuplicateFieldNames(bool $bool)</summary>
+
 Specify whether multiple form fields exported are allowed to have the same field name.
-</details><details><summary>`convertOooTargetToPdfTarget(bool $bool)`</summary>
+
+</details><details>
+<summary>convertOooTargetToPdfTarget(bool $bool)</summary>
+
 Specify that the target documents with .od[tpgs] extension, will have that extension changed to .pdf when the link is exported to PDF. The source document remains untouched.
-</details><details><summary>`doNotExportBookmarks(bool $bool)`</summary>
+
+</details><details>
+<summary>doNotExportBookmarks(bool $bool)</summary>
+
 Specify if bookmarks are exported to PDF.
-</details><details><summary>`doNotExportFormFields(bool $bool)`</summary>
+
+</details><details>
+<summary>doNotExportFormFields(bool $bool)</summary>
+
 Set whether to export the form fields or to use the inputted/selected content of the fields.
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`exportBookmarksToPdfDestination(bool $bool)`</summary>
+
+</details><details>
+<summary>exportBookmarksToPdfDestination(bool $bool)</summary>
+
 Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
-</details><details><summary>`exportHiddenSlides(bool $bool)`</summary>
+
+</details><details>
+<summary>exportHiddenSlides(bool $bool)</summary>
+
 Export, for LibreOffice Impress, slides that are not included in slide shows.
-</details><details><summary>`exportLinksRelativeFsys(bool $bool)`</summary>
+
+</details><details>
+<summary>exportLinksRelativeFsys(bool $bool)</summary>
+
 Specify that the file system related hyperlinks (file:// protocol) present in the document will be exported as relative to the source document location.
-</details><details><summary>`exportNotes(bool $bool)`</summary>
+
+</details><details>
+<summary>exportNotes(bool $bool)</summary>
+
 Specify if notes are exported to PDF.
-</details><details><summary>`exportNotesInMargin(bool $bool)`</summary>
+
+</details><details>
+<summary>exportNotesInMargin(bool $bool)</summary>
+
 Specify if notes in margin are exported to PDF.
-</details><details><summary>`exportNotesPages(bool $bool)`</summary>
+
+</details><details>
+<summary>exportNotesPages(bool $bool)</summary>
+
 Specify if notes pages are exported to PDF. Notes pages are available in Impress documents only.
-</details><details><summary>`exportOnlyNotesPages(bool $bool)`</summary>
+
+</details><details>
+<summary>exportOnlyNotesPages(bool $bool)</summary>
+
 Specify, if the form field exportNotesPages is set to true, if only notes pages are exported to PDF.
-</details><details><summary>`exportPlaceholders(bool $bool)`</summary>
+
+</details><details>
+<summary>exportPlaceholders(bool $bool)</summary>
+
 Export the placeholders fields visual markings only. The exported placeholder is ineffective.
-</details><details><summary>`files(string $paths)`</summary>
+
+</details><details>
+<summary>files(string $paths)</summary>
+
 Adds office files to convert (overrides any previous files).
-</details><details><summary>`landscape(bool $bool)`</summary>
+
+</details><details>
+<summary>landscape(bool $bool)</summary>
+
 Sets the paper orientation to landscape.
-</details><details><summary>`losslessImageCompression(bool $bool)`</summary>
+
+</details><details>
+<summary>losslessImageCompression(bool $bool)</summary>
+
 Specify if images are exported to PDF using a lossless compression format like PNG or compressed using the JPEG format.
-</details><details><summary>`maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)`</summary>
+
+</details><details>
+<summary>maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)</summary>
+
 If the form field reduceImageResolution is set to true, tell if all images will be reduced to the given value in DPI. Possible values are: 75, 150, 300, 600 and 1200.
-</details><details><summary>`merge(bool $bool)`</summary>
+
+</details><details>
+<summary>merge(bool $bool)</summary>
+
 Merge alphanumerically the resulting PDFs.
-</details><details><summary>`metadata(array $metadata)`</summary>
+
+</details><details>
+<summary>metadata(array $metadata)</summary>
+
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-</details><details><summary>`nativePageRanges(string $range)`</summary>
+
+</details><details>
+<summary>nativePageRanges(string $range)</summary>
+
 Page ranges to print, e.g., '1-4' - empty means all pages.<br /><br />If multiple files are provided, the page ranges will be applied independently to each file.
-</details><details><summary>`password(string $password)`</summary>
+
+</details><details>
+<summary>password(string $password)</summary>
+
 Set the password for opening the source file.
-</details><details><summary>`pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
+
+</details><details>
+<summary>pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
+
 Convert the resulting PDF into the given PDF/A format.
-</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
+
+</details><details>
+<summary>pdfUniversalAccess(bool $bool)</summary>
+
 Enable PDF for Universal Access for optimal accessibility.
-</details><details><summary>`quality(int $quality)`</summary>
+
+</details><details>
+<summary>quality(int $quality)</summary>
+
 Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.<br />
-</details><details><summary>`reduceImageResolution(bool $bool)`</summary>
+
+</details><details>
+<summary>reduceImageResolution(bool $bool)</summary>
+
 Specify if the resolution of each image is reduced to the resolution specified by the form field maxImageResolution.
-</details><details><summary>`singlePageSheets(bool $bool)`</summary>
+
+</details><details>
+<summary>singlePageSheets(bool $bool)</summary>
+
 Set whether to render the entire spreadsheet as a single page.
-</details><details><summary>`skipEmptyPages(bool $bool)`</summary>
+
+</details><details>
+<summary>skipEmptyPages(bool $bool)</summary>
+
 Specify that automatically inserted empty pages are suppressed. This option is active only if storing Writer documents.
-</details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
+
+</details><details>
+<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
+
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
-</details><details><summary>`splitSpan(string $splitSpan)`</summary>
+
+</details><details>
+<summary>splitSpan(string $splitSpan)</summary>
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
-</details><details><summary>`splitUnify(bool $bool)`</summary>
+
+</details><details>
+<summary>splitUnify(bool $bool)</summary>
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 </details>

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -1,166 +1,95 @@
 # LibreOfficePdfBuilder
 
-* `addMetadata(string $key, string $value)`:
-
+<details><summary>`addMetadata(string $key, string $value)`</summary>
 The metadata to write.
-
-* `addOriginalDocumentAsStream(bool $bool)`:
-
+</details><details><summary>`addOriginalDocumentAsStream(bool $bool)`</summary>
 Specify that a stream is inserted to the PDF file which contains the original document for archiving purposes.
-
-* `allowDuplicateFieldNames(bool $bool)`:
-
+</details><details><summary>`allowDuplicateFieldNames(bool $bool)`</summary>
 Specify whether multiple form fields exported are allowed to have the same field name.
-
-* `convertOooTargetToPdfTarget(bool $bool)`:
-
+</details><details><summary>`convertOooTargetToPdfTarget(bool $bool)`</summary>
 Specify that the target documents with .od[tpgs] extension, will have that extension changed to .pdf when the link is exported to PDF. The source document remains untouched.
-
-* `doNotExportBookmarks(bool $bool)`:
-
+</details><details><summary>`doNotExportBookmarks(bool $bool)`</summary>
 Specify if bookmarks are exported to PDF.
-
-* `doNotExportFormFields(bool $bool)`:
-
+</details><details><summary>`doNotExportFormFields(bool $bool)`</summary>
 Set whether to export the form fields or to use the inputted/selected content of the fields.
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `exportBookmarksToPdfDestination(bool $bool)`:
-
+</details><details><summary>`exportBookmarksToPdfDestination(bool $bool)`</summary>
 Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
-
-* `exportHiddenSlides(bool $bool)`:
-
+</details><details><summary>`exportHiddenSlides(bool $bool)`</summary>
 Export, for LibreOffice Impress, slides that are not included in slide shows.
-
-* `exportLinksRelativeFsys(bool $bool)`:
-
+</details><details><summary>`exportLinksRelativeFsys(bool $bool)`</summary>
 Specify that the file system related hyperlinks (file:// protocol) present in the document will be exported as relative to the source document location.
-
-* `exportNotes(bool $bool)`:
-
+</details><details><summary>`exportNotes(bool $bool)`</summary>
 Specify if notes are exported to PDF.
-
-* `exportNotesInMargin(bool $bool)`:
-
+</details><details><summary>`exportNotesInMargin(bool $bool)`</summary>
 Specify if notes in margin are exported to PDF.
-
-* `exportNotesPages(bool $bool)`:
-
+</details><details><summary>`exportNotesPages(bool $bool)`</summary>
 Specify if notes pages are exported to PDF. Notes pages are available in Impress documents only.
-
-* `exportOnlyNotesPages(bool $bool)`:
-
+</details><details><summary>`exportOnlyNotesPages(bool $bool)`</summary>
 Specify, if the form field exportNotesPages is set to true, if only notes pages are exported to PDF.
-
-* `exportPlaceholders(bool $bool)`:
-
+</details><details><summary>`exportPlaceholders(bool $bool)`</summary>
 Export the placeholders fields visual markings only. The exported placeholder is ineffective.
-
-* `files(string $paths)`:
-
+</details><details><summary>`files(string $paths)`</summary>
 Adds office files to convert (overrides any previous files).
-
-* `landscape(bool $bool)`:
-
+</details><details><summary>`landscape(bool $bool)`</summary>
 Sets the paper orientation to landscape.
-
-* `losslessImageCompression(bool $bool)`:
-
+</details><details><summary>`losslessImageCompression(bool $bool)`</summary>
 Specify if images are exported to PDF using a lossless compression format like PNG or compressed using the JPEG format.
-
-* `maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)`:
-
+</details><details><summary>`maxImageResolution(Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI $resolution)`</summary>
 If the form field reduceImageResolution is set to true, tell if all images will be reduced to the given value in DPI. Possible values are: 75, 150, 300, 600 and 1200.
-
-* `merge(bool $bool)`:
-
+</details><details><summary>`merge(bool $bool)`</summary>
 Merge alphanumerically the resulting PDFs.
-
-* `metadata(array $metadata)`:
-
+</details><details><summary>`metadata(array $metadata)`</summary>
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-* `nativePageRanges(string $range)`:
-
+</details><details><summary>`nativePageRanges(string $range)`</summary>
 Page ranges to print, e.g., '1-4' - empty means all pages.<br /><br />If multiple files are provided, the page ranges will be applied independently to each file.
-
-* `password(string $password)`:
-
+</details><details><summary>`password(string $password)`</summary>
 Set the password for opening the source file.
-
-* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-
+</details><details><summary>`pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
 Convert the resulting PDF into the given PDF/A format.
-
-* `pdfUniversalAccess(bool $bool)`:
-
+</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
 Enable PDF for Universal Access for optimal accessibility.
-
-* `quality(int $quality)`:
-
+</details><details><summary>`quality(int $quality)`</summary>
 Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.<br />
-
-* `reduceImageResolution(bool $bool)`:
-
+</details><details><summary>`reduceImageResolution(bool $bool)`</summary>
 Specify if the resolution of each image is reduced to the resolution specified by the form field maxImageResolution.
-
-* `singlePageSheets(bool $bool)`:
-
+</details><details><summary>`singlePageSheets(bool $bool)`</summary>
 Set whether to render the entire spreadsheet as a single page.
-
-* `skipEmptyPages(bool $bool)`:
-
+</details><details><summary>`skipEmptyPages(bool $bool)`</summary>
 Specify that automatically inserted empty pages are suppressed. This option is active only if storing Writer documents.
-
-* `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
-
+</details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
-
-* `splitSpan(string $splitSpan)`:
-
+</details><details><summary>`splitSpan(string $splitSpan)`</summary>
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
-
-* `splitUnify(bool $bool)`:
-
+</details><details><summary>`splitUnify(bool $bool)`</summary>
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
+</details>

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -83,7 +83,7 @@ Merge alphanumerically the resulting PDFs.
 
 * `metadata(array $metadata)`:
 
-Resets the metadata.
+Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
@@ -91,11 +91,7 @@ Resets the metadata.
 
 * `nativePageRanges(string $range)`:
 
-Page ranges to print, e.g., '1-4' - empty means all pages.
-
-
-
-If multiple files are provided, the page ranges will be applied independently to each file.
+Page ranges to print, e.g., '1-4' - empty means all pages.<br /><br />If multiple files are provided, the page ranges will be applied independently to each file.
 
 * `password(string $password)`:
 
@@ -111,7 +107,7 @@ Enable PDF for Universal Access for optimal accessibility.
 
 * `quality(int $quality)`:
 
-Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.
+Specify the quality of the JPG export. A higher value produces a higher-quality image and a larger file. Between 1 and 100.<br />
 
 * `reduceImageResolution(bool $bool)`:
 
@@ -127,30 +123,28 @@ Specify that automatically inserted empty pages are suppressed. This option is a
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
-Either intervals or pages. (default None).
+Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `splitSpan(string $splitSpan)`:
 
-Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
+Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `splitUnify(bool $bool)`:
 
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -161,13 +155,11 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -8,6 +8,7 @@ Sets the paper orientation to landscape.
 
 * `nativePageRanges(string $range)`:
 Page ranges to print, e.g., '1-4' - empty means all pages.
+
 If multiple files are provided, the page ranges will be applied independently to each file.
 
 * `doNotExportFormFields(bool $bool)`:
@@ -30,6 +31,10 @@ Adds office files to convert (overrides any previous files).
 
 * `metadata(array $metadata)`:
 Resets the metadata.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
@@ -88,11 +93,20 @@ If the form field reduceImageResolution is set to true, tell if all images will 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
+
 * `splitSpan(string $splitSpan)`:
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
+
 * `splitUnify(bool $bool)`:
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
 
 * `downloadFrom(array $downloadFrom)`:
 
@@ -103,9 +117,15 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -19,6 +19,8 @@ Specify if bookmarks are exported to PDF.
 Set whether to export the form fields or to use the inputted/selected content of the fields.
 
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -46,7 +46,7 @@ Specify, if the form field exportNotesPages is set to true, if only notes pages 
 ### exportPlaceholders(bool $bool)
 Export the placeholders fields visual markings only. The exported placeholder is ineffective.
 
-### files(string $paths)
+### files(Stringable|string $paths)
 Adds office files to convert (overrides any previous files).
 
 ### landscape(bool $bool)

--- a/docs/pdf/builders_api/LibreOfficePdfBuilder.md
+++ b/docs/pdf/builders_api/LibreOfficePdfBuilder.md
@@ -29,14 +29,6 @@ Set whether to export the form fields or to use the inputted/selected content of
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `exportBookmarksToPdfDestination(bool $bool)`:
 
 Specify that the bookmarks contained in the source LibreOffice file should be exported to the PDF file as Named Destination.
@@ -151,6 +143,14 @@ Specify whether to put extracted pages into a single file or as many files as th
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-libreoffice](https://gotenberg.dev/docs/routes#split-libreoffice)
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookConfiguration(string $name)`:
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -6,9 +6,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
 
-Adds extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None).
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
@@ -28,52 +26,42 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `extraHttpHeaders(array $headers)`:
 
-Sets extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None). (overrides any previous headers).
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
 
-Forces GotenbergPdf to return a 409 Conflict response if there are
-
-exceptions in the Chromium console. (default false).
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from
-
-the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
-
-(default None). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions load at least one resource. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
@@ -88,7 +76,7 @@ HTML file containing the footer. (default None).
 
 * `generateDocumentOutline(bool $bool)`:
 
-Define whether the document outline should be embedded into the PDF. (Default false).
+Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -101,7 +89,7 @@ HTML file containing the header. (default None).
 
 * `landscape(bool $bool)`:
 
-Sets the paper orientation to landscape. (Default false).
+Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -116,14 +104,14 @@ Sets the paper orientation to landscape. (Default false).
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-Overrides the default margins (e.g., 0.39), in inches.
+Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
 
-Resets the metadata.
+Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
@@ -131,16 +119,14 @@ Resets the metadata.
 
 * `nativePageRanges(string $range)`:
 
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
 
-Hides default white background and allows generating PDFs with
-
-transparency. (Default false).
+Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -149,35 +135,7 @@ transparency. (Default false).
 
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-Overrides the default paper size, in inches.
-
-
-
-Examples of paper size (width x height):
-
-
-
-Letter - 8.5 x 11 (default)
-
-Legal - 8.5 x 14
-
-Tabloid - 11 x 17
-
-Ledger - 17 x 11
-
-A0 - 33.1 x 46.8
-
-A1 - 23.4 x 33.1
-
-A2 - 16.54 x 23.4
-
-A3 - 11.7 x 16.54
-
-A4 - 8.27 x 11.7
-
-A5 - 5.83 x 8.27
-
-A6 - 4.13 x 5.83
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -188,96 +146,84 @@ A6 - 4.13 x 5.83
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
-Sets the PDF format of the resulting PDF. (default None).
+Sets the PDF format of the resulting PDF. (default None).<br />
 
 * `pdfUniversalAccess(bool $bool)`:
 
-Enable PDF for Universal Access for optimal accessibility. (default false).
+Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
 * `preferCssPageSize(bool $bool)`:
 
-Define whether to prefer page size as defined by CSS. (Default false).
+Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `printBackground(bool $bool)`:
 
-Prints the background graphics. (Default false).
+Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
 
-The scale of the page rendering (e.g., 1.0). (Default 1.0).
+The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `singlePage(bool $bool)`:
 
-Define whether to print the entire content in one single page.
-
-
-
-If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
-Either intervals or pages. (default None).
+Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitSpan(string $splitSpan)`:
 
-Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
+Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitUnify(bool $bool)`:
 
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `userAgent(string $userAgent)`:
 
-Override the default User-Agent HTTP header. (default None).
+Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
 
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-
-document before converting it to PDF. (default None).
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
 
-Sets the JavaScript expression to wait before converting an HTML
-
-document to PDF until it returns true. (default None).
-
-
-
-For instance: "window.status === 'ready'".
+Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `wrapper(string $template, array $context)`:
 
-The HTML file that wraps the markdown content, rendered from a Twig template.
+The HTML file that wraps the markdown content, rendered from a Twig template.<br />
 
 * `wrapperFile(string $path)`:
 
@@ -285,9 +231,7 @@ The HTML file that wraps the markdown content.
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -298,27 +242,25 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
 
-Add cookies to store in the Chromium cookie jar.
+Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
 
-Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
+Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -1,271 +1,166 @@
 # MarkdownPdfBuilder
 
-* `addAsset(string $path)`:
-
+<details><summary>`addAsset(string $path)`</summary>
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addExtraHttpHeaders(array $headers)`:
-
+</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-* `addMetadata(string $key, string $value)`:
-
+</details><details><summary>`addMetadata(string $key, string $value)`</summary>
 The metadata to write.
-
-* `assets(string $paths)`:
-
+</details><details><summary>`assets(string $paths)`</summary>
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
-
+</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `extraHttpHeaders(array $headers)`:
-
+</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-* `failOnConsoleExceptions(bool $bool)`:
-
+</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `failOnHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceLoadingFailed(bool $bool)`:
-
+</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-* `files(string $paths)`:
-
-* `footer(string $template, array $context)`:
-
-* `footerFile(string $path)`:
-
+</details><details><summary>`files(string $paths)`</summary></details><details><summary>`footer(string $template, array $context)`</summary></details><details><summary>`footerFile(string $path)`</summary>
 HTML file containing the footer. (default None).
-
-* `generateDocumentOutline(bool $bool)`:
-
+</details><details><summary>`generateDocumentOutline(bool $bool)`</summary>
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `header(string $template, array $context)`:
-
-* `headerFile(string $path)`:
-
+</details><details><summary>`header(string $template, array $context)`</summary></details><details><summary>`headerFile(string $path)`</summary>
 HTML file containing the header. (default None).
-
-* `landscape(bool $bool)`:
-
+</details><details><summary>`landscape(bool $bool)`</summary>
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
+</details><details><summary>`marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `metadata(array $metadata)`:
-
+</details><details><summary>`metadata(array $metadata)`</summary>
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-* `nativePageRanges(string $range)`:
-
+</details><details><summary>`nativePageRanges(string $range)`</summary>
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `omitBackground(bool $bool)`:
-
+</details><details><summary>`omitBackground(bool $bool)`</summary>
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
+</details><details><summary>`paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
-
-* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-
+</details><details><summary>`paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`</summary></details><details><summary>`paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
 Sets the PDF format of the resulting PDF. (default None).<br />
-
-* `pdfUniversalAccess(bool $bool)`:
-
+</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
-
-* `preferCssPageSize(bool $bool)`:
-
+</details><details><summary>`preferCssPageSize(bool $bool)`</summary>
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `printBackground(bool $bool)`:
-
+</details><details><summary>`printBackground(bool $bool)`</summary>
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `scale(float $scale)`:
-
+</details><details><summary>`scale(float $scale)`</summary>
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `singlePage(bool $bool)`:
-
+</details><details><summary>`singlePage(bool $bool)`</summary>
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-* `skipNetworkIdleEvent(bool $bool)`:
-
-* `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
-
+</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `splitSpan(string $splitSpan)`:
-
+</details><details><summary>`splitSpan(string $splitSpan)`</summary>
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `splitUnify(bool $bool)`:
-
+</details><details><summary>`splitUnify(bool $bool)`</summary>
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `userAgent(string $userAgent)`:
-
+</details><details><summary>`userAgent(string $userAgent)`</summary>
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-* `waitDelay(string $delay)`:
-
+</details><details><summary>`waitDelay(string $delay)`</summary>
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-
+</details><details><summary>`waitForExpression(string $expression)`</summary>
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `wrapper(string $template, array $context)`:
-
+</details><details><summary>`wrapper(string $template, array $context)`</summary>
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
-
-* `wrapperFile(string $path)`:
-
+</details><details><summary>`wrapperFile(string $path)`</summary>
 The HTML file that wraps the markdown content.
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `addCookies(array $cookies)`:
-
+</details><details><summary>`addCookies(array $cookies)`</summary>
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `cookies(array $cookies)`:
-
+</details><details><summary>`cookies(array $cookies)`</summary>
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `forwardCookie(string $name)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
+</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -82,9 +82,7 @@ exceptions load at least one resource. (default false).
 
 * `files(string $paths)`:
 
-
 * `footer(string $template, array $context)`:
-
 
 * `footerFile(string $path)`:
 
@@ -99,7 +97,6 @@ Define whether the document outline should be embedded into the PDF. (Default fa
 
 * `header(string $template, array $context)`:
 
-
 * `headerFile(string $path)`:
 
 HTML file containing the header. (default None).
@@ -113,15 +110,11 @@ Sets the paper orientation to landscape. (Default false).
 
 * `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
@@ -155,7 +148,6 @@ transparency. (Default false).
 
 * `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 Overrides the default paper size, in inches.
@@ -179,9 +171,7 @@ A6 - 4.13 x 5.83
 
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
-
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
@@ -219,7 +209,6 @@ Define whether to print the entire content in one single page.
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
-
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
@@ -307,7 +296,5 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 * `forwardCookie(string $name)`:
 
-
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -7,6 +7,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 * `addExtraHttpHeaders(array $headers)`:
 
 Adds extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None).
 
 > [!TIP]
@@ -35,6 +36,7 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None). (overrides any previous headers).
 
 > [!TIP]
@@ -43,6 +45,7 @@ document. (default None). (overrides any previous headers).
 * `failOnConsoleExceptions(bool $bool)`:
 
 Forces GotenbergPdf to return a 409 Conflict response if there are
+
 exceptions in the Chromium console. (default false).
 
 > [!TIP]
@@ -51,6 +54,7 @@ exceptions in the Chromium console. (default false).
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from
+
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
 > [!TIP]
@@ -59,6 +63,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
+
 (default None). (overrides any previous configuration).
 
 > [!TIP]
@@ -67,6 +72,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 * `failOnResourceLoadingFailed(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions load at least one resource. (default false).
 
 > [!TIP]
@@ -133,6 +139,7 @@ Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
 * `omitBackground(bool $bool)`:
 
 Hides default white background and allows generating PDFs with
+
 transparency. (Default false).
 
 > [!TIP]
@@ -144,18 +151,32 @@ transparency. (Default false).
 
 Overrides the default paper size, in inches.
 
+
+
 Examples of paper size (width x height):
 
+
+
 Letter - 8.5 x 11 (default)
+
 Legal - 8.5 x 14
+
 Tabloid - 11 x 17
+
 Ledger - 17 x 11
+
 A0 - 33.1 x 46.8
+
 A1 - 23.4 x 33.1
+
 A2 - 16.54 x 23.4
+
 A3 - 11.7 x 16.54
+
 A4 - 8.27 x 11.7
+
 A5 - 5.83 x 8.27
+
 A6 - 4.13 x 5.83
 
 > [!TIP]
@@ -198,6 +219,8 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 Define whether to print the entire content in one single page.
 
+
+
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
@@ -233,6 +256,7 @@ Override the default User-Agent HTTP header. (default None).
 * `waitDelay(string $delay)`:
 
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+
 document before converting it to PDF. (default None).
 
 > [!TIP]
@@ -241,7 +265,10 @@ document before converting it to PDF. (default None).
 * `waitForExpression(string $expression)`:
 
 Sets the JavaScript expression to wait before converting an HTML
+
 document to PDF until it returns true. (default None).
+
+
 
 For instance: "window.status === 'ready'".
 
@@ -259,6 +286,7 @@ The HTML file that wraps the markdown content.
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -275,6 +303,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -7,7 +7,7 @@ The metadata to write.
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-### files(string $paths)
+### files(Stringable|string $paths)
 ### metadata(array $metadata)
 Resets the metadata.<br />
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -68,6 +68,8 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
+* `files(string $paths)`:
+
 * `footer(string $template, array $context)`:
 
 * `footerFile(string $path)`:
@@ -89,6 +91,14 @@ Sets the paper orientation to landscape. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default margins (e.g., 0.39), in inches.
@@ -116,6 +126,8 @@ transparency. (Default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
+* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default paper size, in inches.
 
@@ -135,6 +147,10 @@ A6 - 4.13 x 5.83
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
+
+* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 Sets the PDF format of the resulting PDF. (default None).
@@ -164,6 +180,8 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 Define whether to print the entire content in one single page.
 
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+* `skipNetworkIdleEvent(bool $bool)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -1,166 +1,325 @@
 # MarkdownPdfBuilder
 
-<details><summary>`addAsset(string $path)`</summary>
+<details>
+<summary>addAsset(string $path)</summary>
+
 Adds a file, like an image, font, stylesheet, and so on.
-</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>addExtraHttpHeaders(array $headers)</summary>
+
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-</details><details><summary>`addMetadata(string $key, string $value)`</summary>
+
+</details><details>
+<summary>addMetadata(string $key, string $value)</summary>
+
 The metadata to write.
-</details><details><summary>`assets(string $paths)`</summary>
+
+</details><details>
+<summary>assets(string $paths)</summary>
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
+
+</details><details>
+<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>extraHttpHeaders(array $headers)</summary>
+
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnConsoleExceptions(bool $bool)</summary>
+
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnResourceLoadingFailed(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-</details><details><summary>`files(string $paths)`</summary></details><details><summary>`footer(string $template, array $context)`</summary></details><details><summary>`footerFile(string $path)`</summary>
+
+</details><details>
+<summary>files(string $paths)</summary>
+
+</details><details>
+<summary>footer(string $template, array $context)</summary>
+
+</details><details>
+<summary>footerFile(string $path)</summary>
+
 HTML file containing the footer. (default None).
-</details><details><summary>`generateDocumentOutline(bool $bool)`</summary>
+
+</details><details>
+<summary>generateDocumentOutline(bool $bool)</summary>
+
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`header(string $template, array $context)`</summary></details><details><summary>`headerFile(string $path)`</summary>
+
+</details><details>
+<summary>header(string $template, array $context)</summary>
+
+</details><details>
+<summary>headerFile(string $path)</summary>
+
 HTML file containing the header. (default None).
-</details><details><summary>`landscape(bool $bool)`</summary>
+
+</details><details>
+<summary>landscape(bool $bool)</summary>
+
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
+
+</details><details>
+<summary>marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`metadata(array $metadata)`</summary>
+
+</details><details>
+<summary>metadata(array $metadata)</summary>
+
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-</details><details><summary>`nativePageRanges(string $range)`</summary>
+
+</details><details>
+<summary>nativePageRanges(string $range)</summary>
+
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`omitBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>omitBackground(bool $bool)</summary>
+
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
+
+</details><details>
+<summary>paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`</summary></details><details><summary>`paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
+
+</details><details>
+<summary>paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)</summary>
+
+</details><details>
+<summary>paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
+
 Sets the PDF format of the resulting PDF. (default None).<br />
-</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
+
+</details><details>
+<summary>pdfUniversalAccess(bool $bool)</summary>
+
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
-</details><details><summary>`preferCssPageSize(bool $bool)`</summary>
+
+</details><details>
+<summary>preferCssPageSize(bool $bool)</summary>
+
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`printBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>printBackground(bool $bool)</summary>
+
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`scale(float $scale)`</summary>
+
+</details><details>
+<summary>scale(float $scale)</summary>
+
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`singlePage(bool $bool)`</summary>
+
+</details><details>
+<summary>singlePage(bool $bool)</summary>
+
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
+
+</details><details>
+<summary>skipNetworkIdleEvent(bool $bool)</summary>
+
+</details><details>
+<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
+
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`splitSpan(string $splitSpan)`</summary>
+
+</details><details>
+<summary>splitSpan(string $splitSpan)</summary>
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`splitUnify(bool $bool)`</summary>
+
+</details><details>
+<summary>splitUnify(bool $bool)</summary>
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`userAgent(string $userAgent)`</summary>
+
+</details><details>
+<summary>userAgent(string $userAgent)</summary>
+
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-</details><details><summary>`waitDelay(string $delay)`</summary>
+
+</details><details>
+<summary>waitDelay(string $delay)</summary>
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`waitForExpression(string $expression)`</summary>
+
+</details><details>
+<summary>waitForExpression(string $expression)</summary>
+
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`wrapper(string $template, array $context)`</summary>
+
+</details><details>
+<summary>wrapper(string $template, array $context)</summary>
+
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
-</details><details><summary>`wrapperFile(string $path)`</summary>
+
+</details><details>
+<summary>wrapperFile(string $path)</summary>
+
 The HTML file that wraps the markdown content.
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`addCookies(array $cookies)`</summary>
+
+</details><details>
+<summary>addCookies(array $cookies)</summary>
+
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`cookies(array $cookies)`</summary>
+
+</details><details>
+<summary>cookies(array $cookies)</summary>
+
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>
+
+</details><details>
+<summary>forwardCookie(string $name)</summary>
+
+</details><details>
+<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
+
+</details>

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -3,12 +3,6 @@
 * `addAsset(string $path)`:
 Adds a file, like an image, font, stylesheet, and so on.
 
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
@@ -22,9 +16,9 @@ The metadata to write.
 * `assets(string $paths)`:
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-* `cookies(array $cookies)`:
-
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -166,8 +160,6 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
 
@@ -231,4 +223,20 @@ The HTML file that wraps the markdown content, rendered from a Twig template.
 
 * `wrapperFile(string $path)`:
 The HTML file that wraps the markdown content.
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `cookies(array $cookies)`:
+Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `forwardCookie(string $name)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -16,11 +16,14 @@ The HTML file that wraps the markdown content.
 
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
+
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default paper size, in inches.
+
 Examples of paper size (width x height):
+
 Letter - 8.5 x 11 (default)
 Legal - 8.5 x 14
 Tabloid - 11 x 17
@@ -33,6 +36,9 @@ A4 - 8.27 x 11.7
 A5 - 5.83 x 8.27
 A6 - 4.13 x 5.83
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
@@ -41,6 +47,9 @@ A6 - 4.13 x 5.83
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default margins (e.g., 0.39), in inches.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
@@ -53,24 +62,45 @@ Overrides the default margins (e.g., 0.39), in inches.
 * `preferCssPageSize(bool $bool)`:
 Define whether to prefer page size as defined by CSS. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `generateDocumentOutline(bool $bool)`:
 Define whether the document outline should be embedded into the PDF. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `printBackground(bool $bool)`:
 Prints the background graphics. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
 Hides default white background and allows generating PDFs with
 transparency. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `landscape(bool $bool)`:
 Sets the paper orientation to landscape. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `nativePageRanges(string $range)`:
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `header(string $template, array $context)`:
 
@@ -92,40 +122,71 @@ Adds a file, like an image, font, stylesheet, and so on.
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to PDF. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
 * `waitForExpression(string $expression)`:
 Sets the JavaScript expression to wait before converting an HTML
 document to PDF until it returns true. (default None).
+
 For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
 * `failOnConsoleExceptions(bool $bool)`:
 Forces GotenbergPdf to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
@@ -138,17 +199,30 @@ Enable PDF for Universal Access for optimal accessibility. (default false).
 * `metadata(array $metadata)`:
 Resets the metadata.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
+
 * `splitSpan(string $splitSpan)`:
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
+
 * `splitUnify(bool $bool)`:
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `downloadFrom(array $downloadFrom)`:
 
@@ -159,13 +233,22 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `addCookies(array $cookies)`:
 Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -1,138 +1,30 @@
 # MarkdownPdfBuilder
 
-* `wrapper(string $template, array $context)`:
-The HTML file that wraps the markdown content, rendered from a Twig template.
+* `addAsset(string $path)`:
+Adds a file, like an image, font, stylesheet, and so on.
 
-* `wrapperFile(string $path)`:
-The HTML file that wraps the markdown content.
-
-* `files(Stringable|string $paths)`:
-
-* `cookies(array $cookies)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
-* `forwardCookie(string $name)`:
-
-* `singlePage(bool $bool)`:
-Define whether to print the entire content in one single page.
-
-If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-Overrides the default paper size, in inches.
-
-Examples of paper size (width x height):
-
-Letter - 8.5 x 11 (default)
-Legal - 8.5 x 14
-Tabloid - 11 x 17
-Ledger - 17 x 11
-A0 - 33.1 x 46.8
-A1 - 23.4 x 33.1
-A2 - 16.54 x 23.4
-A3 - 11.7 x 16.54
-A4 - 8.27 x 11.7
-A5 - 5.83 x 8.27
-A6 - 4.13 x 5.83
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
-
-* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-Overrides the default margins (e.g., 0.39), in inches.
+* `addExtraHttpHeaders(array $headers)`:
+Adds extra HTTP headers that Chromium will send when loading the HTML
+document. (default None).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `preferCssPageSize(bool $bool)`:
-Define whether to prefer page size as defined by CSS. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `generateDocumentOutline(bool $bool)`:
-Define whether the document outline should be embedded into the PDF. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `printBackground(bool $bool)`:
-Prints the background graphics. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `omitBackground(bool $bool)`:
-Hides default white background and allows generating PDFs with
-transparency. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `landscape(bool $bool)`:
-Sets the paper orientation to landscape. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `scale(float $scale)`:
-The scale of the page rendering (e.g., 1.0). (Default 1.0).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `nativePageRanges(string $range)`:
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `header(string $template, array $context)`:
-
-* `footer(string $template, array $context)`:
-
-* `headerFile(string $path)`:
-HTML file containing the header. (default None).
-
-* `footerFile(string $path)`:
-HTML file containing the footer. (default None).
+* `addMetadata(string $key, string $value)`:
+The metadata to write.
 
 * `assets(string $paths)`:
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-* `addAsset(string $path)`:
-Adds a file, like an image, font, stylesheet, and so on.
+* `cookies(array $cookies)`:
 
-* `waitDelay(string $delay)`:
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-document before converting it to PDF. (default None).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-Sets the JavaScript expression to wait before converting an HTML
-document to PDF until it returns true. (default None).
-
-For instance: "window.status === 'ready'".
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+* `downloadFrom(array $downloadFrom)`:
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -140,11 +32,12 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `userAgent(string $userAgent)`:
-Override the default User-Agent HTTP header. (default None).
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -153,12 +46,12 @@ document. (default None). (overrides any previous headers).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-* `addExtraHttpHeaders(array $headers)`:
-Adds extra HTTP headers that Chromium will send when loading the HTML
-document. (default None).
+* `failOnConsoleExceptions(bool $bool)`:
+Forces GotenbergPdf to return a 409 Conflict response if there are
+exceptions in the Chromium console. (default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
@@ -181,20 +74,33 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-* `failOnConsoleExceptions(bool $bool)`:
-Forces GotenbergPdf to return a 409 Conflict response if there are
-exceptions in the Chromium console. (default false).
+* `footer(string $template, array $context)`:
+
+* `footerFile(string $path)`:
+HTML file containing the footer. (default None).
+
+* `generateDocumentOutline(bool $bool)`:
+Define whether the document outline should be embedded into the PDF. (Default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-* `skipNetworkIdleEvent(bool $bool)`:
+* `header(string $template, array $context)`:
 
-* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-Sets the PDF format of the resulting PDF. (default None).
+* `headerFile(string $path)`:
+HTML file containing the header. (default None).
 
-* `pdfUniversalAccess(bool $bool)`:
-Enable PDF for Universal Access for optimal accessibility. (default false).
+* `landscape(bool $bool)`:
+Sets the paper orientation to landscape. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+Overrides the default margins (e.g., 0.39), in inches.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
 Resets the metadata.
@@ -203,8 +109,69 @@ Resets the metadata.
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-* `addMetadata(string $key, string $value)`:
-The metadata to write.
+* `nativePageRanges(string $range)`:
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `omitBackground(bool $bool)`:
+Hides default white background and allows generating PDFs with
+transparency. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+Overrides the default paper size, in inches.
+
+Examples of paper size (width x height):
+
+Letter - 8.5 x 11 (default)
+Legal - 8.5 x 14
+Tabloid - 11 x 17
+Ledger - 17 x 11
+A0 - 33.1 x 46.8
+A1 - 23.4 x 33.1
+A2 - 16.54 x 23.4
+A3 - 11.7 x 16.54
+A4 - 8.27 x 11.7
+A5 - 5.83 x 8.27
+A6 - 4.13 x 5.83
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+Sets the PDF format of the resulting PDF. (default None).
+
+* `pdfUniversalAccess(bool $bool)`:
+Enable PDF for Universal Access for optimal accessibility. (default false).
+
+* `preferCssPageSize(bool $bool)`:
+Define whether to prefer page size as defined by CSS. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `printBackground(bool $bool)`:
+Prints the background graphics. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `scale(float $scale)`:
+The scale of the page rendering (e.g., 1.0). (Default 1.0).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
+* `singlePage(bool $bool)`:
+Define whether to print the entire content in one single page.
+
+If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
@@ -224,10 +191,33 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-* `downloadFrom(array $downloadFrom)`:
+* `userAgent(string $userAgent)`:
+Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+
+* `waitDelay(string $delay)`:
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+document before converting it to PDF. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `waitForExpression(string $expression)`:
+Sets the JavaScript expression to wait before converting an HTML
+document to PDF until it returns true. (default None).
+
+For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -236,19 +226,9 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+* `wrapper(string $template, array $context)`:
+The HTML file that wraps the markdown content, rendered from a Twig template.
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
-
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+* `wrapperFile(string $path)`:
+The HTML file that wraps the markdown content.
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -1,325 +1,218 @@
 # MarkdownPdfBuilder
 
-<details>
-<summary>addAsset(string $path)</summary>
-
+### addAsset(string $path)
 Adds a file, like an image, font, stylesheet, and so on.
 
-</details><details>
-<summary>addExtraHttpHeaders(array $headers)</summary>
-
+### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-</details><details>
-<summary>addMetadata(string $key, string $value)</summary>
-
+### addMetadata(string $key, string $value)
 The metadata to write.
 
-</details><details>
-<summary>assets(string $paths)</summary>
-
+### assets(string $paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
-
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>extraHttpHeaders(array $headers)</summary>
-
+### extraHttpHeaders(array $headers)
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-</details><details>
-<summary>failOnConsoleExceptions(bool $bool)</summary>
-
+### failOnConsoleExceptions(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceLoadingFailed(bool $bool)</summary>
-
+### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-</details><details>
-<summary>files(string $paths)</summary>
-
-</details><details>
-<summary>footer(string $template, array $context)</summary>
-
-</details><details>
-<summary>footerFile(string $path)</summary>
-
+### files(string $paths)
+### footer(string $template, array $context)
+### footerFile(string $path)
 HTML file containing the footer. (default None).
 
-</details><details>
-<summary>generateDocumentOutline(bool $bool)</summary>
-
+### generateDocumentOutline(bool $bool)
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>header(string $template, array $context)</summary>
-
-</details><details>
-<summary>headerFile(string $path)</summary>
-
+### header(string $template, array $context)
+### headerFile(string $path)
 HTML file containing the header. (default None).
 
-</details><details>
-<summary>landscape(bool $bool)</summary>
-
+### landscape(bool $bool)
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
+### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>metadata(array $metadata)</summary>
-
+### metadata(array $metadata)
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-</details><details>
-<summary>nativePageRanges(string $range)</summary>
-
+### nativePageRanges(string $range)
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>omitBackground(bool $bool)</summary>
-
+### omitBackground(bool $bool)
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
+### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)</summary>
-
-</details><details>
-<summary>paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
-
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Sets the PDF format of the resulting PDF. (default None).<br />
 
-</details><details>
-<summary>pdfUniversalAccess(bool $bool)</summary>
-
+### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
-</details><details>
-<summary>preferCssPageSize(bool $bool)</summary>
-
+### preferCssPageSize(bool $bool)
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>printBackground(bool $bool)</summary>
-
+### printBackground(bool $bool)
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>scale(float $scale)</summary>
-
+### scale(float $scale)
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>singlePage(bool $bool)</summary>
-
+### singlePage(bool $bool)
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
-</details><details>
-<summary>skipNetworkIdleEvent(bool $bool)</summary>
-
-</details><details>
-<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
-
+### skipNetworkIdleEvent(bool $bool)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>splitSpan(string $splitSpan)</summary>
-
+### splitSpan(string $splitSpan)
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>splitUnify(bool $bool)</summary>
-
+### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>userAgent(string $userAgent)</summary>
-
+### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-</details><details>
-<summary>waitDelay(string $delay)</summary>
-
+### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>waitForExpression(string $expression)</summary>
-
+### waitForExpression(string $expression)
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>wrapper(string $template, array $context)</summary>
-
+### wrapper(string $template, array $context)
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
 
-</details><details>
-<summary>wrapperFile(string $path)</summary>
-
+### wrapperFile(string $path)
 The HTML file that wraps the markdown content.
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>addCookies(array $cookies)</summary>
-
+### addCookies(array $cookies)
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>cookies(array $cookies)</summary>
-
+### cookies(array $cookies)
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>forwardCookie(string $name)</summary>
-
-</details><details>
-<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
-
-</details>
+### forwardCookie(string $name)
+### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -1,9 +1,11 @@
 # MarkdownPdfBuilder
 
 * `addAsset(string $path)`:
+
 Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
+
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
 
@@ -11,22 +13,27 @@ document. (default None).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `addMetadata(string $key, string $value)`:
+
 The metadata to write.
 
 * `assets(string $paths)`:
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -34,6 +41,7 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
+
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
@@ -41,6 +49,7 @@ document. (default None). (overrides any previous headers).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
+
 Forces GotenbergPdf to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
 
@@ -48,6 +57,7 @@ exceptions in the Chromium console. (default false).
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
@@ -55,6 +65,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
 
@@ -62,6 +73,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
@@ -70,12 +82,16 @@ exceptions load at least one resource. (default false).
 
 * `files(string $paths)`:
 
+
 * `footer(string $template, array $context)`:
 
+
 * `footerFile(string $path)`:
+
 HTML file containing the footer. (default None).
 
 * `generateDocumentOutline(bool $bool)`:
+
 Define whether the document outline should be embedded into the PDF. (Default false).
 
 > [!TIP]
@@ -83,10 +99,13 @@ Define whether the document outline should be embedded into the PDF. (Default fa
 
 * `header(string $template, array $context)`:
 
+
 * `headerFile(string $path)`:
+
 HTML file containing the header. (default None).
 
 * `landscape(bool $bool)`:
+
 Sets the paper orientation to landscape. (Default false).
 
 > [!TIP]
@@ -94,19 +113,25 @@ Sets the paper orientation to landscape. (Default false).
 
 * `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 
 * `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 Overrides the default margins (e.g., 0.39), in inches.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
+
 Resets the metadata.
 
 > [!TIP]
@@ -114,12 +139,14 @@ Resets the metadata.
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 * `nativePageRanges(string $range)`:
+
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
+
 Hides default white background and allows generating PDFs with
 transparency. (Default false).
 
@@ -128,7 +155,9 @@ transparency. (Default false).
 
 * `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 Overrides the default paper size, in inches.
 
 Examples of paper size (width x height):
@@ -150,64 +179,78 @@ A6 - 4.13 x 5.83
 
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
+
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+
 Sets the PDF format of the resulting PDF. (default None).
 
 * `pdfUniversalAccess(bool $bool)`:
+
 Enable PDF for Universal Access for optimal accessibility. (default false).
 
 * `preferCssPageSize(bool $bool)`:
+
 Define whether to prefer page size as defined by CSS. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `printBackground(bool $bool)`:
+
 Prints the background graphics. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
+
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `singlePage(bool $bool)`:
+
 Define whether to print the entire content in one single page.
 
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
+
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
+
 Either intervals or pages. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitSpan(string $splitSpan)`:
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitUnify(bool $bool)`:
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `userAgent(string $userAgent)`:
+
 Override the default User-Agent HTTP header. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to PDF. (default None).
 
@@ -215,6 +258,7 @@ document before converting it to PDF. (default None).
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
+
 Sets the JavaScript expression to wait before converting an HTML
 document to PDF until it returns true. (default None).
 
@@ -224,12 +268,15 @@ For instance: "window.status === 'ready'".
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -237,18 +284,22 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `wrapper(string $template, array $context)`:
+
 The HTML file that wraps the markdown content, rendered from a Twig template.
 
 * `wrapperFile(string $path)`:
+
 The HTML file that wraps the markdown content.
 
 * `addCookies(array $cookies)`:
+
 Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
+
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 > [!TIP]
@@ -256,5 +307,7 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 * `forwardCookie(string $name)`:
 
+
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
 

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -1,91 +1,13 @@
 # MarkdownPdfBuilder
 
-### addAsset(string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
 ### addMetadata(string $key, string $value)
 The metadata to write.
-
-### assets(string $paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
 ### files(string $paths)
-### footer(string $template, array $context)
-### footerFile(string $path)
-HTML file containing the footer. (default None).
-
-### generateDocumentOutline(bool $bool)
-Define whether the document outline should be embedded into the PDF. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### header(string $template, array $context)
-### headerFile(string $path)
-HTML file containing the header. (default None).
-
-### landscape(bool $bool)
-Sets the paper orientation to landscape. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default margins (e.g., 0.39), in inches.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
 ### metadata(array $metadata)
 Resets the metadata.<br />
 
@@ -93,55 +15,12 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-### nativePageRanges(string $range)
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
-### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Sets the PDF format of the resulting PDF. (default None).<br />
 
 ### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
-### preferCssPageSize(bool $bool)
-Define whether to prefer page size as defined by CSS. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### printBackground(bool $bool)
-Prints the background graphics. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### scale(float $scale)
-The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### singlePage(bool $bool)
-Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-### skipNetworkIdleEvent(bool $bool)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
@@ -160,29 +39,17 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
 ### wrapper(string $template, array $context)
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
 
 ### wrapperFile(string $path)
 The HTML file that wraps the markdown content.
+
+### addAsset(string $path)
+Adds a file, like an image, font, stylesheet, and so on.<br />
+
+### assets(string $paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br />
 
 ### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
@@ -216,3 +83,136 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<b
 
 ### forwardCookie(string $name)
 ### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### generateDocumentOutline(bool $bool)
+Define whether the document outline should be embedded into the PDF. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### landscape(bool $bool)
+Sets the paper orientation to landscape. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default margins (e.g., 0.39), in inches.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### nativePageRanges(string $range)
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### preferCssPageSize(bool $bool)
+Define whether to prefer page size as defined by CSS. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### printBackground(bool $bool)
+Prints the background graphics. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### scale(float $scale)
+The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### singlePage(bool $bool)
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.<br />
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### footer(string $template, array $context)
+### footerFile(string $path)
+HTML file containing the footer. (default None).<br />
+
+### header(string $template, array $context)
+### headerFile(string $path)
+HTML file containing the header. (default None).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium ](https://gotenberg.dev/docs/routes#network-errors-chromium )
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/MarkdownPdfBuilder.md
+++ b/docs/pdf/builders_api/MarkdownPdfBuilder.md
@@ -32,14 +32,6 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -256,6 +248,22 @@ For instance: "window.status === 'ready'".
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
+* `wrapper(string $template, array $context)`:
+
+The HTML file that wraps the markdown content, rendered from a Twig template.
+
+* `wrapperFile(string $path)`:
+
+The HTML file that wraps the markdown content.
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `webhookConfiguration(string $name)`:
 
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
@@ -271,14 +279,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `wrapper(string $template, array $context)`:
-
-The HTML file that wraps the markdown content, rendered from a Twig template.
-
-* `wrapperFile(string $path)`:
-
-The HTML file that wraps the markdown content.
 
 * `addCookies(array $cookies)`:
 

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -11,14 +11,6 @@ The metadata to write.
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `files(string $paths)`:
 
 * `metadata(array $metadata)`:
@@ -36,6 +28,14 @@ Convert the resulting PDF into the given PDF/A format.
 * `pdfUniversalAccess(bool $bool)`:
 
 Enable PDF for Universal Access for optimal accessibility.
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookConfiguration(string $name)`:
 

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -15,7 +15,7 @@ The metadata to write.
 
 * `metadata(array $metadata)`:
 
-Resets the metadata.
+Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
@@ -31,9 +31,7 @@ Enable PDF for Universal Access for optimal accessibility.
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -44,13 +42,11 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -16,6 +16,8 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
+* `files(string $paths)`:
+
 * `metadata(array $metadata)`:
 Resets the metadata.
 

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -3,13 +3,16 @@
 Merge `n` pdf files into a single one.
 
 * `addMetadata(string $key, string $value)`:
+
 The metadata to write.
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -18,7 +21,9 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 * `files(string $paths)`:
 
+
 * `metadata(array $metadata)`:
+
 Resets the metadata.
 
 > [!TIP]
@@ -26,18 +31,23 @@ Resets the metadata.
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 * `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+
 Convert the resulting PDF into the given PDF/A format.
 
 * `pdfUniversalAccess(bool $bool)`:
+
 Enable PDF for Universal Access for optimal accessibility.
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -32,6 +32,7 @@ Enable PDF for Universal Access for optimal accessibility.
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -48,6 +49,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -2,33 +2,63 @@
 
 Merge `n` pdf files into a single one.
 
-<details><summary>`addMetadata(string $key, string $value)`</summary>
+<details>
+<summary>addMetadata(string $key, string $value)</summary>
+
 The metadata to write.
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`files(string $paths)`</summary></details><details><summary>`metadata(array $metadata)`</summary>
+
+</details><details>
+<summary>files(string $paths)</summary>
+
+</details><details>
+<summary>metadata(array $metadata)</summary>
+
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-</details><details><summary>`pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
+
+</details><details>
+<summary>pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
+
 Convert the resulting PDF into the given PDF/A format.
-</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
+
+</details><details>
+<summary>pdfUniversalAccess(bool $bool)</summary>
+
 Enable PDF for Universal Access for optimal accessibility.
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 </details>

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -21,7 +21,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 * `files(string $paths)`:
 
-
 * `metadata(array $metadata)`:
 
 Resets the metadata.

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -2,63 +2,42 @@
 
 Merge `n` pdf files into a single one.
 
-<details>
-<summary>addMetadata(string $key, string $value)</summary>
-
+### addMetadata(string $key, string $value)
 The metadata to write.
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>files(string $paths)</summary>
-
-</details><details>
-<summary>metadata(array $metadata)</summary>
-
+### files(string $paths)
+### metadata(array $metadata)
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-</details><details>
-<summary>pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
-
+### pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Convert the resulting PDF into the given PDF/A format.
 
-</details><details>
-<summary>pdfUniversalAccess(bool $bool)</summary>
-
+### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility.
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details>

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -13,6 +13,10 @@ Enable PDF for Universal Access for optimal accessibility.
 * `metadata(array $metadata)`:
 Resets the metadata.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
 
@@ -25,9 +29,15 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -1,36 +1,10 @@
 # MergePdfBuilder
 
 Merge `n` pdf files into a single one.
-
-* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-Convert the resulting PDF into the given PDF/A format.
-
-* `pdfUniversalAccess(bool $bool)`:
-Enable PDF for Universal Access for optimal accessibility.
-
-* `files(Stringable|string $paths)`:
-
-* `metadata(array $metadata)`:
-Resets the metadata.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
-> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
 
 * `downloadFrom(array $downloadFrom)`:
-
-* `webhookConfiguration(string $name)`:
-Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookUrl(string $url, ?string $method)`:
-Sets the webhook for cases of success.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
@@ -39,6 +13,29 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
+* `metadata(array $metadata)`:
+Resets the metadata.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
+* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+Convert the resulting PDF into the given PDF/A format.
+
+* `pdfUniversalAccess(bool $bool)`:
+Enable PDF for Universal Access for optimal accessibility.
+
+* `webhookConfiguration(string $name)`:
+Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+
+* `webhookUrl(string $url, ?string $method)`:
+Sets the webhook for cases of success.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -2,52 +2,33 @@
 
 Merge `n` pdf files into a single one.
 
-* `addMetadata(string $key, string $value)`:
-
+<details><summary>`addMetadata(string $key, string $value)`</summary>
 The metadata to write.
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `files(string $paths)`:
-
-* `metadata(array $metadata)`:
-
+</details><details><summary>`files(string $paths)`</summary></details><details><summary>`metadata(array $metadata)`</summary>
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-* `pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-
+</details><details><summary>`pdfFormat(Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
 Convert the resulting PDF into the given PDF/A format.
-
-* `pdfUniversalAccess(bool $bool)`:
-
+</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
 Enable PDF for Universal Access for optimal accessibility.
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
+</details>

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -1,10 +1,13 @@
 # MergePdfBuilder
 
 Merge `n` pdf files into a single one.
+
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
 
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.

--- a/docs/pdf/builders_api/MergePdfBuilder.md
+++ b/docs/pdf/builders_api/MergePdfBuilder.md
@@ -9,7 +9,7 @@ The metadata to write.
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-### files(string $paths)
+### files(Stringable|string $paths)
 ### metadata(array $metadata)
 Resets the metadata.<br />
 

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -6,7 +6,7 @@ Split `n` pdf files.
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-### files(string $paths)
+### files(Stringable|string $paths)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -1,6 +1,14 @@
 # SplitPdfBuilder
 
 Split `n` pdf files.
+* `downloadFrom(array $downloadFrom)`:
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
@@ -20,12 +28,11 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
-* `files(string $paths)`:
-
-* `downloadFrom(array $downloadFrom)`:
-
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -33,14 +40,4 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -7,14 +7,6 @@ Split `n` pdf files.
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `files(string $paths)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
@@ -37,6 +29,14 @@ Specify whether to put extracted pages into a single file or as many files as th
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookConfiguration(string $name)`:
 

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -5,13 +5,22 @@ Split `n` pdf files.
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
+
 * `splitSpan(string $splitSpan)`:
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `splitUnify(bool $bool)`:
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
-* `files(Stringable|string $paths)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
+
+* `files(string $paths)`:
 
 * `downloadFrom(array $downloadFrom)`:
 
@@ -22,9 +31,15 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -2,63 +2,44 @@
 
 Split `n` pdf files.
 
-<details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>files(string $paths)</summary>
-
-</details><details>
-<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
-
+### files(string $paths)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
-</details><details>
-<summary>splitSpan(string $splitSpan)</summary>
-
+### splitSpan(string $splitSpan)
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
-</details><details>
-<summary>splitUnify(bool $bool)</summary>
-
+### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details>

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -33,6 +33,7 @@ Specify whether to put extracted pages into a single file or as many files as th
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -49,6 +50,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -3,10 +3,12 @@
 Split `n` pdf files.
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -15,31 +17,38 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 * `files(string $paths)`:
 
+
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
+
 Either intervals or pages. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `splitSpan(string $splitSpan)`:
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `splitUnify(bool $bool)`:
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -11,30 +11,28 @@ Split `n` pdf files.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
-Either intervals or pages. (default None).
+Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `splitSpan(string $splitSpan)`:
 
-Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
+Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `splitUnify(bool $bool)`:
 
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -45,13 +43,11 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -2,36 +2,63 @@
 
 Split `n` pdf files.
 
-<details><summary>`downloadFrom(array $downloadFrom)`</summary>
+<details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`files(string $paths)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
+
+</details><details>
+<summary>files(string $paths)</summary>
+
+</details><details>
+<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
+
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
-</details><details><summary>`splitSpan(string $splitSpan)`</summary>
+
+</details><details>
+<summary>splitSpan(string $splitSpan)</summary>
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
-</details><details><summary>`splitUnify(bool $bool)`</summary>
+
+</details><details>
+<summary>splitUnify(bool $bool)</summary>
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 </details>

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -2,53 +2,36 @@
 
 Split `n` pdf files.
 
-* `downloadFrom(array $downloadFrom)`:
-
+<details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `files(string $paths)`:
-
-* `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
-
+</details><details><summary>`files(string $paths)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
-
-* `splitSpan(string $splitSpan)`:
-
+</details><details><summary>`splitSpan(string $splitSpan)`</summary>
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
-
-* `splitUnify(bool $bool)`:
-
+</details><details><summary>`splitUnify(bool $bool)`</summary>
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-pdfs-route](https://gotenberg.dev/docs/routes#split-pdfs-route)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
+</details>

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -13,6 +13,8 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
+* `files(string $paths)`:
+
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
 

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -17,7 +17,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 * `files(string $paths)`:
 
-
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
 Either intervals or pages. (default None).

--- a/docs/pdf/builders_api/SplitPdfBuilder.md
+++ b/docs/pdf/builders_api/SplitPdfBuilder.md
@@ -1,7 +1,10 @@
 # SplitPdfBuilder
 
 Split `n` pdf files.
+
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -32,14 +32,6 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -261,6 +253,14 @@ For instance: "window.status === 'ready'".
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookConfiguration(string $name)`:
 

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -1,269 +1,164 @@
 # UrlPdfBuilder
 
-* `addAsset(string $path)`:
-
+<details><summary>`addAsset(string $path)`</summary>
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addExtraHttpHeaders(array $headers)`:
-
+</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-* `addMetadata(string $key, string $value)`:
-
+</details><details><summary>`addMetadata(string $key, string $value)`</summary>
 The metadata to write.
-
-* `assets(string $paths)`:
-
+</details><details><summary>`assets(string $paths)`</summary>
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
-
+</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `extraHttpHeaders(array $headers)`:
-
+</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-* `failOnConsoleExceptions(bool $bool)`:
-
+</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `failOnHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceLoadingFailed(bool $bool)`:
-
+</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-* `footer(string $template, array $context)`:
-
-* `footerFile(string $path)`:
-
+</details><details><summary>`footer(string $template, array $context)`</summary></details><details><summary>`footerFile(string $path)`</summary>
 HTML file containing the footer. (default None).
-
-* `generateDocumentOutline(bool $bool)`:
-
+</details><details><summary>`generateDocumentOutline(bool $bool)`</summary>
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `header(string $template, array $context)`:
-
-* `headerFile(string $path)`:
-
+</details><details><summary>`header(string $template, array $context)`</summary></details><details><summary>`headerFile(string $path)`</summary>
 HTML file containing the header. (default None).
-
-* `landscape(bool $bool)`:
-
+</details><details><summary>`landscape(bool $bool)`</summary>
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
+</details><details><summary>`marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `metadata(array $metadata)`:
-
+</details><details><summary>`metadata(array $metadata)`</summary>
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-
-* `nativePageRanges(string $range)`:
-
+</details><details><summary>`nativePageRanges(string $range)`</summary>
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `omitBackground(bool $bool)`:
-
+</details><details><summary>`omitBackground(bool $bool)`</summary>
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
+</details><details><summary>`paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
-
-* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-
+</details><details><summary>`paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`</summary></details><details><summary>`paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
 Sets the PDF format of the resulting PDF. (default None).<br />
-
-* `pdfUniversalAccess(bool $bool)`:
-
+</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
-
-* `preferCssPageSize(bool $bool)`:
-
+</details><details><summary>`preferCssPageSize(bool $bool)`</summary>
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `printBackground(bool $bool)`:
-
+</details><details><summary>`printBackground(bool $bool)`</summary>
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `route(string $name, array $parameters)`:
-
-* `scale(float $scale)`:
-
+</details><details><summary>`route(string $name, array $parameters)`</summary></details><details><summary>`scale(float $scale)`</summary>
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
-
-* `singlePage(bool $bool)`:
-
+</details><details><summary>`setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`</summary></details><details><summary>`singlePage(bool $bool)`</summary>
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-* `skipNetworkIdleEvent(bool $bool)`:
-
-* `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
-
+</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `splitSpan(string $splitSpan)`:
-
+</details><details><summary>`splitSpan(string $splitSpan)`</summary>
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `splitUnify(bool $bool)`:
-
+</details><details><summary>`splitUnify(bool $bool)`</summary>
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-
-* `url(string $url)`:
-
+</details><details><summary>`url(string $url)`</summary>
 URL of the page you want to convert into PDF.
-
-* `userAgent(string $userAgent)`:
-
+</details><details><summary>`userAgent(string $userAgent)`</summary>
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-* `waitDelay(string $delay)`:
-
+</details><details><summary>`waitDelay(string $delay)`</summary>
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-
+</details><details><summary>`waitForExpression(string $expression)`</summary>
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `addCookies(array $cookies)`:
-
+</details><details><summary>`addCookies(array $cookies)`</summary>
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `cookies(array $cookies)`:
-
+</details><details><summary>`cookies(array $cookies)`</summary>
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `forwardCookie(string $name)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
+</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -1,9 +1,11 @@
 # UrlPdfBuilder
 
 * `addAsset(string $path)`:
+
 Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
+
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
 
@@ -11,22 +13,27 @@ document. (default None).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `addMetadata(string $key, string $value)`:
+
 The metadata to write.
 
 * `assets(string $paths)`:
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -34,6 +41,7 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
+
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
@@ -41,6 +49,7 @@ document. (default None). (overrides any previous headers).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
+
 Forces GotenbergPdf to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
 
@@ -48,6 +57,7 @@ exceptions in the Chromium console. (default false).
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
@@ -55,6 +65,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
 
@@ -62,6 +73,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
@@ -70,10 +82,13 @@ exceptions load at least one resource. (default false).
 
 * `footer(string $template, array $context)`:
 
+
 * `footerFile(string $path)`:
+
 HTML file containing the footer. (default None).
 
 * `generateDocumentOutline(bool $bool)`:
+
 Define whether the document outline should be embedded into the PDF. (Default false).
 
 > [!TIP]
@@ -81,10 +96,13 @@ Define whether the document outline should be embedded into the PDF. (Default fa
 
 * `header(string $template, array $context)`:
 
+
 * `headerFile(string $path)`:
+
 HTML file containing the header. (default None).
 
 * `landscape(bool $bool)`:
+
 Sets the paper orientation to landscape. (Default false).
 
 > [!TIP]
@@ -92,19 +110,25 @@ Sets the paper orientation to landscape. (Default false).
 
 * `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 
 * `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 Overrides the default margins (e.g., 0.39), in inches.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
+
 Resets the metadata.
 
 > [!TIP]
@@ -112,12 +136,14 @@ Resets the metadata.
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
 * `nativePageRanges(string $range)`:
+
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
+
 Hides default white background and allows generating PDFs with
 transparency. (Default false).
 
@@ -126,7 +152,9 @@ transparency. (Default false).
 
 * `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 Overrides the default paper size, in inches.
 
 Examples of paper size (width x height):
@@ -148,21 +176,27 @@ A6 - 4.13 x 5.83
 
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
+
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
+
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+
 Sets the PDF format of the resulting PDF. (default None).
 
 * `pdfUniversalAccess(bool $bool)`:
+
 Enable PDF for Universal Access for optimal accessibility. (default false).
 
 * `preferCssPageSize(bool $bool)`:
+
 Define whether to prefer page size as defined by CSS. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `printBackground(bool $bool)`:
+
 Prints the background graphics. (Default false).
 
 > [!TIP]
@@ -170,7 +204,9 @@ Prints the background graphics. (Default false).
 
 * `route(string $name, array $parameters)`:
 
+
 * `scale(float $scale)`:
+
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 > [!TIP]
@@ -178,41 +214,50 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 * `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
 
+
 * `singlePage(bool $bool)`:
+
 Define whether to print the entire content in one single page.
 
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
+
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
+
 Either intervals or pages. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitSpan(string $splitSpan)`:
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitUnify(bool $bool)`:
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `url(string $url)`:
+
 URL of the page you want to convert into PDF.
 
 * `userAgent(string $userAgent)`:
+
 Override the default User-Agent HTTP header. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to PDF. (default None).
 
@@ -220,6 +265,7 @@ document before converting it to PDF. (default None).
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
+
 Sets the JavaScript expression to wait before converting an HTML
 document to PDF until it returns true. (default None).
 
@@ -229,12 +275,15 @@ For instance: "window.status === 'ready'".
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -242,12 +291,14 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
+
 Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
+
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 > [!TIP]
@@ -255,5 +306,7 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 * `forwardCookie(string $name)`:
 
+
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
 

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -7,6 +7,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 * `addExtraHttpHeaders(array $headers)`:
 
 Adds extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None).
 
 > [!TIP]
@@ -35,6 +36,7 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None). (overrides any previous headers).
 
 > [!TIP]
@@ -43,6 +45,7 @@ document. (default None). (overrides any previous headers).
 * `failOnConsoleExceptions(bool $bool)`:
 
 Forces GotenbergPdf to return a 409 Conflict response if there are
+
 exceptions in the Chromium console. (default false).
 
 > [!TIP]
@@ -51,6 +54,7 @@ exceptions in the Chromium console. (default false).
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from
+
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
 > [!TIP]
@@ -59,6 +63,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
+
 (default None). (overrides any previous configuration).
 
 > [!TIP]
@@ -67,6 +72,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 * `failOnResourceLoadingFailed(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions load at least one resource. (default false).
 
 > [!TIP]
@@ -131,6 +137,7 @@ Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
 * `omitBackground(bool $bool)`:
 
 Hides default white background and allows generating PDFs with
+
 transparency. (Default false).
 
 > [!TIP]
@@ -142,18 +149,32 @@ transparency. (Default false).
 
 Overrides the default paper size, in inches.
 
+
+
 Examples of paper size (width x height):
 
+
+
 Letter - 8.5 x 11 (default)
+
 Legal - 8.5 x 14
+
 Tabloid - 11 x 17
+
 Ledger - 17 x 11
+
 A0 - 33.1 x 46.8
+
 A1 - 23.4 x 33.1
+
 A2 - 16.54 x 23.4
+
 A3 - 11.7 x 16.54
+
 A4 - 8.27 x 11.7
+
 A5 - 5.83 x 8.27
+
 A6 - 4.13 x 5.83
 
 > [!TIP]
@@ -200,6 +221,8 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 Define whether to print the entire content in one single page.
 
+
+
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
@@ -239,6 +262,7 @@ Override the default User-Agent HTTP header. (default None).
 * `waitDelay(string $delay)`:
 
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+
 document before converting it to PDF. (default None).
 
 > [!TIP]
@@ -247,7 +271,10 @@ document before converting it to PDF. (default None).
 * `waitForExpression(string $expression)`:
 
 Sets the JavaScript expression to wait before converting an HTML
+
 document to PDF until it returns true. (default None).
+
+
 
 For instance: "window.status === 'ready'".
 
@@ -257,6 +284,7 @@ For instance: "window.status === 'ready'".
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -273,6 +301,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -90,6 +90,14 @@ Sets the paper orientation to landscape. (Default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
+* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
+* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default margins (e.g., 0.39), in inches.
 
@@ -116,6 +124,8 @@ transparency. (Default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
+* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default paper size, in inches.
 
@@ -135,6 +145,10 @@ A6 - 4.13 x 5.83
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
+
+* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 Sets the PDF format of the resulting PDF. (default None).
@@ -162,10 +176,14 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
+* `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
+
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
 
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+
+* `skipNetworkIdleEvent(bool $bool)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -6,9 +6,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
 
-Adds extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None).
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
@@ -28,52 +26,42 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `extraHttpHeaders(array $headers)`:
 
-Sets extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None). (overrides any previous headers).
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
 
-Forces GotenbergPdf to return a 409 Conflict response if there are
-
-exceptions in the Chromium console. (default false).
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from
-
-the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
-
-(default None). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions load at least one resource. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
@@ -86,7 +74,7 @@ HTML file containing the footer. (default None).
 
 * `generateDocumentOutline(bool $bool)`:
 
-Define whether the document outline should be embedded into the PDF. (Default false).
+Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -99,7 +87,7 @@ HTML file containing the header. (default None).
 
 * `landscape(bool $bool)`:
 
-Sets the paper orientation to landscape. (Default false).
+Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -114,14 +102,14 @@ Sets the paper orientation to landscape. (Default false).
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-Overrides the default margins (e.g., 0.39), in inches.
+Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
 
-Resets the metadata.
+Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
@@ -129,16 +117,14 @@ Resets the metadata.
 
 * `nativePageRanges(string $range)`:
 
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
 
-Hides default white background and allows generating PDFs with
-
-transparency. (Default false).
+Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -147,35 +133,7 @@ transparency. (Default false).
 
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-Overrides the default paper size, in inches.
-
-
-
-Examples of paper size (width x height):
-
-
-
-Letter - 8.5 x 11 (default)
-
-Legal - 8.5 x 14
-
-Tabloid - 11 x 17
-
-Ledger - 17 x 11
-
-A0 - 33.1 x 46.8
-
-A1 - 23.4 x 33.1
-
-A2 - 16.54 x 23.4
-
-A3 - 11.7 x 16.54
-
-A4 - 8.27 x 11.7
-
-A5 - 5.83 x 8.27
-
-A6 - 4.13 x 5.83
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -186,22 +144,22 @@ A6 - 4.13 x 5.83
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
-Sets the PDF format of the resulting PDF. (default None).
+Sets the PDF format of the resulting PDF. (default None).<br />
 
 * `pdfUniversalAccess(bool $bool)`:
 
-Enable PDF for Universal Access for optimal accessibility. (default false).
+Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
 * `preferCssPageSize(bool $bool)`:
 
-Define whether to prefer page size as defined by CSS. (Default false).
+Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `printBackground(bool $bool)`:
 
-Prints the background graphics. (Default false).
+Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -210,7 +168,7 @@ Prints the background graphics. (Default false).
 
 * `scale(float $scale)`:
 
-The scale of the page rendering (e.g., 1.0). (Default 1.0).
+The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
@@ -219,31 +177,27 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 * `singlePage(bool $bool)`:
 
-Define whether to print the entire content in one single page.
-
-
-
-If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
-Either intervals or pages. (default None).
+Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitSpan(string $splitSpan)`:
 
-Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
+Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `splitUnify(bool $bool)`:
 
-Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
@@ -254,38 +208,28 @@ URL of the page you want to convert into PDF.
 
 * `userAgent(string $userAgent)`:
 
-Override the default User-Agent HTTP header. (default None).
+Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
 
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-
-document before converting it to PDF. (default None).
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
 
-Sets the JavaScript expression to wait before converting an HTML
-
-document to PDF until it returns true. (default None).
-
-
-
-For instance: "window.status === 'ready'".
+Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -296,27 +240,25 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
 
-Add cookies to store in the Chromium cookie jar.
+Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
 
-Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
+Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -1,323 +1,216 @@
 # UrlPdfBuilder
 
-<details>
-<summary>addAsset(string $path)</summary>
-
+### addAsset(string $path)
 Adds a file, like an image, font, stylesheet, and so on.
 
-</details><details>
-<summary>addExtraHttpHeaders(array $headers)</summary>
-
+### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-</details><details>
-<summary>addMetadata(string $key, string $value)</summary>
-
+### addMetadata(string $key, string $value)
 The metadata to write.
 
-</details><details>
-<summary>assets(string $paths)</summary>
-
+### assets(string $paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
-
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>extraHttpHeaders(array $headers)</summary>
-
+### extraHttpHeaders(array $headers)
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-</details><details>
-<summary>failOnConsoleExceptions(bool $bool)</summary>
-
+### failOnConsoleExceptions(bool $bool)
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceLoadingFailed(bool $bool)</summary>
-
+### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-</details><details>
-<summary>footer(string $template, array $context)</summary>
-
-</details><details>
-<summary>footerFile(string $path)</summary>
-
+### footer(string $template, array $context)
+### footerFile(string $path)
 HTML file containing the footer. (default None).
 
-</details><details>
-<summary>generateDocumentOutline(bool $bool)</summary>
-
+### generateDocumentOutline(bool $bool)
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>header(string $template, array $context)</summary>
-
-</details><details>
-<summary>headerFile(string $path)</summary>
-
+### header(string $template, array $context)
+### headerFile(string $path)
 HTML file containing the header. (default None).
 
-</details><details>
-<summary>landscape(bool $bool)</summary>
-
+### landscape(bool $bool)
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
+### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>metadata(array $metadata)</summary>
-
+### metadata(array $metadata)
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-</details><details>
-<summary>nativePageRanges(string $range)</summary>
-
+### nativePageRanges(string $range)
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>omitBackground(bool $bool)</summary>
-
+### omitBackground(bool $bool)
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
+### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)</summary>
-
-</details><details>
-<summary>paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
-
-</details><details>
-<summary>pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
-
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Sets the PDF format of the resulting PDF. (default None).<br />
 
-</details><details>
-<summary>pdfUniversalAccess(bool $bool)</summary>
-
+### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
-</details><details>
-<summary>preferCssPageSize(bool $bool)</summary>
-
+### preferCssPageSize(bool $bool)
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>printBackground(bool $bool)</summary>
-
+### printBackground(bool $bool)
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>route(string $name, array $parameters)</summary>
-
-</details><details>
-<summary>scale(float $scale)</summary>
-
+### route(string $name, array $parameters)
+### scale(float $scale)
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)</summary>
-
-</details><details>
-<summary>singlePage(bool $bool)</summary>
-
+### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
+### singlePage(bool $bool)
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
-</details><details>
-<summary>skipNetworkIdleEvent(bool $bool)</summary>
-
-</details><details>
-<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
-
+### skipNetworkIdleEvent(bool $bool)
+### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>splitSpan(string $splitSpan)</summary>
-
+### splitSpan(string $splitSpan)
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>splitUnify(bool $bool)</summary>
-
+### splitUnify(bool $bool)
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-</details><details>
-<summary>url(string $url)</summary>
-
+### url(string $url)
 URL of the page you want to convert into PDF.
 
-</details><details>
-<summary>userAgent(string $userAgent)</summary>
-
+### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-</details><details>
-<summary>waitDelay(string $delay)</summary>
-
+### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>waitForExpression(string $expression)</summary>
-
+### waitForExpression(string $expression)
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>addCookies(array $cookies)</summary>
-
+### addCookies(array $cookies)
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>cookies(array $cookies)</summary>
-
+### cookies(array $cookies)
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>forwardCookie(string $name)</summary>
-
-</details><details>
-<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
-
-</details>
+### forwardCookie(string $name)
+### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -82,7 +82,6 @@ exceptions load at least one resource. (default false).
 
 * `footer(string $template, array $context)`:
 
-
 * `footerFile(string $path)`:
 
 HTML file containing the footer. (default None).
@@ -95,7 +94,6 @@ Define whether the document outline should be embedded into the PDF. (Default fa
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `header(string $template, array $context)`:
-
 
 * `headerFile(string $path)`:
 
@@ -110,15 +108,11 @@ Sets the paper orientation to landscape. (Default false).
 
 * `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
@@ -152,7 +146,6 @@ transparency. (Default false).
 
 * `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
-
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
 Overrides the default paper size, in inches.
@@ -176,9 +169,7 @@ A6 - 4.13 x 5.83
 
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
-
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
 
 * `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
 
@@ -204,7 +195,6 @@ Prints the background graphics. (Default false).
 
 * `route(string $name, array $parameters)`:
 
-
 * `scale(float $scale)`:
 
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
@@ -214,7 +204,6 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
 * `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
 
-
 * `singlePage(bool $bool)`:
 
 Define whether to print the entire content in one single page.
@@ -222,7 +211,6 @@ Define whether to print the entire content in one single page.
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `skipNetworkIdleEvent(bool $bool)`:
-
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 
@@ -306,7 +294,5 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
 
 * `forwardCookie(string $name)`:
 
-
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -1,89 +1,11 @@
 # UrlPdfBuilder
 
-### addAsset(string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
-### addExtraHttpHeaders(array $headers)
-Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
 ### addMetadata(string $key, string $value)
 The metadata to write.
-
-### assets(string $paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 ### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
-Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### extraHttpHeaders(array $headers)
-Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### footer(string $template, array $context)
-### footerFile(string $path)
-HTML file containing the footer. (default None).
-
-### generateDocumentOutline(bool $bool)
-Define whether the document outline should be embedded into the PDF. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### header(string $template, array $context)
-### headerFile(string $path)
-HTML file containing the header. (default None).
-
-### landscape(bool $bool)
-Sets the paper orientation to landscape. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default margins (e.g., 0.39), in inches.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 ### metadata(array $metadata)
 Resets the metadata.<br />
@@ -92,57 +14,14 @@ Resets the metadata.<br />
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-### nativePageRanges(string $range)
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
-Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
-### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
 ### pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)
 Sets the PDF format of the resulting PDF. (default None).<br />
 
 ### pdfUniversalAccess(bool $bool)
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
 
-### preferCssPageSize(bool $bool)
-Define whether to prefer page size as defined by CSS. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### printBackground(bool $bool)
-Prints the background graphics. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
 ### route(string $name, array $parameters)
-### scale(float $scale)
-The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
 ### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
-### singlePage(bool $bool)
-Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-### skipNetworkIdleEvent(bool $bool)
 ### splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)
 Either intervals or pages. (default None).<br />
 
@@ -164,23 +43,11 @@ Specify whether to put extracted pages into a single file or as many files as th
 ### url(string $url)
 URL of the page you want to convert into PDF.
 
-### userAgent(string $userAgent)
-Override the default User-Agent HTTP header. (default None).<br />
+### addAsset(string $path)
+Adds a file, like an image, font, stylesheet, and so on.<br />
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+### assets(string $paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br />
 
 ### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
@@ -214,3 +81,136 @@ Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<b
 
 ### forwardCookie(string $name)
 ### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### generateDocumentOutline(bool $bool)
+Define whether the document outline should be embedded into the PDF. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### landscape(bool $bool)
+Sets the paper orientation to landscape. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default margins (e.g., 0.39), in inches.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### nativePageRanges(string $range)
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)
+### paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)
+### preferCssPageSize(bool $bool)
+Define whether to prefer page size as defined by CSS. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### printBackground(bool $bool)
+Prints the background graphics. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### scale(float $scale)
+The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### singlePage(bool $bool)
+Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.<br />
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### footer(string $template, array $context)
+### footerFile(string $path)
+HTML file containing the footer. (default None).<br />
+
+### header(string $template, array $context)
+### headerFile(string $path)
+HTML file containing the header. (default None).<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium ](https://gotenberg.dev/docs/routes#network-errors-chromium )
+
+### addExtraHttpHeaders(array $headers)
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+### extraHttpHeaders(array $headers)
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
+### userAgent(string $userAgent)
+Override the default User-Agent HTTP header. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -1,164 +1,323 @@
 # UrlPdfBuilder
 
-<details><summary>`addAsset(string $path)`</summary>
+<details>
+<summary>addAsset(string $path)</summary>
+
 Adds a file, like an image, font, stylesheet, and so on.
-</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>addExtraHttpHeaders(array $headers)</summary>
+
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-</details><details><summary>`addMetadata(string $key, string $value)`</summary>
+
+</details><details>
+<summary>addMetadata(string $key, string $value)</summary>
+
 The metadata to write.
-</details><details><summary>`assets(string $paths)`</summary>
+
+</details><details>
+<summary>assets(string $paths)</summary>
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
+
+</details><details>
+<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>extraHttpHeaders(array $headers)</summary>
+
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnConsoleExceptions(bool $bool)</summary>
+
 Forces GotenbergPdf to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnResourceLoadingFailed(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-</details><details><summary>`footer(string $template, array $context)`</summary></details><details><summary>`footerFile(string $path)`</summary>
+
+</details><details>
+<summary>footer(string $template, array $context)</summary>
+
+</details><details>
+<summary>footerFile(string $path)</summary>
+
 HTML file containing the footer. (default None).
-</details><details><summary>`generateDocumentOutline(bool $bool)`</summary>
+
+</details><details>
+<summary>generateDocumentOutline(bool $bool)</summary>
+
 Define whether the document outline should be embedded into the PDF. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`header(string $template, array $context)`</summary></details><details><summary>`headerFile(string $path)`</summary>
+
+</details><details>
+<summary>header(string $template, array $context)</summary>
+
+</details><details>
+<summary>headerFile(string $path)</summary>
+
 HTML file containing the header. (default None).
-</details><details><summary>`landscape(bool $bool)`</summary>
+
+</details><details>
+<summary>landscape(bool $bool)</summary>
+
 Sets the paper orientation to landscape. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
+
+</details><details>
+<summary>marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
 Overrides the default margins (e.g., 0.39), in inches.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`metadata(array $metadata)`</summary>
+
+</details><details>
+<summary>metadata(array $metadata)</summary>
+
 Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
-</details><details><summary>`nativePageRanges(string $range)`</summary>
+
+</details><details>
+<summary>nativePageRanges(string $range)</summary>
+
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`omitBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>omitBackground(bool $bool)</summary>
+
 Hides default white background and allows generating PDFs with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary>
+
+</details><details>
+<summary>paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
 Overrides the default paper size, in inches.<br /><br />Examples of paper size (width x height):<br /><br />Letter - 8.5 x 11 (default)<br />Legal - 8.5 x 14<br />Tabloid - 11 x 17<br />Ledger - 17 x 11<br />A0 - 33.1 x 46.8<br />A1 - 23.4 x 33.1<br />A2 - 16.54 x 23.4<br />A3 - 11.7 x 16.54<br />A4 - 8.27 x 11.7<br />A5 - 5.83 x 8.27<br />A6 - 4.13 x 5.83<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`</summary></details><details><summary>`paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`</summary></details><details><summary>`pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`</summary>
+
+</details><details>
+<summary>paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)</summary>
+
+</details><details>
+<summary>paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)</summary>
+
+</details><details>
+<summary>pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)</summary>
+
 Sets the PDF format of the resulting PDF. (default None).<br />
-</details><details><summary>`pdfUniversalAccess(bool $bool)`</summary>
+
+</details><details>
+<summary>pdfUniversalAccess(bool $bool)</summary>
+
 Enable PDF for Universal Access for optimal accessibility. (default false).<br />
-</details><details><summary>`preferCssPageSize(bool $bool)`</summary>
+
+</details><details>
+<summary>preferCssPageSize(bool $bool)</summary>
+
 Define whether to prefer page size as defined by CSS. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`printBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>printBackground(bool $bool)</summary>
+
 Prints the background graphics. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`route(string $name, array $parameters)`</summary></details><details><summary>`scale(float $scale)`</summary>
+
+</details><details>
+<summary>route(string $name, array $parameters)</summary>
+
+</details><details>
+<summary>scale(float $scale)</summary>
+
 The scale of the page rendering (e.g., 1.0). (Default 1.0).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`</summary></details><details><summary>`singlePage(bool $bool)`</summary>
+
+</details><details>
+<summary>setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)</summary>
+
+</details><details>
+<summary>singlePage(bool $bool)</summary>
+
 Define whether to print the entire content in one single page.<br /><br />If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`</summary>
+
+</details><details>
+<summary>skipNetworkIdleEvent(bool $bool)</summary>
+
+</details><details>
+<summary>splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)</summary>
+
 Either intervals or pages. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`splitSpan(string $splitSpan)`</summary>
+
+</details><details>
+<summary>splitSpan(string $splitSpan)</summary>
+
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`splitUnify(bool $bool)`</summary>
+
+</details><details>
+<summary>splitUnify(bool $bool)</summary>
+
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
-</details><details><summary>`url(string $url)`</summary>
+
+</details><details>
+<summary>url(string $url)</summary>
+
 URL of the page you want to convert into PDF.
-</details><details><summary>`userAgent(string $userAgent)`</summary>
+
+</details><details>
+<summary>userAgent(string $userAgent)</summary>
+
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-</details><details><summary>`waitDelay(string $delay)`</summary>
+
+</details><details>
+<summary>waitDelay(string $delay)</summary>
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to PDF. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`waitForExpression(string $expression)`</summary>
+
+</details><details>
+<summary>waitForExpression(string $expression)</summary>
+
 Sets the JavaScript expression to wait before converting an HTML<br />document to PDF until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`addCookies(array $cookies)`</summary>
+
+</details><details>
+<summary>addCookies(array $cookies)</summary>
+
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`cookies(array $cookies)`</summary>
+
+</details><details>
+<summary>cookies(array $cookies)</summary>
+
 Cookies to store in the Chromium cookie jar. (overrides any previous cookies).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>
+
+</details><details>
+<summary>forwardCookie(string $name)</summary>
+
+</details><details>
+<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
+
+</details>

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -3,12 +3,6 @@
 * `addAsset(string $path)`:
 Adds a file, like an image, font, stylesheet, and so on.
 
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
@@ -22,9 +16,9 @@ The metadata to write.
 * `assets(string $paths)`:
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-* `cookies(array $cookies)`:
-
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -168,8 +162,6 @@ The scale of the page rendering (e.g., 1.0). (Default 1.0).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
 
@@ -230,4 +222,20 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `cookies(array $cookies)`:
+Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `forwardCookie(string $name)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
 

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -15,11 +15,14 @@ URL of the page you want to convert into PDF.
 
 * `singlePage(bool $bool)`:
 Define whether to print the entire content in one single page.
+
 If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default paper size, in inches.
+
 Examples of paper size (width x height):
+
 Letter - 8.5 x 11 (default)
 Legal - 8.5 x 14
 Tabloid - 11 x 17
@@ -32,6 +35,9 @@ A4 - 8.27 x 11.7
 A5 - 5.83 x 8.27
 A6 - 4.13 x 5.83
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
 
 * `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
@@ -40,6 +46,9 @@ A6 - 4.13 x 5.83
 
 * `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 Overrides the default margins (e.g., 0.39), in inches.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
 
@@ -52,24 +61,45 @@ Overrides the default margins (e.g., 0.39), in inches.
 * `preferCssPageSize(bool $bool)`:
 Define whether to prefer page size as defined by CSS. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `generateDocumentOutline(bool $bool)`:
 Define whether the document outline should be embedded into the PDF. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `printBackground(bool $bool)`:
 Prints the background graphics. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `omitBackground(bool $bool)`:
 Hides default white background and allows generating PDFs with
 transparency. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `landscape(bool $bool)`:
 Sets the paper orientation to landscape. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `scale(float $scale)`:
 The scale of the page rendering (e.g., 1.0). (Default 1.0).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `nativePageRanges(string $range)`:
 Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `header(string $template, array $context)`:
 
@@ -91,40 +121,71 @@ Adds a file, like an image, font, stylesheet, and so on.
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to PDF. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
 * `waitForExpression(string $expression)`:
 Sets the JavaScript expression to wait before converting an HTML
 document to PDF until it returns true. (default None).
+
 For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
 * `failOnConsoleExceptions(bool $bool)`:
 Forces GotenbergPdf to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
@@ -137,17 +198,30 @@ Enable PDF for Universal Access for optimal accessibility. (default false).
 * `metadata(array $metadata)`:
 Resets the metadata.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
+
 * `addMetadata(string $key, string $value)`:
 The metadata to write.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
+
 * `splitSpan(string $splitSpan)`:
 Either the intervals or the page ranges to extract, depending on the selected mode. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
+
 * `splitUnify(bool $bool)`:
 Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
 * `downloadFrom(array $downloadFrom)`:
 
@@ -158,13 +232,22 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `addCookies(array $cookies)`:
 Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/pdf/builders_api/UrlPdfBuilder.md
+++ b/docs/pdf/builders_api/UrlPdfBuilder.md
@@ -1,137 +1,30 @@
 # UrlPdfBuilder
 
-* `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
+* `addAsset(string $path)`:
+Adds a file, like an image, font, stylesheet, and so on.
 
-* `url(string $url)`:
-URL of the page you want to convert into PDF.
-
-* `route(string $name, array $parameters)`:
-
-* `cookies(array $cookies)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
-* `forwardCookie(string $name)`:
-
-* `singlePage(bool $bool)`:
-Define whether to print the entire content in one single page.
-
-If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
-
-* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-Overrides the default paper size, in inches.
-
-Examples of paper size (width x height):
-
-Letter - 8.5 x 11 (default)
-Legal - 8.5 x 14
-Tabloid - 11 x 17
-Ledger - 17 x 11
-A0 - 33.1 x 46.8
-A1 - 23.4 x 33.1
-A2 - 16.54 x 23.4
-A3 - 11.7 x 16.54
-A4 - 8.27 x 11.7
-A5 - 5.83 x 8.27
-A6 - 4.13 x 5.83
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-* `paperStandardSize(Sensiolabs\GotenbergBundle\Enumeration\PaperSizeInterface $paperSize)`:
-
-* `paperWidth(float $width, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `paperHeight(float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-Overrides the default margins (e.g., 0.39), in inches.
+* `addExtraHttpHeaders(array $headers)`:
+Adds extra HTTP headers that Chromium will send when loading the HTML
+document. (default None).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-* `marginTop(float $top, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginBottom(float $bottom, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginLeft(float $left, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `marginRight(float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
-
-* `preferCssPageSize(bool $bool)`:
-Define whether to prefer page size as defined by CSS. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `generateDocumentOutline(bool $bool)`:
-Define whether the document outline should be embedded into the PDF. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `printBackground(bool $bool)`:
-Prints the background graphics. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `omitBackground(bool $bool)`:
-Hides default white background and allows generating PDFs with
-transparency. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `landscape(bool $bool)`:
-Sets the paper orientation to landscape. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `scale(float $scale)`:
-The scale of the page rendering (e.g., 1.0). (Default 1.0).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `nativePageRanges(string $range)`:
-Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `header(string $template, array $context)`:
-
-* `footer(string $template, array $context)`:
-
-* `headerFile(string $path)`:
-HTML file containing the header. (default None).
-
-* `footerFile(string $path)`:
-HTML file containing the footer. (default None).
+* `addMetadata(string $key, string $value)`:
+The metadata to write.
 
 * `assets(string $paths)`:
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-* `addAsset(string $path)`:
-Adds a file, like an image, font, stylesheet, and so on.
+* `cookies(array $cookies)`:
 
-* `waitDelay(string $delay)`:
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-document before converting it to PDF. (default None).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-Sets the JavaScript expression to wait before converting an HTML
-document to PDF until it returns true. (default None).
-
-For instance: "window.status === 'ready'".
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+* `downloadFrom(array $downloadFrom)`:
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -139,11 +32,12 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `userAgent(string $userAgent)`:
-Override the default User-Agent HTTP header. (default None).
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -152,12 +46,12 @@ document. (default None). (overrides any previous headers).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-* `addExtraHttpHeaders(array $headers)`:
-Adds extra HTTP headers that Chromium will send when loading the HTML
-document. (default None).
+* `failOnConsoleExceptions(bool $bool)`:
+Forces GotenbergPdf to return a 409 Conflict response if there are
+exceptions in the Chromium console. (default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
@@ -180,20 +74,33 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-* `failOnConsoleExceptions(bool $bool)`:
-Forces GotenbergPdf to return a 409 Conflict response if there are
-exceptions in the Chromium console. (default false).
+* `footer(string $template, array $context)`:
+
+* `footerFile(string $path)`:
+HTML file containing the footer. (default None).
+
+* `generateDocumentOutline(bool $bool)`:
+Define whether the document outline should be embedded into the PDF. (Default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-* `skipNetworkIdleEvent(bool $bool)`:
+* `header(string $template, array $context)`:
 
-* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
-Sets the PDF format of the resulting PDF. (default None).
+* `headerFile(string $path)`:
+HTML file containing the header. (default None).
 
-* `pdfUniversalAccess(bool $bool)`:
-Enable PDF for Universal Access for optimal accessibility. (default false).
+* `landscape(bool $bool)`:
+Sets the paper orientation to landscape. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `margins(float $top, float $bottom, float $left, float $right, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+Overrides the default margins (e.g., 0.39), in inches.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `metadata(array $metadata)`:
 Resets the metadata.
@@ -202,8 +109,71 @@ Resets the metadata.
 > See: [https://gotenberg.dev/docs/routes#metadata-chromium](https://gotenberg.dev/docs/routes#metadata-chromium)
 > See: [https://exiftool.org/TagNames/XMP.html#pdf ](https://exiftool.org/TagNames/XMP.html#pdf )
 
-* `addMetadata(string $key, string $value)`:
-The metadata to write.
+* `nativePageRanges(string $range)`:
+Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `omitBackground(bool $bool)`:
+Hides default white background and allows generating PDFs with
+transparency. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `paperSize(float $width, float $height, Sensiolabs\GotenbergBundle\Enumeration\Unit $unit)`:
+Overrides the default paper size, in inches.
+
+Examples of paper size (width x height):
+
+Letter - 8.5 x 11 (default)
+Legal - 8.5 x 14
+Tabloid - 11 x 17
+Ledger - 17 x 11
+A0 - 33.1 x 46.8
+A1 - 23.4 x 33.1
+A2 - 16.54 x 23.4
+A3 - 11.7 x 16.54
+A4 - 8.27 x 11.7
+A5 - 5.83 x 8.27
+A6 - 4.13 x 5.83
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `pdfFormat(?Sensiolabs\GotenbergBundle\Enumeration\PdfFormat $format)`:
+Sets the PDF format of the resulting PDF. (default None).
+
+* `pdfUniversalAccess(bool $bool)`:
+Enable PDF for Universal Access for optimal accessibility. (default false).
+
+* `preferCssPageSize(bool $bool)`:
+Define whether to prefer page size as defined by CSS. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `printBackground(bool $bool)`:
+Prints the background graphics. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `route(string $name, array $parameters)`:
+
+* `scale(float $scale)`:
+The scale of the page rendering (e.g., 1.0). (Default 1.0).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
+* `singlePage(bool $bool)`:
+Define whether to print the entire content in one single page.
+
+If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
 
 * `splitMode(?Sensiolabs\GotenbergBundle\Enumeration\SplitMode $splitMode)`:
 Either intervals or pages. (default None).
@@ -223,10 +193,36 @@ Specify whether to put extracted pages into a single file or as many files as th
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#split-chromium](https://gotenberg.dev/docs/routes#split-chromium)
 
-* `downloadFrom(array $downloadFrom)`:
+* `url(string $url)`:
+URL of the page you want to convert into PDF.
+
+* `userAgent(string $userAgent)`:
+Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+
+* `waitDelay(string $delay)`:
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+document before converting it to PDF. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `waitForExpression(string $expression)`:
+Sets the JavaScript expression to wait before converting an HTML
+document to PDF until it returns true. (default None).
+
+For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -234,20 +230,4 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
-
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -25,7 +25,6 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 
 * `content(string $template, array $context)`:
 
-
 * `contentFile(string $path)`:
 
 The HTML file to convert into Screenshot.
@@ -128,7 +127,6 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
-
 * `userAgent(string $userAgent)`:
 
 Override the default User-Agent HTTP header. (default None).
@@ -191,7 +189,5 @@ Add cookies to store in the Chromium cookie jar.
 
 * `forwardCookie(string $name)`:
 
-
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -1,26 +1,10 @@
 # HtmlScreenshotBuilder
 
-### addAsset(string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
 ### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-### assets(string $paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### content(string $template, array $context)
-### contentFile(string $path)
-The HTML file to convert into Screenshot.
 
 ### downloadFrom(array $downloadFrom)
 > [!TIP]
@@ -38,84 +22,17 @@ Sets extra HTTP headers that Chromium will send when loading the HTML<br />docum
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### height(int $height)
-The device screen width in pixels. (Default 600).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### skipNetworkIdleEvent(bool $bool)
 ### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
+### addAsset(string $path)
+Adds a file, like an image, font, stylesheet, and so on.<br />
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### width(int $width)
-The device screen width in pixels. (Default 800).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+### assets(string $paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br />
 
 ### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
@@ -147,3 +64,86 @@ Add cookies to store in the Chromium cookie jar.<br />
 
 ### forwardCookie(string $name)
 ### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### height(int $height)
+The device screen width in pixels. (Default 600).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### width(int $width)
+The device screen width in pixels. (Default 800).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### content(string $template, array $context)
+### contentFile(string $path)
+The HTML file to convert into Screenshot.<br />
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium ](https://gotenberg.dev/docs/routes#network-errors-chromium )
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -7,6 +7,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 * `addExtraHttpHeaders(array $headers)`:
 
 Adds extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None).
 
 > [!TIP]
@@ -44,6 +45,7 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None). (overrides any previous headers).
 
 > [!TIP]
@@ -52,6 +54,7 @@ document. (default None). (overrides any previous headers).
 * `failOnConsoleExceptions(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions in the Chromium console. (default false).
 
 > [!TIP]
@@ -60,6 +63,7 @@ exceptions in the Chromium console. (default false).
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from
+
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
 > [!TIP]
@@ -68,6 +72,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
+
 (default None). (overrides any previous configuration).
 
 > [!TIP]
@@ -76,6 +81,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 * `failOnResourceLoadingFailed(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions load at least one resource. (default false).
 
 > [!TIP]
@@ -98,6 +104,7 @@ The device screen width in pixels. (Default 600).
 * `omitBackground(bool $bool)`:
 
 Hides default white background and allows generating screenshot with
+
 transparency. (Default false).
 
 > [!TIP]
@@ -129,6 +136,7 @@ Override the default User-Agent HTTP header. (default None).
 * `waitDelay(string $delay)`:
 
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+
 document before converting it to screenshot. (default None).
 
 > [!TIP]
@@ -137,7 +145,10 @@ document before converting it to screenshot. (default None).
 * `waitForExpression(string $expression)`:
 
 Sets the JavaScript expression to wait before converting an HTML
+
 document to screenshot until it returns true. (default None).
+
+
 
 For instance: "window.status === 'ready'".
 
@@ -154,6 +165,7 @@ The device screen width in pixels. (Default 800).
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -170,6 +182,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -107,6 +107,8 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
+* `skipNetworkIdleEvent(bool $bool)`:
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -1,212 +1,149 @@
 # HtmlScreenshotBuilder
 
-<details>
-<summary>addAsset(string $path)</summary>
-
+### addAsset(string $path)
 Adds a file, like an image, font, stylesheet, and so on.
 
-</details><details>
-<summary>addExtraHttpHeaders(array $headers)</summary>
-
+### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-</details><details>
-<summary>assets(string $paths)</summary>
-
+### assets(string $paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-</details><details>
-<summary>clip(bool $bool)</summary>
-
+### clip(bool $bool)
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>content(string $template, array $context)</summary>
-
-</details><details>
-<summary>contentFile(string $path)</summary>
-
+### content(string $template, array $context)
+### contentFile(string $path)
 The HTML file to convert into Screenshot.
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
-
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>extraHttpHeaders(array $headers)</summary>
-
+### extraHttpHeaders(array $headers)
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-</details><details>
-<summary>failOnConsoleExceptions(bool $bool)</summary>
-
+### failOnConsoleExceptions(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceLoadingFailed(bool $bool)</summary>
-
+### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-</details><details>
-<summary>format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)</summary>
-
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>height(int $height)</summary>
-
+### height(int $height)
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>omitBackground(bool $bool)</summary>
-
+### omitBackground(bool $bool)
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>optimizeForSpeed(bool $bool)</summary>
-
+### optimizeForSpeed(bool $bool)
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>quality(int $quality)</summary>
-
+### quality(int $quality)
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>skipNetworkIdleEvent(bool $bool)</summary>
-
-</details><details>
-<summary>userAgent(string $userAgent)</summary>
-
+### skipNetworkIdleEvent(bool $bool)
+### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-</details><details>
-<summary>waitDelay(string $delay)</summary>
-
+### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>waitForExpression(string $expression)</summary>
-
+### waitForExpression(string $expression)
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>width(int $width)</summary>
-
+### width(int $width)
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>addCookies(array $cookies)</summary>
-
+### addCookies(array $cookies)
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>cookies(array $cookies)</summary>
-
+### cookies(array $cookies)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>forwardCookie(string $name)</summary>
-
-</details><details>
-<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
-
-</details>
+### forwardCookie(string $name)
+### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -3,12 +3,6 @@
 * `addAsset(string $path)`:
 Adds a file, like an image, font, stylesheet, and so on.
 
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
@@ -30,9 +24,9 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 * `contentFile(string $path)`:
 The HTML file to convert into Screenshot.
 
-* `cookies(array $cookies)`:
-
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -113,8 +107,6 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
 
@@ -155,4 +147,18 @@ The device screen width in pixels. (Default 800).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `cookies(array $cookies)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `forwardCookie(string $name)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -1,9 +1,11 @@
 # HtmlScreenshotBuilder
 
 * `addAsset(string $path)`:
+
 Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
+
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
 
@@ -11,9 +13,11 @@ document. (default None).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `assets(string $paths)`:
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `clip(bool $bool)`:
+
 Define whether to clip the screenshot according to the device dimensions. (Default false).
 
 > [!TIP]
@@ -21,20 +25,25 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 
 * `content(string $template, array $context)`:
 
+
 * `contentFile(string $path)`:
+
 The HTML file to convert into Screenshot.
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -42,6 +51,7 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
+
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
@@ -49,6 +59,7 @@ document. (default None). (overrides any previous headers).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
 
@@ -56,6 +67,7 @@ exceptions in the Chromium console. (default false).
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
@@ -63,6 +75,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
 
@@ -70,6 +83,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
@@ -77,18 +91,21 @@ exceptions load at least one resource. (default false).
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
+
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `height(int $height)`:
+
 The device screen width in pixels. (Default 600).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
+
 Hides default white background and allows generating screenshot with
 transparency. (Default false).
 
@@ -96,12 +113,14 @@ transparency. (Default false).
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `optimizeForSpeed(bool $bool)`:
+
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `quality(int $quality)`:
+
 The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 > [!TIP]
@@ -109,13 +128,16 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
+
 * `userAgent(string $userAgent)`:
+
 Override the default User-Agent HTTP header. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to screenshot. (default None).
 
@@ -123,6 +145,7 @@ document before converting it to screenshot. (default None).
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
+
 Sets the JavaScript expression to wait before converting an HTML
 document to screenshot until it returns true. (default None).
 
@@ -132,12 +155,15 @@ For instance: "window.status === 'ready'".
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -145,22 +171,27 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `width(int $width)`:
+
 The device screen width in pixels. (Default 800).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `addCookies(array $cookies)`:
+
 Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `forwardCookie(string $name)`:
 
+
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -1,119 +1,212 @@
 # HtmlScreenshotBuilder
 
-<details><summary>`addAsset(string $path)`</summary>
+<details>
+<summary>addAsset(string $path)</summary>
+
 Adds a file, like an image, font, stylesheet, and so on.
-</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>addExtraHttpHeaders(array $headers)</summary>
+
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-</details><details><summary>`assets(string $paths)`</summary>
+
+</details><details>
+<summary>assets(string $paths)</summary>
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-</details><details><summary>`clip(bool $bool)`</summary>
+
+</details><details>
+<summary>clip(bool $bool)</summary>
+
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`content(string $template, array $context)`</summary></details><details><summary>`contentFile(string $path)`</summary>
+
+</details><details>
+<summary>content(string $template, array $context)</summary>
+
+</details><details>
+<summary>contentFile(string $path)</summary>
+
 The HTML file to convert into Screenshot.
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
+
+</details><details>
+<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>extraHttpHeaders(array $headers)</summary>
+
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnConsoleExceptions(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnResourceLoadingFailed(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-</details><details><summary>`format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`</summary>
+
+</details><details>
+<summary>format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)</summary>
+
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`height(int $height)`</summary>
+
+</details><details>
+<summary>height(int $height)</summary>
+
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`omitBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>omitBackground(bool $bool)</summary>
+
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`optimizeForSpeed(bool $bool)`</summary>
+
+</details><details>
+<summary>optimizeForSpeed(bool $bool)</summary>
+
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`quality(int $quality)`</summary>
+
+</details><details>
+<summary>quality(int $quality)</summary>
+
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`userAgent(string $userAgent)`</summary>
+
+</details><details>
+<summary>skipNetworkIdleEvent(bool $bool)</summary>
+
+</details><details>
+<summary>userAgent(string $userAgent)</summary>
+
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-</details><details><summary>`waitDelay(string $delay)`</summary>
+
+</details><details>
+<summary>waitDelay(string $delay)</summary>
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`waitForExpression(string $expression)`</summary>
+
+</details><details>
+<summary>waitForExpression(string $expression)</summary>
+
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`width(int $width)`</summary>
+
+</details><details>
+<summary>width(int $width)</summary>
+
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`addCookies(array $cookies)`</summary>
+
+</details><details>
+<summary>addCookies(array $cookies)</summary>
+
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`cookies(array $cookies)`</summary>
+
+</details><details>
+<summary>cookies(array $cookies)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>
+
+</details><details>
+<summary>forwardCookie(string $name)</summary>
+
+</details><details>
+<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
+
+</details>

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -41,14 +41,6 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -152,6 +144,21 @@ For instance: "window.status === 'ready'".
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
+* `width(int $width)`:
+
+The device screen width in pixels. (Default 800).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `webhookConfiguration(string $name)`:
 
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
@@ -167,13 +174,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `width(int $width)`:
-
-The device screen width in pixels. (Default 800).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `addCookies(array $cookies)`:
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -14,63 +14,115 @@ The HTML file to convert into Screenshot.
 * `width(int $width)`:
 The device screen width in pixels. (Default 800).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `height(int $height)`:
 The device screen width in pixels. (Default 600).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `clip(bool $bool)`:
 Define whether to clip the screenshot according to the device dimensions. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `quality(int $quality)`:
 The compression quality from range 0 to 100 (jpeg only). (default 100).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
 Hides default white background and allows generating screenshot with
 transparency. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `optimizeForSpeed(bool $bool)`:
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `waitDelay(string $delay)`:
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to screenshot. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
 * `waitForExpression(string $expression)`:
 Sets the JavaScript expression to wait before converting an HTML
 document to screenshot until it returns true. (default None).
+
 For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
 * `failOnConsoleExceptions(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
@@ -89,13 +141,22 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `addCookies(array $cookies)`:
 Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -1,27 +1,23 @@
 # HtmlScreenshotBuilder
 
-* `content(string $template, array $context)`:
+* `addAsset(string $path)`:
+Adds a file, like an image, font, stylesheet, and so on.
 
-* `contentFile(string $path)`:
-The HTML file to convert into Screenshot.
-
-* `cookies(array $cookies)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
-* `forwardCookie(string $name)`:
-
-* `width(int $width)`:
-The device screen width in pixels. (Default 800).
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-* `height(int $height)`:
-The device screen width in pixels. (Default 600).
+* `addExtraHttpHeaders(array $headers)`:
+Adds extra HTTP headers that Chromium will send when loading the HTML
+document. (default None).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+* `assets(string $paths)`:
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `clip(bool $bool)`:
 Define whether to clip the screenshot according to the device dimensions. (Default false).
@@ -29,46 +25,14 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
-The image compression format, either "png", "jpeg" or "webp". (default png).
+* `content(string $template, array $context)`:
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+* `contentFile(string $path)`:
+The HTML file to convert into Screenshot.
 
-* `quality(int $quality)`:
-The compression quality from range 0 to 100 (jpeg only). (default 100).
+* `cookies(array $cookies)`:
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `omitBackground(bool $bool)`:
-Hides default white background and allows generating screenshot with
-transparency. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `optimizeForSpeed(bool $bool)`:
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `waitDelay(string $delay)`:
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-document before converting it to screenshot. (default None).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-Sets the JavaScript expression to wait before converting an HTML
-document to screenshot until it returns true. (default None).
-
-For instance: "window.status === 'ready'".
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+* `downloadFrom(array $downloadFrom)`:
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -76,11 +40,12 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `userAgent(string $userAgent)`:
-Override the default User-Agent HTTP header. (default None).
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -89,12 +54,12 @@ document. (default None). (overrides any previous headers).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-* `addExtraHttpHeaders(array $headers)`:
-Adds extra HTTP headers that Chromium will send when loading the HTML
-document. (default None).
+* `failOnConsoleExceptions(bool $bool)`:
+Forces GotenbergScreenshot to return a 409 Conflict response if there are
+exceptions in the Chromium console. (default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
@@ -117,25 +82,66 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-* `failOnConsoleExceptions(bool $bool)`:
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-exceptions in the Chromium console. (default false).
+* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
+The image compression format, either "png", "jpeg" or "webp". (default png).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `skipNetworkIdleEvent(bool $bool)`:
+* `height(int $height)`:
+The device screen width in pixels. (Default 600).
 
-* `assets(string $paths)`:
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `addAsset(string $path)`:
-Adds a file, like an image, font, stylesheet, and so on.
+* `omitBackground(bool $bool)`:
+Hides default white background and allows generating screenshot with
+transparency. (Default false).
 
-* `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `optimizeForSpeed(bool $bool)`:
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `quality(int $quality)`:
+The compression quality from range 0 to 100 (jpeg only). (default 100).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
+* `userAgent(string $userAgent)`:
+Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+
+* `waitDelay(string $delay)`:
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+document before converting it to screenshot. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `waitForExpression(string $expression)`:
+Sets the JavaScript expression to wait before converting an HTML
+document to screenshot until it returns true. (default None).
+
+For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -144,19 +150,9 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+* `width(int $width)`:
+The device screen width in pixels. (Default 800).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
-
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -6,9 +6,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
 
-Adds extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None).
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
@@ -19,7 +17,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 
 * `clip(bool $bool)`:
 
-Define whether to clip the screenshot according to the device dimensions. (Default false).
+Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
@@ -37,89 +35,77 @@ The HTML file to convert into Screenshot.
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `extraHttpHeaders(array $headers)`:
 
-Sets extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None). (overrides any previous headers).
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions in the Chromium console. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from
-
-the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
-
-(default None). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions load at least one resource. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 
-The image compression format, either "png", "jpeg" or "webp". (default png).
+The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `height(int $height)`:
 
-The device screen width in pixels. (Default 600).
+The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
 
-Hides default white background and allows generating screenshot with
-
-transparency. (Default false).
+Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `optimizeForSpeed(bool $bool)`:
 
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `quality(int $quality)`:
 
-The compression quality from range 0 to 100 (jpeg only). (default 100).
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
@@ -128,45 +114,35 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `userAgent(string $userAgent)`:
 
-Override the default User-Agent HTTP header. (default None).
+Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
 
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-
-document before converting it to screenshot. (default None).
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
 
-Sets the JavaScript expression to wait before converting an HTML
-
-document to screenshot until it returns true. (default None).
-
-
-
-For instance: "window.status === 'ready'".
+Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `width(int $width)`:
 
-The device screen width in pixels. (Default 800).
+The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -177,20 +153,18 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
 
-Add cookies to store in the Chromium cookie jar.
+Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )

--- a/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/HtmlScreenshotBuilder.md
@@ -1,180 +1,119 @@
 # HtmlScreenshotBuilder
 
-* `addAsset(string $path)`:
-
+<details><summary>`addAsset(string $path)`</summary>
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addExtraHttpHeaders(array $headers)`:
-
+</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-* `assets(string $paths)`:
-
+</details><details><summary>`assets(string $paths)`</summary>
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `clip(bool $bool)`:
-
+</details><details><summary>`clip(bool $bool)`</summary>
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `content(string $template, array $context)`:
-
-* `contentFile(string $path)`:
-
+</details><details><summary>`content(string $template, array $context)`</summary></details><details><summary>`contentFile(string $path)`</summary>
 The HTML file to convert into Screenshot.
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
-
+</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `extraHttpHeaders(array $headers)`:
-
+</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-* `failOnConsoleExceptions(bool $bool)`:
-
+</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `failOnHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceLoadingFailed(bool $bool)`:
-
+</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
-
+</details><details><summary>`format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`</summary>
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `height(int $height)`:
-
+</details><details><summary>`height(int $height)`</summary>
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `omitBackground(bool $bool)`:
-
+</details><details><summary>`omitBackground(bool $bool)`</summary>
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `optimizeForSpeed(bool $bool)`:
-
+</details><details><summary>`optimizeForSpeed(bool $bool)`</summary>
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `quality(int $quality)`:
-
+</details><details><summary>`quality(int $quality)`</summary>
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `skipNetworkIdleEvent(bool $bool)`:
-
-* `userAgent(string $userAgent)`:
-
+</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`userAgent(string $userAgent)`</summary>
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-* `waitDelay(string $delay)`:
-
+</details><details><summary>`waitDelay(string $delay)`</summary>
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-
+</details><details><summary>`waitForExpression(string $expression)`</summary>
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `width(int $width)`:
-
+</details><details><summary>`width(int $width)`</summary>
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `addCookies(array $cookies)`:
-
+</details><details><summary>`addCookies(array $cookies)`</summary>
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `cookies(array $cookies)`:
-
+</details><details><summary>`cookies(array $cookies)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `forwardCookie(string $name)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
+</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -3,185 +3,122 @@
 > [!TIP]
 > See: [https://google.com](https://google.com)
 
-* `addAsset(string $path)`:
-
+<details><summary>`addAsset(string $path)`</summary>
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addExtraHttpHeaders(array $headers)`:
-
+</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-* `assets(string $paths)`:
-
+</details><details><summary>`assets(string $paths)`</summary>
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `clip(bool $bool)`:
-
+</details><details><summary>`clip(bool $bool)`</summary>
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
-
+</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `extraHttpHeaders(array $headers)`:
-
+</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-* `failOnConsoleExceptions(bool $bool)`:
-
+</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `failOnHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceLoadingFailed(bool $bool)`:
-
+</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-* `files(string $paths)`:
-
-* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
-
+</details><details><summary>`files(string $paths)`</summary></details><details><summary>`format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`</summary>
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `height(int $height)`:
-
+</details><details><summary>`height(int $height)`</summary>
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `omitBackground(bool $bool)`:
-
+</details><details><summary>`omitBackground(bool $bool)`</summary>
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `optimizeForSpeed(bool $bool)`:
-
+</details><details><summary>`optimizeForSpeed(bool $bool)`</summary>
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `quality(int $quality)`:
-
+</details><details><summary>`quality(int $quality)`</summary>
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `skipNetworkIdleEvent(bool $bool)`:
-
-* `userAgent(string $userAgent)`:
-
+</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`userAgent(string $userAgent)`</summary>
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-* `waitDelay(string $delay)`:
-
+</details><details><summary>`waitDelay(string $delay)`</summary>
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-
+</details><details><summary>`waitForExpression(string $expression)`</summary>
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `width(int $width)`:
-
+</details><details><summary>`width(int $width)`</summary>
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `wrapper(string $template, array $context)`:
-
+</details><details><summary>`wrapper(string $template, array $context)`</summary>
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
-
-* `wrapperFile(string $path)`:
-
+</details><details><summary>`wrapperFile(string $path)`</summary>
 The HTML file that wraps the markdown content.
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `addCookies(array $cookies)`:
-
+</details><details><summary>`addCookies(array $cookies)`</summary>
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `cookies(array $cookies)`:
-
+</details><details><summary>`cookies(array $cookies)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `forwardCookie(string $name)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
+</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -3,122 +3,218 @@
 > [!TIP]
 > See: [https://google.com](https://google.com)
 
-<details><summary>`addAsset(string $path)`</summary>
+<details>
+<summary>addAsset(string $path)</summary>
+
 Adds a file, like an image, font, stylesheet, and so on.
-</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>addExtraHttpHeaders(array $headers)</summary>
+
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-</details><details><summary>`assets(string $paths)`</summary>
+
+</details><details>
+<summary>assets(string $paths)</summary>
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-</details><details><summary>`clip(bool $bool)`</summary>
+
+</details><details>
+<summary>clip(bool $bool)</summary>
+
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
+
+</details><details>
+<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>extraHttpHeaders(array $headers)</summary>
+
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnConsoleExceptions(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnResourceLoadingFailed(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-</details><details><summary>`files(string $paths)`</summary></details><details><summary>`format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`</summary>
+
+</details><details>
+<summary>files(string $paths)</summary>
+
+</details><details>
+<summary>format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)</summary>
+
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`height(int $height)`</summary>
+
+</details><details>
+<summary>height(int $height)</summary>
+
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`omitBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>omitBackground(bool $bool)</summary>
+
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`optimizeForSpeed(bool $bool)`</summary>
+
+</details><details>
+<summary>optimizeForSpeed(bool $bool)</summary>
+
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`quality(int $quality)`</summary>
+
+</details><details>
+<summary>quality(int $quality)</summary>
+
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`userAgent(string $userAgent)`</summary>
+
+</details><details>
+<summary>skipNetworkIdleEvent(bool $bool)</summary>
+
+</details><details>
+<summary>userAgent(string $userAgent)</summary>
+
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-</details><details><summary>`waitDelay(string $delay)`</summary>
+
+</details><details>
+<summary>waitDelay(string $delay)</summary>
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`waitForExpression(string $expression)`</summary>
+
+</details><details>
+<summary>waitForExpression(string $expression)</summary>
+
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`width(int $width)`</summary>
+
+</details><details>
+<summary>width(int $width)</summary>
+
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`wrapper(string $template, array $context)`</summary>
+
+</details><details>
+<summary>wrapper(string $template, array $context)</summary>
+
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
-</details><details><summary>`wrapperFile(string $path)`</summary>
+
+</details><details>
+<summary>wrapperFile(string $path)</summary>
+
 The HTML file that wraps the markdown content.
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`addCookies(array $cookies)`</summary>
+
+</details><details>
+<summary>addCookies(array $cookies)</summary>
+
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`cookies(array $cookies)`</summary>
+
+</details><details>
+<summary>cookies(array $cookies)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>
+
+</details><details>
+<summary>forwardCookie(string $name)</summary>
+
+</details><details>
+<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
+
+</details>

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -38,14 +38,6 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -151,6 +143,29 @@ For instance: "window.status === 'ready'".
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
+* `width(int $width)`:
+
+The device screen width in pixels. (Default 800).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `wrapper(string $template, array $context)`:
+
+The HTML file that wraps the markdown content, rendered from a Twig template.
+
+* `wrapperFile(string $path)`:
+
+The HTML file that wraps the markdown content.
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `webhookConfiguration(string $name)`:
 
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
@@ -166,21 +181,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `width(int $width)`:
-
-The device screen width in pixels. (Default 800).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `wrapper(string $template, array $context)`:
-
-The HTML file that wraps the markdown content, rendered from a Twig template.
-
-* `wrapperFile(string $path)`:
-
-The HTML file that wraps the markdown content.
 
 * `addCookies(array $cookies)`:
 

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -74,6 +74,8 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
+* `files(string $paths)`:
+
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
@@ -104,6 +106,8 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `skipNetworkIdleEvent(bool $bool)`:
 
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -9,9 +9,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
 
-Adds extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None).
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
@@ -22,7 +20,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 
 * `clip(bool $bool)`:
 
-Define whether to clip the screenshot according to the device dimensions. (Default false).
+Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
@@ -34,52 +32,42 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `extraHttpHeaders(array $headers)`:
 
-Sets extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None). (overrides any previous headers).
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions in the Chromium console. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from
-
-the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
-
-(default None). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions load at least one resource. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
@@ -88,37 +76,35 @@ exceptions load at least one resource. (default false).
 
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 
-The image compression format, either "png", "jpeg" or "webp". (default png).
+The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `height(int $height)`:
 
-The device screen width in pixels. (Default 600).
+The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
 
-Hides default white background and allows generating screenshot with
-
-transparency. (Default false).
+Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `optimizeForSpeed(bool $bool)`:
 
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `quality(int $quality)`:
 
-The compression quality from range 0 to 100 (jpeg only). (default 100).
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
@@ -127,43 +113,35 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `userAgent(string $userAgent)`:
 
-Override the default User-Agent HTTP header. (default None).
+Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
 
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-
-document before converting it to screenshot. (default None).
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
 
-Sets the JavaScript expression to wait before converting an HTML
-
-document to screenshot until it returns true. (default None).
-
-
-
-For instance: "window.status === 'ready'".
+Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `width(int $width)`:
 
-The device screen width in pixels. (Default 800).
+The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `wrapper(string $template, array $context)`:
 
-The HTML file that wraps the markdown content, rendered from a Twig template.
+The HTML file that wraps the markdown content, rendered from a Twig template.<br />
 
 * `wrapperFile(string $path)`:
 
@@ -171,9 +149,7 @@ The HTML file that wraps the markdown content.
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -184,20 +160,18 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
 
-Add cookies to store in the Chromium cookie jar.
+Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -88,7 +88,6 @@ exceptions load at least one resource. (default false).
 
 * `files(string $paths)`:
 
-
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 
 The image compression format, either "png", "jpeg" or "webp". (default png).
@@ -126,7 +125,6 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `skipNetworkIdleEvent(bool $bool)`:
-
 
 * `userAgent(string $userAgent)`:
 
@@ -198,7 +196,5 @@ Add cookies to store in the Chromium cookie jar.
 
 * `forwardCookie(string $name)`:
 
-
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -1,30 +1,25 @@
 # MarkdownScreenshotBuilder
 
-* `wrapper(string $template, array $context)`:
-The HTML file that wraps the markdown content, rendered from a Twig template.
+> [!TIP]
+> See: [https://google.com](https://google.com)
+* `addAsset(string $path)`:
+Adds a file, like an image, font, stylesheet, and so on.
 
-* `wrapperFile(string $path)`:
-The HTML file that wraps the markdown content.
-
-* `files(Stringable|string $paths)`:
-
-* `cookies(array $cookies)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
-* `forwardCookie(string $name)`:
-
-* `width(int $width)`:
-The device screen width in pixels. (Default 800).
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-* `height(int $height)`:
-The device screen width in pixels. (Default 600).
+* `addExtraHttpHeaders(array $headers)`:
+Adds extra HTTP headers that Chromium will send when loading the HTML
+document. (default None).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+* `assets(string $paths)`:
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `clip(bool $bool)`:
 Define whether to clip the screenshot according to the device dimensions. (Default false).
@@ -32,46 +27,9 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
-The image compression format, either "png", "jpeg" or "webp". (default png).
+* `cookies(array $cookies)`:
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `quality(int $quality)`:
-The compression quality from range 0 to 100 (jpeg only). (default 100).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `omitBackground(bool $bool)`:
-Hides default white background and allows generating screenshot with
-transparency. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `optimizeForSpeed(bool $bool)`:
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `waitDelay(string $delay)`:
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-document before converting it to screenshot. (default None).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-Sets the JavaScript expression to wait before converting an HTML
-document to screenshot until it returns true. (default None).
-
-For instance: "window.status === 'ready'".
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+* `downloadFrom(array $downloadFrom)`:
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -79,11 +37,12 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `userAgent(string $userAgent)`:
-Override the default User-Agent HTTP header. (default None).
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -92,12 +51,12 @@ document. (default None). (overrides any previous headers).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-* `addExtraHttpHeaders(array $headers)`:
-Adds extra HTTP headers that Chromium will send when loading the HTML
-document. (default None).
+* `failOnConsoleExceptions(bool $bool)`:
+Forces GotenbergScreenshot to return a 409 Conflict response if there are
+exceptions in the Chromium console. (default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
@@ -120,25 +79,66 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-* `failOnConsoleExceptions(bool $bool)`:
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-exceptions in the Chromium console. (default false).
+* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
+The image compression format, either "png", "jpeg" or "webp". (default png).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `skipNetworkIdleEvent(bool $bool)`:
+* `height(int $height)`:
+The device screen width in pixels. (Default 600).
 
-* `assets(string $paths)`:
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `addAsset(string $path)`:
-Adds a file, like an image, font, stylesheet, and so on.
+* `omitBackground(bool $bool)`:
+Hides default white background and allows generating screenshot with
+transparency. (Default false).
 
-* `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `optimizeForSpeed(bool $bool)`:
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `quality(int $quality)`:
+The compression quality from range 0 to 100 (jpeg only). (default 100).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
+* `userAgent(string $userAgent)`:
+Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+
+* `waitDelay(string $delay)`:
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+document before converting it to screenshot. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `waitForExpression(string $expression)`:
+Sets the JavaScript expression to wait before converting an HTML
+document to screenshot until it returns true. (default None).
+
+For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -147,19 +147,15 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+* `width(int $width)`:
+The device screen width in pixels. (Default 800).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+* `wrapper(string $template, array $context)`:
+The HTML file that wraps the markdown content, rendered from a Twig template.
 
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+* `wrapperFile(string $path)`:
+The HTML file that wraps the markdown content.
 

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -22,7 +22,7 @@ Sets extra HTTP headers that Chromium will send when loading the HTML<br />docum
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-### files(string $paths)
+### files(Stringable|string $paths)
 ### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -1,25 +1,10 @@
 # MarkdownScreenshotBuilder
 
-> [!TIP]
-> See: [https://google.com](https://google.com)
-
-### addAsset(string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
 ### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-### assets(string $paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 ### downloadFrom(array $downloadFrom)
 > [!TIP]
@@ -37,91 +22,24 @@ Sets extra HTTP headers that Chromium will send when loading the HTML<br />docum
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
 ### files(string $paths)
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### height(int $height)
-The device screen width in pixels. (Default 600).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### skipNetworkIdleEvent(bool $bool)
 ### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### width(int $width)
-The device screen width in pixels. (Default 800).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
 ### wrapper(string $template, array $context)
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
 
 ### wrapperFile(string $path)
 The HTML file that wraps the markdown content.
+
+### addAsset(string $path)
+Adds a file, like an image, font, stylesheet, and so on.<br />
+
+### assets(string $paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br />
 
 ### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
@@ -153,3 +71,82 @@ Add cookies to store in the Chromium cookie jar.<br />
 
 ### forwardCookie(string $name)
 ### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### height(int $height)
+The device screen width in pixels. (Default 600).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### width(int $width)
+The device screen width in pixels. (Default 800).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium ](https://gotenberg.dev/docs/routes#network-errors-chromium )
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -4,9 +4,11 @@
 > See: [https://google.com](https://google.com)
 
 * `addAsset(string $path)`:
+
 Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
+
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
 
@@ -14,25 +16,30 @@ document. (default None).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `assets(string $paths)`:
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `clip(bool $bool)`:
+
 Define whether to clip the screenshot according to the device dimensions. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -40,6 +47,7 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
+
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
@@ -47,6 +55,7 @@ document. (default None). (overrides any previous headers).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
 
@@ -54,6 +63,7 @@ exceptions in the Chromium console. (default false).
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
@@ -61,6 +71,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
 
@@ -68,6 +79,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
@@ -76,19 +88,23 @@ exceptions load at least one resource. (default false).
 
 * `files(string $paths)`:
 
+
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
+
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `height(int $height)`:
+
 The device screen width in pixels. (Default 600).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
+
 Hides default white background and allows generating screenshot with
 transparency. (Default false).
 
@@ -96,12 +112,14 @@ transparency. (Default false).
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `optimizeForSpeed(bool $bool)`:
+
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `quality(int $quality)`:
+
 The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 > [!TIP]
@@ -109,13 +127,16 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
+
 * `userAgent(string $userAgent)`:
+
 Override the default User-Agent HTTP header. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to screenshot. (default None).
 
@@ -123,6 +144,7 @@ document before converting it to screenshot. (default None).
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
+
 Sets the JavaScript expression to wait before converting an HTML
 document to screenshot until it returns true. (default None).
 
@@ -132,12 +154,15 @@ For instance: "window.status === 'ready'".
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -145,28 +170,35 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `width(int $width)`:
+
 The device screen width in pixels. (Default 800).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `wrapper(string $template, array $context)`:
+
 The HTML file that wraps the markdown content, rendered from a Twig template.
 
 * `wrapperFile(string $path)`:
+
 The HTML file that wraps the markdown content.
 
 * `addCookies(array $cookies)`:
+
 Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `forwardCookie(string $name)`:
 
+
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
 

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -3,218 +3,153 @@
 > [!TIP]
 > See: [https://google.com](https://google.com)
 
-<details>
-<summary>addAsset(string $path)</summary>
-
+### addAsset(string $path)
 Adds a file, like an image, font, stylesheet, and so on.
 
-</details><details>
-<summary>addExtraHttpHeaders(array $headers)</summary>
-
+### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-</details><details>
-<summary>assets(string $paths)</summary>
-
+### assets(string $paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-</details><details>
-<summary>clip(bool $bool)</summary>
-
+### clip(bool $bool)
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
-
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>extraHttpHeaders(array $headers)</summary>
-
+### extraHttpHeaders(array $headers)
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-</details><details>
-<summary>failOnConsoleExceptions(bool $bool)</summary>
-
+### failOnConsoleExceptions(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceLoadingFailed(bool $bool)</summary>
-
+### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-</details><details>
-<summary>files(string $paths)</summary>
-
-</details><details>
-<summary>format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)</summary>
-
+### files(string $paths)
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>height(int $height)</summary>
-
+### height(int $height)
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>omitBackground(bool $bool)</summary>
-
+### omitBackground(bool $bool)
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>optimizeForSpeed(bool $bool)</summary>
-
+### optimizeForSpeed(bool $bool)
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>quality(int $quality)</summary>
-
+### quality(int $quality)
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>skipNetworkIdleEvent(bool $bool)</summary>
-
-</details><details>
-<summary>userAgent(string $userAgent)</summary>
-
+### skipNetworkIdleEvent(bool $bool)
+### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-</details><details>
-<summary>waitDelay(string $delay)</summary>
-
+### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>waitForExpression(string $expression)</summary>
-
+### waitForExpression(string $expression)
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>width(int $width)</summary>
-
+### width(int $width)
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>wrapper(string $template, array $context)</summary>
-
+### wrapper(string $template, array $context)
 The HTML file that wraps the markdown content, rendered from a Twig template.<br />
 
-</details><details>
-<summary>wrapperFile(string $path)</summary>
-
+### wrapperFile(string $path)
 The HTML file that wraps the markdown content.
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>addCookies(array $cookies)</summary>
-
+### addCookies(array $cookies)
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>cookies(array $cookies)</summary>
-
+### cookies(array $cookies)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>forwardCookie(string $name)</summary>
-
-</details><details>
-<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
-
-</details>
+### forwardCookie(string $name)
+### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -2,14 +2,9 @@
 
 > [!TIP]
 > See: [https://google.com](https://google.com)
+
 * `addAsset(string $path)`:
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
@@ -27,9 +22,9 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `cookies(array $cookies)`:
-
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -110,8 +105,6 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
 
@@ -158,4 +151,18 @@ The HTML file that wraps the markdown content, rendered from a Twig template.
 
 * `wrapperFile(string $path)`:
 The HTML file that wraps the markdown content.
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `cookies(array $cookies)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `forwardCookie(string $name)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
 

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -10,6 +10,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 * `addExtraHttpHeaders(array $headers)`:
 
 Adds extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None).
 
 > [!TIP]
@@ -41,6 +42,7 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None). (overrides any previous headers).
 
 > [!TIP]
@@ -49,6 +51,7 @@ document. (default None). (overrides any previous headers).
 * `failOnConsoleExceptions(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions in the Chromium console. (default false).
 
 > [!TIP]
@@ -57,6 +60,7 @@ exceptions in the Chromium console. (default false).
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from
+
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
 > [!TIP]
@@ -65,6 +69,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
+
 (default None). (overrides any previous configuration).
 
 > [!TIP]
@@ -73,6 +78,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 * `failOnResourceLoadingFailed(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions load at least one resource. (default false).
 
 > [!TIP]
@@ -97,6 +103,7 @@ The device screen width in pixels. (Default 600).
 * `omitBackground(bool $bool)`:
 
 Hides default white background and allows generating screenshot with
+
 transparency. (Default false).
 
 > [!TIP]
@@ -128,6 +135,7 @@ Override the default User-Agent HTTP header. (default None).
 * `waitDelay(string $delay)`:
 
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+
 document before converting it to screenshot. (default None).
 
 > [!TIP]
@@ -136,7 +144,10 @@ document before converting it to screenshot. (default None).
 * `waitForExpression(string $expression)`:
 
 Sets the JavaScript expression to wait before converting an HTML
+
 document to screenshot until it returns true. (default None).
+
+
 
 For instance: "window.status === 'ready'".
 
@@ -161,6 +172,7 @@ The HTML file that wraps the markdown content.
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -177,6 +189,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/MarkdownScreenshotBuilder.md
@@ -17,63 +17,115 @@ The HTML file that wraps the markdown content.
 * `width(int $width)`:
 The device screen width in pixels. (Default 800).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `height(int $height)`:
 The device screen width in pixels. (Default 600).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `clip(bool $bool)`:
 Define whether to clip the screenshot according to the device dimensions. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `quality(int $quality)`:
 The compression quality from range 0 to 100 (jpeg only). (default 100).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
 Hides default white background and allows generating screenshot with
 transparency. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `optimizeForSpeed(bool $bool)`:
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `waitDelay(string $delay)`:
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to screenshot. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
 * `waitForExpression(string $expression)`:
 Sets the JavaScript expression to wait before converting an HTML
 document to screenshot until it returns true. (default None).
+
 For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
 * `failOnConsoleExceptions(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
@@ -92,13 +144,22 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `addCookies(array $cookies)`:
 Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,215 +1,150 @@
 # UrlScreenshotBuilder
 
-<details>
-<summary>addAsset(string $path)</summary>
-
+### addAsset(string $path)
 Adds a file, like an image, font, stylesheet, and so on.
 
-</details><details>
-<summary>addExtraHttpHeaders(array $headers)</summary>
-
+### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
-</details><details>
-<summary>assets(string $paths)</summary>
-
+### assets(string $paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
-</details><details>
-<summary>clip(bool $bool)</summary>
-
+### clip(bool $bool)
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>downloadFrom(array $downloadFrom)</summary>
-
+### downloadFrom(array $downloadFrom)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
-</details><details>
-<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
-
+### emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>extraHttpHeaders(array $headers)</summary>
-
+### extraHttpHeaders(array $headers)
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-</details><details>
-<summary>failOnConsoleExceptions(bool $bool)</summary>
-
+### failOnConsoleExceptions(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-</details><details>
-<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
-
+### failOnResourceHttpStatusCodes(array $statusCodes)
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
-</details><details>
-<summary>failOnResourceLoadingFailed(bool $bool)</summary>
-
+### failOnResourceLoadingFailed(bool $bool)
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-</details><details>
-<summary>format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)</summary>
-
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>height(int $height)</summary>
-
+### height(int $height)
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>omitBackground(bool $bool)</summary>
-
+### omitBackground(bool $bool)
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
-</details><details>
-<summary>optimizeForSpeed(bool $bool)</summary>
-
+### optimizeForSpeed(bool $bool)
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>quality(int $quality)</summary>
-
+### quality(int $quality)
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>route(string $name, array $parameters)</summary>
-
-</details><details>
-<summary>setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)</summary>
-
-</details><details>
-<summary>skipNetworkIdleEvent(bool $bool)</summary>
-
-</details><details>
-<summary>url(string $url)</summary>
-
+### route(string $name, array $parameters)
+### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
+### skipNetworkIdleEvent(bool $bool)
+### url(string $url)
 URL of the page you want to screenshot.
 
-</details><details>
-<summary>userAgent(string $userAgent)</summary>
-
+### userAgent(string $userAgent)
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-</details><details>
-<summary>waitDelay(string $delay)</summary>
-
+### waitDelay(string $delay)
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>waitForExpression(string $expression)</summary>
-
+### waitForExpression(string $expression)
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
-</details><details>
-<summary>width(int $width)</summary>
-
+### width(int $width)
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-</details><details>
-<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
-
+### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>webhookConfiguration(string $name)</summary>
-
+### webhookConfiguration(string $name)
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
-</details><details>
-<summary>webhookExtraHeaders(array $extraHeaders)</summary>
-
+### webhookExtraHeaders(array $extraHeaders)
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
-</details><details>
-<summary>webhookUrl(string $url, ?string $method)</summary>
-
+### webhookUrl(string $url, ?string $method)
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-</details><details>
-<summary>addCookies(array $cookies)</summary>
-
+### addCookies(array $cookies)
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>cookies(array $cookies)</summary>
-
+### cookies(array $cookies)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-</details><details>
-<summary>forwardCookie(string $name)</summary>
-
-</details><details>
-<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
-
-</details>
+### forwardCookie(string $name)
+### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -3,12 +3,6 @@
 * `addAsset(string $path)`:
 Adds a file, like an image, font, stylesheet, and so on.
 
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
@@ -25,9 +19,9 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `cookies(array $cookies)`:
-
 * `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -110,8 +104,6 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `route(string $name, array $parameters)`:
 
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 * `url(string $url)`:
 URL of the page you want to screenshot.
 
@@ -155,4 +147,18 @@ The device screen width in pixels. (Default 800).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `cookies(array $cookies)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+
+* `forwardCookie(string $name)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,22 +1,10 @@
 # UrlScreenshotBuilder
 
-### addAsset(string $path)
-Adds a file, like an image, font, stylesheet, and so on.
-
 ### addExtraHttpHeaders(array $headers)
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-### assets(string $paths)
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-### clip(bool $bool)
-Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 ### downloadFrom(array $downloadFrom)
 > [!TIP]
@@ -34,63 +22,8 @@ Sets extra HTTP headers that Chromium will send when loading the HTML<br />docum
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-### failOnConsoleExceptions(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-### failOnHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceHttpStatusCodes(array $statusCodes)
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-### failOnResourceLoadingFailed(bool $bool)
-Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
-The image compression format, either "png", "jpeg" or "webp". (default png).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### height(int $height)
-The device screen width in pixels. (Default 600).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### omitBackground(bool $bool)
-Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-### optimizeForSpeed(bool $bool)
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-### quality(int $quality)
-The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
 ### route(string $name, array $parameters)
 ### setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)
-### skipNetworkIdleEvent(bool $bool)
 ### url(string $url)
 URL of the page you want to screenshot.
 
@@ -100,23 +33,11 @@ Override the default User-Agent HTTP header. (default None).<br />
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
-### waitDelay(string $delay)
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
+### addAsset(string $path)
+Adds a file, like an image, font, stylesheet, and so on.<br />
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### waitForExpression(string $expression)
-Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-### width(int $width)
-The device screen width in pixels. (Default 800).<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+### assets(string $paths)
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br />
 
 ### errorWebhookUrl(?string $url, ?string $method)
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
@@ -148,3 +69,82 @@ Add cookies to store in the Chromium cookie jar.<br />
 
 ### forwardCookie(string $name)
 ### setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)
+### clip(bool $bool)
+Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)
+The image compression format, either "png", "jpeg" or "webp". (default png).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### height(int $height)
+The device screen width in pixels. (Default 600).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### omitBackground(bool $bool)
+Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium ](https://gotenberg.dev/docs/routes#page-properties-chromium )
+
+### optimizeForSpeed(bool $bool)
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### quality(int $quality)
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### width(int $width)
+The device screen width in pixels. (Default 800).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route ](https://gotenberg.dev/docs/routes#screenshots-route )
+
+### waitDelay(string $delay)
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### waitForExpression(string $expression)
+Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering ](https://gotenberg.dev/docs/routes#wait-before-rendering )
+
+### failOnConsoleExceptions(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions ](https://gotenberg.dev/docs/routes#console-exceptions )
+
+### failOnHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceHttpStatusCodes(array $statusCodes)
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
+### failOnResourceLoadingFailed(bool $bool)
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium ](https://gotenberg.dev/docs/routes#network-errors-chromium )
+
+### skipNetworkIdleEvent(bool $bool)

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -16,63 +16,115 @@ URL of the page you want to screenshot.
 * `width(int $width)`:
 The device screen width in pixels. (Default 800).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `height(int $height)`:
 The device screen width in pixels. (Default 600).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `clip(bool $bool)`:
 Define whether to clip the screenshot according to the device dimensions. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
 * `quality(int $quality)`:
 The compression quality from range 0 to 100 (jpeg only). (default 100).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
 Hides default white background and allows generating screenshot with
 transparency. (Default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
 * `optimizeForSpeed(bool $bool)`:
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `waitDelay(string $delay)`:
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to screenshot. (default None).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
 * `waitForExpression(string $expression)`:
 Sets the JavaScript expression to wait before converting an HTML
 document to screenshot until it returns true. (default None).
+
 For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+
 * `userAgent(string $userAgent)`:
 Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
+
 * `addExtraHttpHeaders(array $headers)`:
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
+
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
+
 * `failOnConsoleExceptions(bool $bool)`:
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
@@ -91,13 +143,22 @@ Providing an existing $name from the configuration file, it will correctly set b
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `errorWebhookUrl(?string $url, ?string $method)`:
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `addCookies(array $cookies)`:
 Add cookies to store in the Chromium cookie jar.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -6,9 +6,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
 
-Adds extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None).
+Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
@@ -19,7 +17,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 
 * `clip(bool $bool)`:
 
-Define whether to clip the screenshot according to the device dimensions. (Default false).
+Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
@@ -31,89 +29,77 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 
-Forces Chromium to emulate, either "screen" or "print". (default "print").
+Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `extraHttpHeaders(array $headers)`:
 
-Sets extra HTTP headers that Chromium will send when loading the HTML
-
-document. (default None). (overrides any previous headers).
+Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions in the Chromium console. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from
-
-the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
-Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
-
-(default None). (overrides any previous configuration).
+Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
 
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-
-exceptions load at least one resource. (default false).
+Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
 
-The image compression format, either "png", "jpeg" or "webp". (default png).
+The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `height(int $height)`:
 
-The device screen width in pixels. (Default 600).
+The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
 
-Hides default white background and allows generating screenshot with
-
-transparency. (Default false).
+Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `optimizeForSpeed(bool $bool)`:
 
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `quality(int $quality)`:
 
-The compression quality from range 0 to 100 (jpeg only). (default 100).
+The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
@@ -130,45 +116,35 @@ URL of the page you want to screenshot.
 
 * `userAgent(string $userAgent)`:
 
-Override the default User-Agent HTTP header. (default None).
+Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
 
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-
-document before converting it to screenshot. (default None).
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
 
-Sets the JavaScript expression to wait before converting an HTML
-
-document to screenshot until it returns true. (default None).
-
-
-
-For instance: "window.status === 'ready'".
+Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `width(int $width)`:
 
-The device screen width in pixels. (Default 800).
+The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
-Sets the webhook for cases of error.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
@@ -179,20 +155,18 @@ Providing an existing $name from the configuration file, it will correctly set b
 
 * `webhookExtraHeaders(array $extraHeaders)`:
 
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
 
 * `webhookUrl(string $url, ?string $method)`:
 
-Sets the webhook for cases of success.
-
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `addCookies(array $cookies)`:
 
-Add cookies to store in the Chromium cookie jar.
+Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -7,6 +7,7 @@ Adds a file, like an image, font, stylesheet, and so on.
 * `addExtraHttpHeaders(array $headers)`:
 
 Adds extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None).
 
 > [!TIP]
@@ -38,6 +39,7 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
+
 document. (default None). (overrides any previous headers).
 
 > [!TIP]
@@ -46,6 +48,7 @@ document. (default None). (overrides any previous headers).
 * `failOnConsoleExceptions(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions in the Chromium console. (default false).
 
 > [!TIP]
@@ -54,6 +57,7 @@ exceptions in the Chromium console. (default false).
 * `failOnHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from
+
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
 > [!TIP]
@@ -62,6 +66,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
 
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
+
 (default None). (overrides any previous configuration).
 
 > [!TIP]
@@ -70,6 +75,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 * `failOnResourceLoadingFailed(bool $bool)`:
 
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
+
 exceptions load at least one resource. (default false).
 
 > [!TIP]
@@ -92,6 +98,7 @@ The device screen width in pixels. (Default 600).
 * `omitBackground(bool $bool)`:
 
 Hides default white background and allows generating screenshot with
+
 transparency. (Default false).
 
 > [!TIP]
@@ -131,6 +138,7 @@ Override the default User-Agent HTTP header. (default None).
 * `waitDelay(string $delay)`:
 
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+
 document before converting it to screenshot. (default None).
 
 > [!TIP]
@@ -139,7 +147,10 @@ document before converting it to screenshot. (default None).
 * `waitForExpression(string $expression)`:
 
 Sets the JavaScript expression to wait before converting an HTML
+
 document to screenshot until it returns true. (default None).
+
+
 
 For instance: "window.status === 'ready'".
 
@@ -156,6 +167,7 @@ The device screen width in pixels. (Default 800).
 * `errorWebhookUrl(?string $url, ?string $method)`:
 
 Sets the webhook for cases of error.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
@@ -172,6 +184,7 @@ Extra headers that will be provided to the webhook endpoint. May it either be Su
 * `webhookUrl(string $url, ?string $method)`:
 
 Sets the webhook for cases of success.
+
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -35,14 +35,6 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
 * `extraHttpHeaders(array $headers)`:
 
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -154,6 +146,21 @@ For instance: "window.status === 'ready'".
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
+* `width(int $width)`:
+
+The device screen width in pixels. (Default 800).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `errorWebhookUrl(?string $url, ?string $method)`:
+
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
+
 * `webhookConfiguration(string $name)`:
 
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
@@ -169,13 +176,6 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `width(int $width)`:
-
-The device screen width in pixels. (Default 800).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `addCookies(array $cookies)`:
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,9 +1,11 @@
 # UrlScreenshotBuilder
 
 * `addAsset(string $path)`:
+
 Adds a file, like an image, font, stylesheet, and so on.
 
 * `addExtraHttpHeaders(array $headers)`:
+
 Adds extra HTTP headers that Chromium will send when loading the HTML
 document. (default None).
 
@@ -11,25 +13,30 @@ document. (default None).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
 
 * `assets(string $paths)`:
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `clip(bool $bool)`:
+
 Define whether to clip the screenshot according to the device dimensions. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `downloadFrom(array $downloadFrom)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `errorWebhookUrl(?string $url, ?string $method)`:
+
 Sets the webhook for cases of error.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -37,6 +44,7 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
+
 Sets extra HTTP headers that Chromium will send when loading the HTML
 document. (default None). (overrides any previous headers).
 
@@ -44,6 +52,7 @@ document. (default None). (overrides any previous headers).
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
 * `failOnConsoleExceptions(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions in the Chromium console. (default false).
 
@@ -51,6 +60,7 @@ exceptions in the Chromium console. (default false).
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from
 the main page is not acceptable. (default [499,599]). (overrides any previous configuration).
 
@@ -58,6 +68,7 @@ the main page is not acceptable. (default [499,599]). (overrides any previous co
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceHttpStatusCodes(array $statusCodes)`:
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.
 (default None). (overrides any previous configuration).
 
@@ -65,6 +76,7 @@ Return a 409 Conflict response if the HTTP status code from at least one resourc
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
 
 * `failOnResourceLoadingFailed(bool $bool)`:
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are
 exceptions load at least one resource. (default false).
 
@@ -72,18 +84,21 @@ exceptions load at least one resource. (default false).
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
 * `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
+
 The image compression format, either "png", "jpeg" or "webp". (default png).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `height(int $height)`:
+
 The device screen width in pixels. (Default 600).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `omitBackground(bool $bool)`:
+
 Hides default white background and allows generating screenshot with
 transparency. (Default false).
 
@@ -91,12 +106,14 @@ transparency. (Default false).
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
 
 * `optimizeForSpeed(bool $bool)`:
+
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `quality(int $quality)`:
+
 The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 > [!TIP]
@@ -104,20 +121,26 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `route(string $name, array $parameters)`:
 
+
 * `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
+
 
 * `skipNetworkIdleEvent(bool $bool)`:
 
+
 * `url(string $url)`:
+
 URL of the page you want to screenshot.
 
 * `userAgent(string $userAgent)`:
+
 Override the default User-Agent HTTP header. (default None).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
 
 * `waitDelay(string $delay)`:
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
 document before converting it to screenshot. (default None).
 
@@ -125,6 +148,7 @@ document before converting it to screenshot. (default None).
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `waitForExpression(string $expression)`:
+
 Sets the JavaScript expression to wait before converting an HTML
 document to screenshot until it returns true. (default None).
 
@@ -134,12 +158,15 @@ For instance: "window.status === 'ready'".
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
 
 * `webhookExtraHeaders(array $extraHeaders)`:
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
+
 Sets the webhook for cases of success.
 Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
@@ -147,22 +174,27 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `width(int $width)`:
+
 The device screen width in pixels. (Default 800).
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
 * `addCookies(array $cookies)`:
+
 Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `cookies(array $cookies)`:
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
 * `forwardCookie(string $name)`:
 
+
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,119 +1,215 @@
 # UrlScreenshotBuilder
 
-<details><summary>`addAsset(string $path)`</summary>
+<details>
+<summary>addAsset(string $path)</summary>
+
 Adds a file, like an image, font, stylesheet, and so on.
-</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>addExtraHttpHeaders(array $headers)</summary>
+
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-</details><details><summary>`assets(string $paths)`</summary>
+
+</details><details>
+<summary>assets(string $paths)</summary>
+
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-</details><details><summary>`clip(bool $bool)`</summary>
+
+</details><details>
+<summary>clip(bool $bool)</summary>
+
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
+
+</details><details>
+<summary>downloadFrom(array $downloadFrom)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
+
+</details><details>
+<summary>emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)</summary>
+
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
+
+</details><details>
+<summary>extraHttpHeaders(array $headers)</summary>
+
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnConsoleExceptions(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
+
+</details><details>
+<summary>failOnResourceHttpStatusCodes(array $statusCodes)</summary>
+
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
+
+</details><details>
+<summary>failOnResourceLoadingFailed(bool $bool)</summary>
+
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-</details><details><summary>`format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`</summary>
+
+</details><details>
+<summary>format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)</summary>
+
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`height(int $height)`</summary>
+
+</details><details>
+<summary>height(int $height)</summary>
+
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`omitBackground(bool $bool)`</summary>
+
+</details><details>
+<summary>omitBackground(bool $bool)</summary>
+
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-</details><details><summary>`optimizeForSpeed(bool $bool)`</summary>
+
+</details><details>
+<summary>optimizeForSpeed(bool $bool)</summary>
+
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`quality(int $quality)`</summary>
+
+</details><details>
+<summary>quality(int $quality)</summary>
+
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`route(string $name, array $parameters)`</summary></details><details><summary>`setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`</summary></details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`url(string $url)`</summary>
+
+</details><details>
+<summary>route(string $name, array $parameters)</summary>
+
+</details><details>
+<summary>setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)</summary>
+
+</details><details>
+<summary>skipNetworkIdleEvent(bool $bool)</summary>
+
+</details><details>
+<summary>url(string $url)</summary>
+
 URL of the page you want to screenshot.
-</details><details><summary>`userAgent(string $userAgent)`</summary>
+
+</details><details>
+<summary>userAgent(string $userAgent)</summary>
+
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-</details><details><summary>`waitDelay(string $delay)`</summary>
+
+</details><details>
+<summary>waitDelay(string $delay)</summary>
+
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`waitForExpression(string $expression)`</summary>
+
+</details><details>
+<summary>waitForExpression(string $expression)</summary>
+
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-</details><details><summary>`width(int $width)`</summary>
+
+</details><details>
+<summary>width(int $width)</summary>
+
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>errorWebhookUrl(?string $url, ?string $method)</summary>
+
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`webhookConfiguration(string $name)`</summary>
+
+</details><details>
+<summary>webhookConfiguration(string $name)</summary>
+
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
+
+</details><details>
+<summary>webhookExtraHeaders(array $extraHeaders)</summary>
+
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
+
+</details><details>
+<summary>webhookUrl(string $url, ?string $method)</summary>
+
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-</details><details><summary>`addCookies(array $cookies)`</summary>
+
+</details><details>
+<summary>addCookies(array $cookies)</summary>
+
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`cookies(array $cookies)`</summary>
+
+</details><details>
+<summary>cookies(array $cookies)</summary>
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>
+
+</details><details>
+<summary>forwardCookie(string $name)</summary>
+
+</details><details>
+<summary>setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)</summary>
+
+</details>

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -104,6 +104,10 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `route(string $name, array $parameters)`:
 
+* `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
+
+* `skipNetworkIdleEvent(bool $bool)`:
+
 * `url(string $url)`:
 URL of the page you want to screenshot.
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -121,12 +121,9 @@ The compression quality from range 0 to 100 (jpeg only). (default 100).
 
 * `route(string $name, array $parameters)`:
 
-
 * `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
 
-
 * `skipNetworkIdleEvent(bool $bool)`:
-
 
 * `url(string $url)`:
 
@@ -194,7 +191,5 @@ Add cookies to store in the Chromium cookie jar.
 
 * `forwardCookie(string $name)`:
 
-
 * `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,29 +1,23 @@
 # UrlScreenshotBuilder
 
-* `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
+* `addAsset(string $path)`:
+Adds a file, like an image, font, stylesheet, and so on.
 
-* `url(string $url)`:
-URL of the page you want to screenshot.
-
-* `route(string $name, array $parameters)`:
-
-* `cookies(array $cookies)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
-* `forwardCookie(string $name)`:
-
-* `width(int $width)`:
-The device screen width in pixels. (Default 800).
+* `addCookies(array $cookies)`:
+Add cookies to store in the Chromium cookie jar.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
 
-* `height(int $height)`:
-The device screen width in pixels. (Default 600).
+* `addExtraHttpHeaders(array $headers)`:
+Adds extra HTTP headers that Chromium will send when loading the HTML
+document. (default None).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+
+* `assets(string $paths)`:
+Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
 
 * `clip(bool $bool)`:
 Define whether to clip the screenshot according to the device dimensions. (Default false).
@@ -31,46 +25,9 @@ Define whether to clip the screenshot according to the device dimensions. (Defau
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
-The image compression format, either "png", "jpeg" or "webp". (default png).
+* `cookies(array $cookies)`:
 
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `quality(int $quality)`:
-The compression quality from range 0 to 100 (jpeg only). (default 100).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `omitBackground(bool $bool)`:
-Hides default white background and allows generating screenshot with
-transparency. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `optimizeForSpeed(bool $bool)`:
-Define whether to optimize image encoding for speed, not for resulting size. (Default false).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `waitDelay(string $delay)`:
-Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
-document before converting it to screenshot. (default None).
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-Sets the JavaScript expression to wait before converting an HTML
-document to screenshot until it returns true. (default None).
-
-For instance: "window.status === 'ready'".
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+* `downloadFrom(array $downloadFrom)`:
 
 * `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
 Forces Chromium to emulate, either "screen" or "print". (default "print").
@@ -78,11 +35,12 @@ Forces Chromium to emulate, either "screen" or "print". (default "print").
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
-* `userAgent(string $userAgent)`:
-Override the default User-Agent HTTP header. (default None).
+* `errorWebhookUrl(?string $url, ?string $method)`:
+Sets the webhook for cases of error.
+Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
 * `extraHttpHeaders(array $headers)`:
 Sets extra HTTP headers that Chromium will send when loading the HTML
@@ -91,12 +49,12 @@ document. (default None). (overrides any previous headers).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
 
-* `addExtraHttpHeaders(array $headers)`:
-Adds extra HTTP headers that Chromium will send when loading the HTML
-document. (default None).
+* `failOnConsoleExceptions(bool $bool)`:
+Forces GotenbergScreenshot to return a 409 Conflict response if there are
+exceptions in the Chromium console. (default false).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
+> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
 
 * `failOnHttpStatusCodes(array $statusCodes)`:
 Return a 409 Conflict response if the HTTP status code from
@@ -119,25 +77,71 @@ exceptions load at least one resource. (default false).
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
 
-* `failOnConsoleExceptions(bool $bool)`:
-Forces GotenbergScreenshot to return a 409 Conflict response if there are
-exceptions in the Chromium console. (default false).
+* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
+The image compression format, either "png", "jpeg" or "webp". (default png).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `skipNetworkIdleEvent(bool $bool)`:
+* `height(int $height)`:
+The device screen width in pixels. (Default 600).
 
-* `assets(string $paths)`:
-Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 
-* `addAsset(string $path)`:
-Adds a file, like an image, font, stylesheet, and so on.
+* `omitBackground(bool $bool)`:
+Hides default white background and allows generating screenshot with
+transparency. (Default false).
 
-* `downloadFrom(array $downloadFrom)`:
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
+
+* `optimizeForSpeed(bool $bool)`:
+Define whether to optimize image encoding for speed, not for resulting size. (Default false).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `quality(int $quality)`:
+The compression quality from range 0 to 100 (jpeg only). (default 100).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
+
+* `route(string $name, array $parameters)`:
+
+* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
+
+* `url(string $url)`:
+URL of the page you want to screenshot.
+
+* `userAgent(string $userAgent)`:
+Override the default User-Agent HTTP header. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
+
+* `waitDelay(string $delay)`:
+Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML
+document before converting it to screenshot. (default None).
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
+
+* `waitForExpression(string $expression)`:
+Sets the JavaScript expression to wait before converting an HTML
+document to screenshot until it returns true. (default None).
+
+For instance: "window.status === 'ready'".
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
 
 * `webhookConfiguration(string $name)`:
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
+
+* `webhookExtraHeaders(array $extraHeaders)`:
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
 
 * `webhookUrl(string $url, ?string $method)`:
 Sets the webhook for cases of success.
@@ -146,19 +150,9 @@ Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
 
-* `errorWebhookUrl(?string $url, ?string $method)`:
-Sets the webhook for cases of error.
-Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.
+* `width(int $width)`:
+The device screen width in pixels. (Default 800).
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.
-
-* `addCookies(array $cookies)`:
-Add cookies to store in the Chromium cookie jar.
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
+> See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
 

--- a/docs/screenshot/builders_api/UrlScreenshotBuilder.md
+++ b/docs/screenshot/builders_api/UrlScreenshotBuilder.md
@@ -1,182 +1,119 @@
 # UrlScreenshotBuilder
 
-* `addAsset(string $path)`:
-
+<details><summary>`addAsset(string $path)`</summary>
 Adds a file, like an image, font, stylesheet, and so on.
-
-* `addExtraHttpHeaders(array $headers)`:
-
+</details><details><summary>`addExtraHttpHeaders(array $headers)`</summary>
 Adds extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers ](https://gotenberg.dev/docs/routes#custom-http-headers )
-
-* `assets(string $paths)`:
-
+</details><details><summary>`assets(string $paths)`</summary>
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
-
-* `clip(bool $bool)`:
-
+</details><details><summary>`clip(bool $bool)`</summary>
 Define whether to clip the screenshot according to the device dimensions. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `downloadFrom(array $downloadFrom)`:
-
+</details><details><summary>`downloadFrom(array $downloadFrom)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#download-from ](https://gotenberg.dev/docs/routes#download-from )
-
-* `emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`:
-
+</details><details><summary>`emulatedMediaType(Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType $mediaType)`</summary>
 Forces Chromium to emulate, either "screen" or "print". (default "print").<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `extraHttpHeaders(array $headers)`:
-
+</details><details><summary>`extraHttpHeaders(array $headers)`</summary>
 Sets extra HTTP headers that Chromium will send when loading the HTML<br />document. (default None). (overrides any previous headers).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium ](https://gotenberg.dev/docs/routes#custom-http-headers-chromium )
-
-* `failOnConsoleExceptions(bool $bool)`:
-
+</details><details><summary>`failOnConsoleExceptions(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions in the Chromium console. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#console-exceptions](https://gotenberg.dev/docs/routes#console-exceptions)
-
-* `failOnHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from<br />the main page is not acceptable. (default [499,599]). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceHttpStatusCodes(array $statusCodes)`:
-
+</details><details><summary>`failOnResourceHttpStatusCodes(array $statusCodes)`</summary>
 Return a 409 Conflict response if the HTTP status code from at least one resource is not acceptable.<br />(default None). (overrides any previous configuration).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium ](https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium )
-
-* `failOnResourceLoadingFailed(bool $bool)`:
-
+</details><details><summary>`failOnResourceLoadingFailed(bool $bool)`</summary>
 Forces GotenbergScreenshot to return a 409 Conflict response if there are<br />exceptions load at least one resource. (default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#network-errors-chromium](https://gotenberg.dev/docs/routes#network-errors-chromium)
-
-* `format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`:
-
+</details><details><summary>`format(Sensiolabs\GotenbergBundle\Enumeration\ScreenshotFormat $format)`</summary>
 The image compression format, either "png", "jpeg" or "webp". (default png).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `height(int $height)`:
-
+</details><details><summary>`height(int $height)`</summary>
 The device screen width in pixels. (Default 600).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `omitBackground(bool $bool)`:
-
+</details><details><summary>`omitBackground(bool $bool)`</summary>
 Hides default white background and allows generating screenshot with<br />transparency. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#page-properties-chromium](https://gotenberg.dev/docs/routes#page-properties-chromium)
-
-* `optimizeForSpeed(bool $bool)`:
-
+</details><details><summary>`optimizeForSpeed(bool $bool)`</summary>
 Define whether to optimize image encoding for speed, not for resulting size. (Default false).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `quality(int $quality)`:
-
+</details><details><summary>`quality(int $quality)`</summary>
 The compression quality from range 0 to 100 (jpeg only). (default 100).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `route(string $name, array $parameters)`:
-
-* `setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`:
-
-* `skipNetworkIdleEvent(bool $bool)`:
-
-* `url(string $url)`:
-
+</details><details><summary>`route(string $name, array $parameters)`</summary></details><details><summary>`setRequestContext(?Symfony\Component\Routing\RequestContext $requestContext)`</summary></details><details><summary>`skipNetworkIdleEvent(bool $bool)`</summary></details><details><summary>`url(string $url)`</summary>
 URL of the page you want to screenshot.
-
-* `userAgent(string $userAgent)`:
-
+</details><details><summary>`userAgent(string $userAgent)`</summary>
 Override the default User-Agent HTTP header. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#custom-http-headers-chromium](https://gotenberg.dev/docs/routes#custom-http-headers-chromium)
-
-* `waitDelay(string $delay)`:
-
+</details><details><summary>`waitDelay(string $delay)`</summary>
 Sets the duration (i.e., "1s", "2ms", etc.) to wait when loading an HTML<br />document before converting it to screenshot. (default None).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `waitForExpression(string $expression)`:
-
+</details><details><summary>`waitForExpression(string $expression)`</summary>
 Sets the JavaScript expression to wait before converting an HTML<br />document to screenshot until it returns true. (default None).<br /><br />For instance: "window.status === 'ready'".<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#wait-before-rendering](https://gotenberg.dev/docs/routes#wait-before-rendering)
-
-* `width(int $width)`:
-
+</details><details><summary>`width(int $width)`</summary>
 The device screen width in pixels. (Default 800).<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#screenshots-route](https://gotenberg.dev/docs/routes#screenshots-route)
-
-* `errorWebhookUrl(?string $url, ?string $method)`:
-
+</details><details><summary>`errorWebhookUrl(?string $url, ?string $method)`</summary>
 Sets the webhook for cases of error.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `webhookConfiguration(string $name)`:
-
+</details><details><summary>`webhookConfiguration(string $name)`</summary>
 Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.
-
-* `webhookExtraHeaders(array $extraHeaders)`:
-
+</details><details><summary>`webhookExtraHeaders(array $extraHeaders)`</summary>
 Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
-
-* `webhookUrl(string $url, ?string $method)`:
-
+</details><details><summary>`webhookUrl(string $url, ?string $method)`</summary>
 Sets the webhook for cases of success.<br />Optionaly sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook](https://gotenberg.dev/docs/webhook)
-
-* `addCookies(array $cookies)`:
-
+</details><details><summary>`addCookies(array $cookies)`</summary>
 Add cookies to store in the Chromium cookie jar.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `cookies(array $cookies)`:
-
+</details><details><summary>`cookies(array $cookies)`</summary>
 > [!TIP]
 > See: [https://gotenberg.dev/docs/routes#cookies-chromium ](https://gotenberg.dev/docs/routes#cookies-chromium )
-
-* `forwardCookie(string $name)`:
-
-* `setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`:
-
+</details><details><summary>`forwardCookie(string $name)`</summary></details><details><summary>`setCookie(string $key, Symfony\Component\HttpFoundation\Cookie|array $cookie)`</summary></details>

--- a/src/Builder/AsyncBuilderTrait.php
+++ b/src/Builder/AsyncBuilderTrait.php
@@ -5,6 +5,9 @@ namespace Sensiolabs\GotenbergBundle\Builder;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 
+/**
+ * @package Behavior\\Async
+ */
 trait AsyncBuilderTrait
 {
     use DefaultBuilderTrait;

--- a/src/Builder/CookieAwareTrait.php
+++ b/src/Builder/CookieAwareTrait.php
@@ -7,12 +7,13 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\Part\DataPart;
 
+/**
+ * @package Behavior\\Chromium\\Cookie
+ */
 trait CookieAwareTrait
 {
     /**
      * Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
-     *
-     * @package Behavior\\Chromium\\Cookie
      *
      * @see https://gotenberg.dev/docs/routes#cookies-chromium
      *
@@ -48,8 +49,6 @@ trait CookieAwareTrait
     }
 
     /**
-     * @package Behavior\\Chromium\\Cookie
-     *
      * @param Cookie|array{name: string, value: string, domain: string, path?: string|null, secure?: bool|null, httpOnly?: bool|null, sameSite?: 'Strict'|'Lax'|null} $cookie
      */
     abstract public function setCookie(string $key, Cookie|array $cookie): static;
@@ -68,8 +67,6 @@ trait CookieAwareTrait
 
     /**
      * Add cookies to store in the Chromium cookie jar.
-     *
-     * @package Behavior\\Chromium\\Cookie
      *
      * @see https://gotenberg.dev/docs/routes#cookies-chromium
      *
@@ -118,9 +115,6 @@ trait CookieAwareTrait
         ]);
     }
 
-    /**
-     * @package Behavior\\Chromium\\Cookie
-     */
     abstract public function forwardCookie(string $name): static;
 
     /**

--- a/src/Builder/CookieAwareTrait.php
+++ b/src/Builder/CookieAwareTrait.php
@@ -12,6 +12,8 @@ trait CookieAwareTrait
     /**
      * Cookies to store in the Chromium cookie jar. (overrides any previous cookies).
      *
+     * @package Behavior\\Chromium\\Cookie
+     *
      * @see https://gotenberg.dev/docs/routes#cookies-chromium
      *
      * @param list<Cookie|array{name: string, value: string, domain: string, path?: string|null, secure?: bool|null, httpOnly?: bool|null, sameSite?: 'Strict'|'Lax'|null}> $cookies
@@ -46,6 +48,8 @@ trait CookieAwareTrait
     }
 
     /**
+     * @package Behavior\\Chromium\\Cookie
+     *
      * @param Cookie|array{name: string, value: string, domain: string, path?: string|null, secure?: bool|null, httpOnly?: bool|null, sameSite?: 'Strict'|'Lax'|null} $cookie
      */
     abstract public function setCookie(string $key, Cookie|array $cookie): static;
@@ -63,7 +67,9 @@ trait CookieAwareTrait
     }
 
     /**
-     *  Add cookies to store in the Chromium cookie jar.
+     * Add cookies to store in the Chromium cookie jar.
+     *
+     * @package Behavior\\Chromium\\Cookie
      *
      * @see https://gotenberg.dev/docs/routes#cookies-chromium
      *
@@ -112,6 +118,9 @@ trait CookieAwareTrait
         ]);
     }
 
+    /**
+     * @package Behavior\\Chromium\\Cookie
+     */
     abstract public function forwardCookie(string $name): static;
 
     /**

--- a/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
+++ b/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
@@ -80,17 +80,11 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
-    /**
-     * @param list<Cookie|array{name: string, value: string, domain: string, path?: string|null, secure?: bool|null, httpOnly?: bool|null, sameSite?: 'Strict'|'Lax'|null}> $cookies
-     */
     public function cookies(array $cookies): static
     {
         return $this->withCookies($this->formFields, $cookies);
     }
 
-    /**
-     * @param Cookie|array{name: string, value: string, domain: string, path?: string|null, secure?: bool|null, httpOnly?: bool|null, sameSite?: 'Strict'|'Lax'|null} $cookie
-     */
     public function setCookie(string $key, Cookie|array $cookie): static
     {
         return $this->withCookie($this->formFields, $key, $cookie);

--- a/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
+++ b/src/Builder/Pdf/AbstractChromiumPdfBuilder.php
@@ -99,6 +99,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Define whether to print the entire content in one single page.
      *
      * If the singlePage form field is set to true, it automatically overrides the values from the paperHeight and nativePageRanges form fields.
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function singlePage(bool $bool = true): static
     {
@@ -125,6 +127,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * A6 - 4.13 x 5.83
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function paperSize(float $width, float $height, Unit $unit = Unit::Inches): static
     {
@@ -134,6 +138,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function paperStandardSize(PaperSizeInterface $paperSize): static
     {
         $this->paperWidth($paperSize->width(), $paperSize->unit());
@@ -142,6 +149,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function paperWidth(float $width, Unit $unit = Unit::Inches): static
     {
         $this->formFields['paperWidth'] = $width.$unit->value;
@@ -149,6 +159,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function paperHeight(float $height, Unit $unit = Unit::Inches): static
     {
         $this->formFields['paperHeight'] = $height.$unit->value;
@@ -160,6 +173,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Overrides the default margins (e.g., 0.39), in inches.
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function margins(float $top, float $bottom, float $left, float $right, Unit $unit = Unit::Inches): static
     {
@@ -171,6 +186,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function marginTop(float $top, Unit $unit = Unit::Inches): static
     {
         $this->formFields['marginTop'] = $top.$unit->value;
@@ -178,6 +196,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function marginBottom(float $bottom, Unit $unit = Unit::Inches): static
     {
         $this->formFields['marginBottom'] = $bottom.$unit->value;
@@ -185,6 +206,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function marginLeft(float $left, Unit $unit = Unit::Inches): static
     {
         $this->formFields['marginLeft'] = $left.$unit->value;
@@ -192,6 +216,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Chromium\\PageProperties
+     */
     public function marginRight(float $right, Unit $unit = Unit::Inches): static
     {
         $this->formFields['marginRight'] = $right.$unit->value;
@@ -203,6 +230,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Define whether to prefer page size as defined by CSS. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function preferCssPageSize(bool $bool = true): static
     {
@@ -215,6 +244,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Define whether the document outline should be embedded into the PDF. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function generateDocumentOutline(bool $bool = true): static
     {
@@ -227,6 +258,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Prints the background graphics. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function printBackground(bool $bool = true): static
     {
@@ -240,6 +273,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * transparency. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function omitBackground(bool $bool = true): static
     {
@@ -252,6 +287,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Sets the paper orientation to landscape. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function landscape(bool $bool = true): static
     {
@@ -264,6 +301,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * The scale of the page rendering (e.g., 1.0). (Default 1.0).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function scale(float $scale): static
     {
@@ -276,6 +315,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Page ranges to print, e.g., '1-5, 8, 11-13'. (default All pages).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function nativePageRanges(string $range): static
     {
@@ -288,6 +329,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
+     * @package Behavior\\Content
+     *
      * @throws PdfPartRenderingException if the template could not be rendered
      */
     public function header(string $template, array $context = []): static
@@ -299,6 +342,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
+     * @package Behavior\\Content
+     *
      * @throws PdfPartRenderingException if the template could not be rendered
      */
     public function footer(string $template, array $context = []): static
@@ -308,6 +353,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
 
     /**
      * HTML file containing the header. (default None).
+     *
+     * @package Behavior\\Content
      */
     public function headerFile(string $path): static
     {
@@ -316,6 +363,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
 
     /**
      * HTML file containing the footer. (default None).
+     *
+     * @package Behavior\\Content
      */
     public function footerFile(string $path): static
     {
@@ -324,6 +373,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
 
     /**
      * Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+     *
+     * @package Behavior\\Assets
      */
     public function assets(string ...$paths): static
     {
@@ -338,6 +389,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
 
     /**
      * Adds a file, like an image, font, stylesheet, and so on.
+     *
+     * @package Behavior\\Assets
      */
     public function addAsset(string $path): static
     {
@@ -355,6 +408,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * document before converting it to PDF. (default None).
      *
      * @see https://gotenberg.dev/docs/routes#wait-before-rendering
+     *
+     * @package Behavior\\Chromium\\WaitFor
      */
     public function waitDelay(string $delay): static
     {
@@ -370,6 +425,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * For instance: "window.status === 'ready'".
      *
      * @see https://gotenberg.dev/docs/routes#wait-before-rendering
+     *
+     * @package Behavior\\Chromium\\WaitFor
      */
     public function waitForExpression(string $expression): static
     {
@@ -382,6 +439,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * Forces Chromium to emulate, either "screen" or "print". (default "print").
      *
      * @see https://gotenberg.dev/docs/routes#console-exceptions
+     *
+     * @package Behavior\\MediaType
      */
     public function emulatedMediaType(EmulatedMediaType $mediaType): static
     {
@@ -393,9 +452,11 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
     /**
      * Override the default User-Agent HTTP header. (default None).
      *
+     * @see https://gotenberg.dev/docs/routes#custom-http-headers-chromium
+     *
      * @param UserAgent::*|string $userAgent
      *
-     * @see https://gotenberg.dev/docs/routes#custom-http-headers-chromium
+     * @package Behavior\\Http\\CustomHeaders
      */
     public function userAgent(string $userAgent): static
     {
@@ -411,6 +472,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * @see https://gotenberg.dev/docs/routes#custom-http-headers-chromium
      *
      * @param array<string, string> $headers
+     *
+     * @package Behavior\\Http\\CustomHeaders
      */
     public function extraHttpHeaders(array $headers): static
     {
@@ -432,6 +495,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * @see https://gotenberg.dev/docs/routes#custom-http-headers
      *
      * @param array<string, string> $headers
+     *
+     * @package Behavior\\Http\\CustomHeaders
      */
     public function addExtraHttpHeaders(array $headers): static
     {
@@ -451,6 +516,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * @see https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium
      *
      * @param array<int, int> $statusCodes
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnHttpStatusCodes(array $statusCodes): static
     {
@@ -466,6 +533,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * @see https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium
      *
      * @param list<int<100, 599>> $statusCodes
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnResourceHttpStatusCodes(array $statusCodes): static
     {
@@ -479,6 +548,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * exceptions load at least one resource. (default false).
      *
      * @see https://gotenberg.dev/docs/routes#network-errors-chromium
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnResourceLoadingFailed(bool $bool = true): static
     {
@@ -492,6 +563,8 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
      * exceptions in the Chromium console. (default false).
      *
      * @see https://gotenberg.dev/docs/routes#console-exceptions
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnConsoleExceptions(bool $bool = true): static
     {
@@ -500,6 +573,9 @@ abstract class AbstractChromiumPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
+    /**
+     * @package Behavior\\Performance
+     */
     public function skipNetworkIdleEvent(bool $bool = true): static
     {
         $this->formFields['skipNetworkIdleEvent'] = $bool;

--- a/src/Builder/Pdf/HtmlPdfBuilder.php
+++ b/src/Builder/Pdf/HtmlPdfBuilder.php
@@ -14,6 +14,8 @@ final class HtmlPdfBuilder extends AbstractChromiumPdfBuilder
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
+     * @package Behavior\\Content
+     *
      * @throws PdfPartRenderingException if the template could not be rendered
      */
     public function content(string $template, array $context = []): self
@@ -23,6 +25,8 @@ final class HtmlPdfBuilder extends AbstractChromiumPdfBuilder
 
     /**
      * The HTML file to convert into PDF.
+     *
+     * @package Behavior\\Content
      */
     public function contentFile(string $path): self
     {

--- a/src/Builder/Screenshot/AbstractChromiumScreenshotBuilder.php
+++ b/src/Builder/Screenshot/AbstractChromiumScreenshotBuilder.php
@@ -95,6 +95,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * The device screen width in pixels. (Default 800).
      *
      * @see https://gotenberg.dev/docs/routes#screenshots-route
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function width(int $width): static
     {
@@ -107,6 +109,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * The device screen width in pixels. (Default 600).
      *
      * @see https://gotenberg.dev/docs/routes#screenshots-route
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function height(int $height): static
     {
@@ -119,6 +123,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * Define whether to clip the screenshot according to the device dimensions. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#screenshots-route
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function clip(bool $bool = true): static
     {
@@ -131,6 +137,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * The image compression format, either "png", "jpeg" or "webp". (default png).
      *
      * @see https://gotenberg.dev/docs/routes#screenshots-route
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function format(ScreenshotFormat $format): static
     {
@@ -145,6 +153,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * @param int<0, 100> $quality
      *
      * @see https://gotenberg.dev/docs/routes#screenshots-route
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function quality(int $quality): static
     {
@@ -158,6 +168,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * transparency. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#page-properties-chromium
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function omitBackground(bool $bool = true): static
     {
@@ -170,6 +182,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * Define whether to optimize image encoding for speed, not for resulting size. (Default false).
      *
      * @see https://gotenberg.dev/docs/routes#screenshots-route
+     *
+     * @package Behavior\\Chromium\\PageProperties
      */
     public function optimizeForSpeed(bool $bool = true): static
     {
@@ -183,6 +197,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * document before converting it to screenshot. (default None).
      *
      * @see https://gotenberg.dev/docs/routes#wait-before-rendering
+     *
+     * @package Behavior\\Chromium\\WaitFor
      */
     public function waitDelay(string $delay): static
     {
@@ -198,6 +214,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * For instance: "window.status === 'ready'".
      *
      * @see https://gotenberg.dev/docs/routes#wait-before-rendering
+     *
+     * @package Behavior\\Chromium\\WaitFor
      */
     public function waitForExpression(string $expression): static
     {
@@ -279,6 +297,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * @see https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium
      *
      * @param array<int, int> $statusCodes
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnHttpStatusCodes(array $statusCodes): static
     {
@@ -294,6 +314,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * @see https://gotenberg.dev/docs/routes#invalid-http-status-codes-chromium
      *
      * @param list<int<100, 599>> $statusCodes
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnResourceHttpStatusCodes(array $statusCodes): static
     {
@@ -307,6 +329,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * exceptions load at least one resource. (default false).
      *
      * @see https://gotenberg.dev/docs/routes#network-errors-chromium
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnResourceLoadingFailed(bool $bool = true): static
     {
@@ -320,6 +344,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
      * exceptions in the Chromium console. (default false).
      *
      * @see https://gotenberg.dev/docs/routes#console-exceptions
+     *
+     * @package Behavior\\FailOn
      */
     public function failOnConsoleExceptions(bool $bool = true): static
     {
@@ -328,6 +354,9 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
         return $this;
     }
 
+    /**
+     * @package Behavior\\Performance
+     */
     public function skipNetworkIdleEvent(bool $bool = true): static
     {
         $this->formFields['skipNetworkIdleEvent'] = $bool;
@@ -337,6 +366,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
 
     /**
      * Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).
+     *
+     * @package Behavior\\Assets
      */
     public function assets(string ...$paths): static
     {
@@ -351,6 +382,8 @@ abstract class AbstractChromiumScreenshotBuilder extends AbstractScreenshotBuild
 
     /**
      * Adds a file, like an image, font, stylesheet, and so on.
+     *
+     * @package Behavior\\Assets
      */
     public function addAsset(string $path): static
     {

--- a/src/Builder/Screenshot/HtmlScreenshotBuilder.php
+++ b/src/Builder/Screenshot/HtmlScreenshotBuilder.php
@@ -14,6 +14,8 @@ final class HtmlScreenshotBuilder extends AbstractChromiumScreenshotBuilder
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
+     * @package Behavior\\Content
+     *
      * @throws ScreenshotPartRenderingException if the template could not be rendered
      */
     public function content(string $template, array $context = []): self
@@ -23,6 +25,8 @@ final class HtmlScreenshotBuilder extends AbstractChromiumScreenshotBuilder
 
     /**
      * The HTML file to convert into Screenshot.
+     *
+     * @package Behavior\\Content
      */
     public function contentFile(string $path): self
     {

--- a/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
+++ b/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
@@ -8,9 +8,6 @@ use Sensiolabs\GotenbergBundle\Exception\ScreenshotPartRenderingException;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\File as DataPartFile;
 
-/**
- * @see https://google.com
- */
 final class MarkdownScreenshotBuilder extends AbstractChromiumScreenshotBuilder
 {
     private const ENDPOINT = '/forms/chromium/screenshot/markdown';

--- a/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
+++ b/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
@@ -8,6 +8,9 @@ use Sensiolabs\GotenbergBundle\Exception\ScreenshotPartRenderingException;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\File as DataPartFile;
 
+/**
+ * @see https://google.com
+ */
 final class MarkdownScreenshotBuilder extends AbstractChromiumScreenshotBuilder
 {
     private const ENDPOINT = '/forms/chromium/screenshot/markdown';


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               |no   |
| New feature ?           | yes   |
| BC break ?              |no   |
| Issues                  | Fix #... |

## Description

Better parsing of phpdoc in case of multlines param + parsing each tag like `see` to be added as a tip

* Easier to maintain
* Handles parent classes / interfaces / traits and overrides on children
* handle sorting of classname / builder types / method names and `@package`
* introduce `@package` to group some method in documentation automatically