### PR TITLE
feat: Allow \SplFileInfo or \Stringable in "files" methods

### DIFF
--- a/src/Builder/Pdf/ConvertPdfBuilder.php
+++ b/src/Builder/Pdf/ConvertPdfBuilder.php
@@ -46,11 +46,12 @@ final class ConvertPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
-    public function files(string ...$paths): self
+    public function files(string|\Stringable ...$paths): self
     {
         $this->formFields['files'] = [];
 
         foreach ($paths as $path) {
+            $path = (string) $path;
             $this->assertFileExtension($path, ['pdf']);
 
             $dataPart = new DataPart(new DataPartFile($this->asset->resolve($path)));

--- a/src/Builder/Pdf/LibreOfficePdfBuilder.php
+++ b/src/Builder/Pdf/LibreOfficePdfBuilder.php
@@ -126,11 +126,13 @@ final class LibreOfficePdfBuilder extends AbstractPdfBuilder
     /**
      * Adds office files to convert (overrides any previous files).
      */
-    public function files(string ...$paths): self
+    public function files(string|\Stringable ...$paths): self
     {
         $this->formFields['files'] = [];
 
         foreach ($paths as $path) {
+            $path = (string) $path;
+
             $this->assertFileExtension($path, self::AVAILABLE_EXTENSIONS);
 
             $dataPart = new DataPart(new DataPartFile($this->asset->resolve($path)));

--- a/src/Builder/Pdf/MarkdownPdfBuilder.php
+++ b/src/Builder/Pdf/MarkdownPdfBuilder.php
@@ -33,11 +33,13 @@ final class MarkdownPdfBuilder extends AbstractChromiumPdfBuilder
         return $this->withPdfPartFile(Part::Body, $path);
     }
 
-    public function files(string ...$paths): self
+    public function files(string|\Stringable ...$paths): self
     {
         $this->formFields['files'] = [];
 
         foreach ($paths as $path) {
+            $path = (string) $path;
+
             $this->assertFileExtension($path, ['md']);
 
             $dataPart = new DataPart(new DataPartFile($this->asset->resolve($path)));

--- a/src/Builder/Pdf/MergePdfBuilder.php
+++ b/src/Builder/Pdf/MergePdfBuilder.php
@@ -49,11 +49,13 @@ final class MergePdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
-    public function files(string ...$paths): self
+    public function files(string|\Stringable ...$paths): self
     {
         $this->formFields['files'] = [];
 
         foreach ($paths as $path) {
+            $path = (string) $path;
+
             $this->assertFileExtension($path, ['pdf']);
 
             $dataPart = new DataPart(new DataPartFile($this->asset->resolve($path)));

--- a/src/Builder/Pdf/SplitPdfBuilder.php
+++ b/src/Builder/Pdf/SplitPdfBuilder.php
@@ -71,11 +71,13 @@ final class SplitPdfBuilder extends AbstractPdfBuilder
         return $this;
     }
 
-    public function files(string ...$paths): self
+    public function files(string|\Stringable ...$paths): self
     {
         $this->formFields['files'] = [];
 
         foreach ($paths as $path) {
+            $path = (string) $path;
+
             $this->assertFileExtension($path, ['pdf']);
 
             $dataPart = new DataPart(new DataPartFile($this->asset->resolve($path)));

--- a/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
+++ b/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
@@ -33,11 +33,13 @@ final class MarkdownScreenshotBuilder extends AbstractChromiumScreenshotBuilder
         return $this->withScreenshotPartFile(Part::Body, $path);
     }
 
-    public function files(string ...$paths): self
+    public function files(string|\Stringable ...$paths): self
     {
         $this->formFields['files'] = [];
 
         foreach ($paths as $path) {
+            $path = (string) $path;
+
             $this->assertFileExtension($path, ['md']);
 
             $dataPart = new DataPart(new DataPartFile($this->asset->resolve($path)));

--- a/tests/Builder/Pdf/MergePdfBuilderTest.php
+++ b/tests/Builder/Pdf/MergePdfBuilderTest.php
@@ -12,6 +12,7 @@ use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Processor\NullProcessor;
 use Sensiolabs\GotenbergBundle\Tests\Builder\AbstractBuilderTestCase;
+use Symfony\Component\Mime\Part\DataPart;
 
 #[CoversClass(MergePdfBuilder::class)]
 #[UsesClass(AbstractPdfBuilder::class)]
@@ -19,7 +20,7 @@ use Sensiolabs\GotenbergBundle\Tests\Builder\AbstractBuilderTestCase;
 #[UsesClass(GotenbergFileResult::class)]
 final class MergePdfBuilderTest extends AbstractBuilderTestCase
 {
-    private const PDF_DOCUMENTS_DIR = 'pdf';
+    public const PDF_DOCUMENTS_DIR = 'pdf';
 
     public function testEndpointIsCorrect(): void
     {
@@ -81,6 +82,38 @@ final class MergePdfBuilderTest extends AbstractBuilderTestCase
         $this->expectExceptionMessage('At least one PDF file is required');
 
         $builder->getMultipartFormData();
+    }
+
+    #[DataProvider('supportedFilePathsProvider')]
+    public function testSupportedFormat(mixed $supportedFilePath): void
+    {
+        $builder = $this->getMergePdfBuilder();
+        $builder
+            ->files($supportedFilePath)
+        ;
+
+        $data = $builder->getMultipartFormData();
+
+        /* @var DataPart $dataPart */
+        self::assertInstanceOf(DataPart::class, $dataPart = $data[0]['files']);
+        self::assertSame(basename((string) $supportedFilePath), $dataPart->getFilename());
+    }
+
+    /**
+     * @return array<list<string|\Stringable>>
+     */
+    public static function supportedFilePathsProvider(): array
+    {
+        return [
+            [self::PDF_DOCUMENTS_DIR.'/simple_pdf.pdf'],
+            [new class implements \Stringable {
+                public function __toString(): string
+                {
+                    return MergePdfBuilderTest::PDF_DOCUMENTS_DIR.'/simple_pdf.pdf';
+                }
+            }],
+            [new \SplFileInfo(self::PDF_DOCUMENTS_DIR.'/simple_pdf.pdf')],
+        ];
     }
 
     private function getMergePdfBuilder(): MergePdfBuilder


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | yes   |
| BC break ?              | no   |
| Issues                  | Fix #96  |

## Description

<!-- 
    Explain the feature/bugfix and explain why you chose this implementation.
    If this is linked to a Gotenberg release please provide link to documentation 
    and release.
-->
