### PR TITLE
AssetBaseDirFormatter Trim windows paths

### DIFF
--- a/src/Formatter/AssetBaseDirFormatter.php
+++ b/src/Formatter/AssetBaseDirFormatter.php
@@ -15,7 +15,7 @@ final class AssetBaseDirFormatter
         private readonly string $projectDir,
         string $baseDir,
     ) {
-        $this->baseDir = rtrim($baseDir, '/');
+        $this->baseDir = rtrim($baseDir, '/\\');
     }
 
     public function resolve(string $path): string


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #... |

## Description

To be fair, this does not change a thing at runtime, as `$this->baseDir` is only consumed by `Path::join(...)` method (that does this already)... for now.

But for defensive programmation it's also done in the constructor.

Then, to enforce the same behaviour on windows... let's trim both path spearators
