### PR TITLE
Update GotenbergRuntime visibility

### DIFF
--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -4,9 +4,6 @@ namespace Sensiolabs\GotenbergBundle\Twig;
 
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 
-/**
- * @internal
- */
 final class GotenbergRuntime
 {
     private BuilderAssetInterface|null $builder = null;

--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -4,6 +4,12 @@ namespace Sensiolabs\GotenbergBundle\Twig;
 
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 
+/**
+ * @internal
+ *
+ *  This class is marked as internal to allow flexibility in evolving the runtime API.
+ *  However, it is considered safe to use for custom builders or test purposes.
+ */
 final class GotenbergRuntime
 {
     private BuilderAssetInterface|null $builder = null;


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | yes   |
| BC break ?              | no   |

## Description

When I make a custom builder using twig I need to use `GotenbergRuntime` for my tests.