### PR TITLE
Deprecate `gotenberg_font` to use `gotenberg_font_style_tag` and `gotenberg_font_face` instead

### DIFF
--- a/UPGRADE-0.4.md
+++ b/UPGRADE-0.4.md
@@ -1,0 +1,36 @@
+# UPGRADE FROM 0.3.1 to 0.4.0
+
+## DEPRECATED
+
+- Deprecate `gotenberg_font`, use `gotenberg_font_face` or
+`gotenberg_font_style_tag` instead.
+
+*Before*
+```html
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>PDF with Custom Font</title>
+        <style>
+            {{ gotenberg_font('fonts/custom-font.ttf', 'my_font') }}
+        </style>
+    </head>
+    <!-- rest of your code -->
+</html>
+```
+
+*After*
+```html
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>PDF with Custom Font</title>
+        <style>
+            {{ gotenberg_font_face('fonts/custom-font.ttf', 'my_font') }}
+        </style>
+    </head>
+    <!-- rest of your code -->
+</html>
+```

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -21,7 +21,12 @@ but it generates a `@font-face` rule that can be used inside a `<style>` block.
 The `{{ gotenberg_font() }}` function helps generate an `@font-face` 
 declaration with the correct asset path expected by gotenberg.
 
-### Example
+> [!NOTE]
+> "gotenberg_font" is deprecated and will be removed in v1.x. use 
+> "gotenberg_font_face" to get the same behavior, or use 
+> "gotenberg_font_style_tag" to get a `style` tag around your font import.
+
+### Example with "gotenberg_font"
 
 ```html
 <!DOCTYPE html>
@@ -56,6 +61,55 @@ declaration with the correct asset path expected by gotenberg.
                 font-family: "my_font";
                 src: url("custom-font.ttf");
             }
+            h1 {
+                color: red;
+                font-family: "my_font";
+            }
+        </style>
+    </head>
+    <body>
+        <h1>This text uses the custom font.</h1>
+    </body>
+</html>
+```
+
+### Example with "gotenberg_font_style_tag"
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>PDF with Custom Font</title>
+        {{ gotenberg_font_style_tag('fonts/custom-font.ttf', 'my_font') }}
+        <style>
+            h1 {
+                color: red;
+                font-family: "my_font";
+            }
+        </style>
+    </head>
+    <body>
+        <h1>This text uses the custom font.</h1>
+    </body>
+</html>
+```
+
+### Output
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>PDF with Custom Font</title>
+        <style>
+            @font-face {
+                font-family: "my_font";
+                src: url("custom-font.ttf");
+            }
+        </style>
+        <style>
             h1 {
                 color: red;
                 font-family: "my_font";

--- a/src/Twig/GotenbergExtension.php
+++ b/src/Twig/GotenbergExtension.php
@@ -14,7 +14,7 @@ final class GotenbergExtension extends AbstractExtension
             new TwigFunction('gotenberg_asset', [GotenbergRuntime::class, 'getAssetUrl']),
             new TwigFunction('gotenberg_font', [GotenbergRuntime::class, 'getFont'], ['is_safe' => ['html'], 'deprecation_info' => new DeprecatedCallableInfo('GotenbergBundle', '0.4.0', 'gotenberg_font_style_tag')]),
             new TwigFunction('gotenberg_font_style_tag', [GotenbergRuntime::class, 'getFontStyleTag'], ['is_safe' => ['html']]),
-            new TwigFunction('gotenberg_font_face', [GotenbergRuntime::class, 'getFontFace'], ['is_safe' => ['html']]),
+            new TwigFunction('gotenberg_font_face', [GotenbergRuntime::class, 'getFontFace'], ['is_safe' => ['css']]),
         ];
     }
 }

--- a/src/Twig/GotenbergExtension.php
+++ b/src/Twig/GotenbergExtension.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Twig;
 
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -11,7 +12,8 @@ final class GotenbergExtension extends AbstractExtension
     {
         return [
             new TwigFunction('gotenberg_asset', [GotenbergRuntime::class, 'getAssetUrl']),
-            new TwigFunction('gotenberg_font', [GotenbergRuntime::class, 'getFont'], ['is_safe' => ['html']]),
+            new TwigFunction('gotenberg_font', [GotenbergRuntime::class, 'getFont'], ['is_safe' => ['html'], 'deprecation_info' => new DeprecatedCallableInfo('GotenbergBundle', 'v1.x', 'gotenberg_font_style_tag')]),
+            new TwigFunction('gotenberg_font_style_tag', [GotenbergRuntime::class, 'getFontStyleTag'], ['is_safe' => ['html']]),
         ];
     }
 }

--- a/src/Twig/GotenbergExtension.php
+++ b/src/Twig/GotenbergExtension.php
@@ -14,6 +14,7 @@ final class GotenbergExtension extends AbstractExtension
             new TwigFunction('gotenberg_asset', [GotenbergRuntime::class, 'getAssetUrl']),
             new TwigFunction('gotenberg_font', [GotenbergRuntime::class, 'getFont'], ['is_safe' => ['html'], 'deprecation_info' => new DeprecatedCallableInfo('GotenbergBundle', '0.4.0', 'gotenberg_font_style_tag')]),
             new TwigFunction('gotenberg_font_style_tag', [GotenbergRuntime::class, 'getFontStyleTag'], ['is_safe' => ['html']]),
+            new TwigFunction('gotenberg_font_face', [GotenbergRuntime::class, 'getFontFace'], ['is_safe' => ['html']]),
         ];
     }
 }

--- a/src/Twig/GotenbergExtension.php
+++ b/src/Twig/GotenbergExtension.php
@@ -12,7 +12,7 @@ final class GotenbergExtension extends AbstractExtension
     {
         return [
             new TwigFunction('gotenberg_asset', [GotenbergRuntime::class, 'getAssetUrl']),
-            new TwigFunction('gotenberg_font', [GotenbergRuntime::class, 'getFont'], ['is_safe' => ['html'], 'deprecation_info' => new DeprecatedCallableInfo('GotenbergBundle', 'v1.x', 'gotenberg_font_style_tag')]),
+            new TwigFunction('gotenberg_font', [GotenbergRuntime::class, 'getFont'], ['is_safe' => ['html'], 'deprecation_info' => new DeprecatedCallableInfo('GotenbergBundle', '0.4.0', 'gotenberg_font_style_tag')]),
             new TwigFunction('gotenberg_font_style_tag', [GotenbergRuntime::class, 'getFontStyleTag'], ['is_safe' => ['html']]),
         ];
     }

--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -55,14 +55,7 @@ final class GotenbergRuntime
         $name = htmlspecialchars($name);
         $basename = htmlspecialchars(basename($path));
 
-        return <<<HTML
-            <style>
-                @font-face {
-                    font-family: "{$name}";
-                    src: url("{$basename}");
-                }
-            </style>
-        HTML;
+        return '<style>@font-face {font-family: "'.$name.'";src: url("'.$basename.'");}</style>';
     }
 
     private function addAsset(string $path, string $function): void

--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -52,10 +52,22 @@ final class GotenbergRuntime
     {
         $this->addAsset($path, 'gotenberg_font_style_tag');
 
+        return '<style>'.$this->generateFontFace($path, $name).'</style>';
+    }
+
+    public function getFontFace(string $path, string $name): string
+    {
+        $this->addAsset($path, 'gotenberg_font_face');
+
+        return $this->generateFontFace($path, $name);
+    }
+
+    private function generateFontFace(string $path, string $name): string
+    {
         $name = htmlspecialchars($name);
         $basename = htmlspecialchars(basename($path));
 
-        return '<style>@font-face {font-family: "'.$name.'";src: url("'.$basename.'");}</style>';
+        return '@font-face {font-family: "'.$name.'";src: url("'.$basename.'");}';
     }
 
     private function addAsset(string $path, string $function): void

--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -31,6 +31,9 @@ final class GotenbergRuntime
         return basename($path);
     }
 
+    /**
+     * @deprecated use "gotenberg_font_style_tag" instead
+     */
     public function getFont(string $path, string $name): string
     {
         $this->addAsset($path, 'gotenberg_font');
@@ -43,6 +46,23 @@ final class GotenbergRuntime
                 src: url("'.$basename.'");
             }'
         ;
+    }
+
+    public function getFontStyleTag(string $path, string $name): string
+    {
+        $this->addAsset($path, 'gotenberg_font_style_tag');
+
+        $name = htmlspecialchars($name);
+        $basename = htmlspecialchars(basename($path));
+
+        return <<<HTML
+            <style>
+                @font-face {
+                    font-family: "{$name}";
+                    src: url("{$basename}");
+                }
+            </style>
+        HTML;
     }
 
     private function addAsset(string $path, string $function): void

--- a/tests/Builder/Pdf/AbstractChromiumPdfBuilderTest.php
+++ b/tests/Builder/Pdf/AbstractChromiumPdfBuilderTest.php
@@ -454,7 +454,6 @@ class AbstractChromiumPdfBuilderTest extends AbstractBuilderTestCase
     public function testThrowIfTwigTemplateIsInvalid(): void
     {
         $this->expectException(PdfPartRenderingException::class);
-        $this->expectExceptionMessage('Could not render template "templates/invalid.html.twig" into PDF part "header.html". Unexpected character "!".');
 
         $builder = $this->getChromiumPdfBuilder();
         $builder->header('templates/invalid.html.twig');

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -117,15 +117,6 @@ class GotenbergRuntimeTest extends TestCase
         $runtime->getFontStyleTag('foo.ttf', 'my_font');
     }
 
-    public function testGetFontStyleTagThrowsWhenBuilderIsNotSet(): void
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The gotenberg_font_style_tag function must be used in a Gotenberg context.');
-        $runtime = new GotenbergRuntime();
-        $runtime->setBuilder(null);
-        $runtime->getFontStyleTag('foo.ttf', 'my_font');
-    }
-
     public function testGetFontStyleTagCallChromiumPdfBuilder(): void
     {
         $runtime = new GotenbergRuntime();
@@ -163,15 +154,6 @@ class GotenbergRuntimeTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The gotenberg_font_face function must be used in a Gotenberg context.');
         $runtime = new GotenbergRuntime();
-        $runtime->getFontFace('foo.ttf', 'my_font');
-    }
-
-    public function testGetFontFaceThrowsWhenBuilderIsNotSet(): void
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('The gotenberg_font_face function must be used in a Gotenberg context.');
-        $runtime = new GotenbergRuntime();
-        $runtime->setBuilder(null);
         $runtime->getFontFace('foo.ttf', 'my_font');
     }
 

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -157,4 +157,53 @@ class GotenbergRuntimeTest extends TestCase
             $runtime->getFontStyleTag('foo.ttf', 'my_font'),
         );
     }
+
+    public function testGetFontFaceThrowsPerDefault(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The gotenberg_font_face function must be used in a Gotenberg context.');
+        $runtime = new GotenbergRuntime();
+        $runtime->getFontFace('foo.ttf', 'my_font');
+    }
+
+    public function testGetFontFaceThrowsWhenBuilderIsNotSet(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The gotenberg_font_face function must be used in a Gotenberg context.');
+        $runtime = new GotenbergRuntime();
+        $runtime->setBuilder(null);
+        $runtime->getFontFace('foo.ttf', 'my_font');
+    }
+
+    public function testGetFontFaceCallChromiumPdfBuilder(): void
+    {
+        $runtime = new GotenbergRuntime();
+        $builder = $this->createMock(AbstractChromiumPdfBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('addAsset')
+            ->with('foo.ttf')
+        ;
+        $runtime->setBuilder($builder);
+        $this->assertSame(
+            '@font-face {font-family: "my_font";src: url("foo.ttf");}',
+            $runtime->getFontFace('foo.ttf', 'my_font'),
+        );
+    }
+
+    public function testGetFontFaceCallChromiumScreenshotBuilder(): void
+    {
+        $runtime = new GotenbergRuntime();
+        $builder = $this->createMock(AbstractChromiumScreenshotBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('addAsset')
+            ->with('foo.ttf')
+        ;
+        $runtime->setBuilder($builder);
+        $this->assertSame(
+            '@font-face {font-family: "my_font";src: url("foo.ttf");}',
+            $runtime->getFontFace('foo.ttf', 'my_font'),
+        );
+    }
 }

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -54,7 +54,7 @@ class GotenbergRuntimeTest extends TestCase
         $this->assertSame('foo', $runtime->getAssetUrl('foo'));
     }
 
-    public function testgetFontThrowsPerDefault(): void
+    public function testGetFontThrowsPerDefault(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The gotenberg_font function must be used in a Gotenberg context.');
@@ -62,7 +62,7 @@ class GotenbergRuntimeTest extends TestCase
         $runtime->getFont('foo.ttf', 'my_font');
     }
 
-    public function testgetFontThrowsWhenBuilderIsNotSet(): void
+    public function testGetFontThrowsWhenBuilderIsNotSet(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The gotenberg_font function must be used in a Gotenberg context.');
@@ -71,7 +71,7 @@ class GotenbergRuntimeTest extends TestCase
         $runtime->getFont('foo.ttf', 'my_font');
     }
 
-    public function testgetFontCallChromiumPdfBuilder(): void
+    public function testGetFontCallChromiumPdfBuilder(): void
     {
         $runtime = new GotenbergRuntime();
         $builder = $this->createMock(AbstractChromiumPdfBuilder::class);
@@ -90,7 +90,7 @@ class GotenbergRuntimeTest extends TestCase
         );
     }
 
-    public function testgetFontCallChromiumScreenshotBuilder(): void
+    public function testGetFontCallChromiumScreenshotBuilder(): void
     {
         $runtime = new GotenbergRuntime();
         $builder = $this->createMock(AbstractChromiumScreenshotBuilder::class);
@@ -106,6 +106,69 @@ class GotenbergRuntimeTest extends TestCase
                 src: url("foo.ttf");
             }',
             $runtime->getFont('foo.ttf', 'my_font'),
+        );
+    }
+
+    public function testGetFontStyleTagThrowsPerDefault(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The gotenberg_font_style_tag function must be used in a Gotenberg context.');
+        $runtime = new GotenbergRuntime();
+        $runtime->getFontStyleTag('foo.ttf', 'my_font');
+    }
+
+    public function testGetFontStyleTagThrowsWhenBuilderIsNotSet(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The gotenberg_font_style_tag function must be used in a Gotenberg context.');
+        $runtime = new GotenbergRuntime();
+        $runtime->setBuilder(null);
+        $runtime->getFontStyleTag('foo.ttf', 'my_font');
+    }
+
+    public function testGetFontStyleTagCallChromiumPdfBuilder(): void
+    {
+        $runtime = new GotenbergRuntime();
+        $builder = $this->createMock(AbstractChromiumPdfBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('addAsset')
+            ->with('foo.ttf')
+        ;
+        $runtime->setBuilder($builder);
+        $this->assertSame(
+            <<<HTML
+                <style>
+                    @font-face {
+                        font-family: "my_font";
+                        src: url("foo.ttf");
+                    }
+                </style>
+            HTML,
+            $runtime->getFontStyleTag('foo.ttf', 'my_font'),
+        );
+    }
+
+    public function testGetFontStyleTagCallChromiumScreenshotBuilder(): void
+    {
+        $runtime = new GotenbergRuntime();
+        $builder = $this->createMock(AbstractChromiumScreenshotBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('addAsset')
+            ->with('foo.ttf')
+        ;
+        $runtime->setBuilder($builder);
+        $this->assertSame(
+            <<<HTML
+                <style>
+                    @font-face {
+                        font-family: "my_font";
+                        src: url("foo.ttf");
+                    }
+                </style>
+            HTML,
+            $runtime->getFontStyleTag('foo.ttf', 'my_font'),
         );
     }
 }

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -137,14 +137,7 @@ class GotenbergRuntimeTest extends TestCase
         ;
         $runtime->setBuilder($builder);
         $this->assertSame(
-            <<<HTML
-                <style>
-                    @font-face {
-                        font-family: "my_font";
-                        src: url("foo.ttf");
-                    }
-                </style>
-            HTML,
+            '<style>@font-face {font-family: "my_font";src: url("foo.ttf");}</style>',
             $runtime->getFontStyleTag('foo.ttf', 'my_font'),
         );
     }
@@ -160,14 +153,7 @@ class GotenbergRuntimeTest extends TestCase
         ;
         $runtime->setBuilder($builder);
         $this->assertSame(
-            <<<HTML
-                <style>
-                    @font-face {
-                        font-family: "my_font";
-                        src: url("foo.ttf");
-                    }
-                </style>
-            HTML,
+            '<style>@font-face {font-family: "my_font";src: url("foo.ttf");}</style>',
             $runtime->getFontStyleTag('foo.ttf', 'my_font'),
         );
     }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | yes  |
| BC break ?              | no   |
| Issues                  | Fix #155  |

## Description

Deprecate `gotenberg_font` to use `gotenberg_font_style_tag` instead. Related to https://github.com/sensiolabs/GotenbergBundle/issues/155#issuecomment-2806261316
