### PR TITLE
Fix README.md bundles.php path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Manually enable the bundle by adding it to the list of registered bundles in you
 
 return [
     // ...
-    SensioLabs\GotenbergBundle\SensioLabsGotenbergBundle::class => ['all' => true],
+    Sensiolabs\GotenbergBundle\SensiolabsGotenbergBundle::class => ['all' => true],
 ];
 ```
 


### PR DESCRIPTION
When using bundle path specified in documentation I got error:

Attempted to load class "SensioLabsGotenbergBundle" from namespace "SensioLabs\GotenbergBundle".\n
    Did you forget a "use" statement for another namespace?