### PR TITLE
docs: Document pageNumber Chromium trick

### DIFF
--- a/docs/pdf/header-footer.md
+++ b/docs/pdf/header-footer.md
@@ -25,6 +25,13 @@ You may have the possibility to add header or footer to your generated PDF.
 > When using header or footer, you need to think about adding margins to your content. Or your header/footer will be under your content.
 > By default, the content will occupy all available space.
 
+> [!TIP]
+> Chromium offers a neat trick to display the page number and the total number of pages.
+> You can use the following HTML code in your header or footer template:
+> ```html
+> Page <span class="pageNumber"></span> / <span class="totalPages"></span>
+> ```
+
 ## Twig file
 
 ```php


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #177 |

## Description

This commit adds a note to the documentation to explain how to use the pageNumber and totalPages classes to display page numbers in the header or footer of a PDF. (thanks Jules)

This addresses issue #177.