### PR TITLE
Fix RequestContext

### DIFF
--- a/src/Builder/Behaviors/Dependencies/RequestContextAwareTrait.php
+++ b/src/Builder/Behaviors/Dependencies/RequestContextAwareTrait.php
@@ -14,13 +14,10 @@ trait RequestContextAwareTrait
     #[SubscribedService('.sensiolabs_gotenberg.request_context', nullable: true, attributes: new Autowire(service: '.sensiolabs_gotenberg.request_context'))]
     protected function getRequestContext(): RequestContext|null
     {
-        if (
-            !$this->container->has('.sensiolabs_gotenberg.request_context')
-            || !($requestContext = $this->container->get('.sensiolabs_gotenberg.request_context')) instanceof RequestContext
-        ) {
+        if (!$this->container->has('.sensiolabs_gotenberg.request_context')) {
             return null;
         }
 
-        return $requestContext;
+        return $this->container->get('.sensiolabs_gotenberg.request_context');
     }
 }

--- a/src/Builder/Behaviors/Dependencies/RequestContextAwareTrait.php
+++ b/src/Builder/Behaviors/Dependencies/RequestContextAwareTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+trait RequestContextAwareTrait
+{
+    use ServiceSubscriberTrait;
+
+    #[SubscribedService('.sensiolabs_gotenberg.request_context', nullable: true, attributes: new Autowire(service: '.sensiolabs_gotenberg.request_context'))]
+    protected function getRequestContext(): RequestContext|null
+    {
+        if (
+            !$this->container->has('.sensiolabs_gotenberg.request_context')
+            || !($requestContext = $this->container->get('.sensiolabs_gotenberg.request_context')) instanceof RequestContext
+        ) {
+            return null;
+        }
+
+        return $requestContext;
+    }
+}

--- a/src/Builder/Pdf/UrlPdfBuilder.php
+++ b/src/Builder/Pdf/UrlPdfBuilder.php
@@ -6,12 +6,10 @@ use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumPdfTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\RequestContextAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
-use Symfony\Component\Routing\RequestContext;
-use Symfony\Contracts\Service\Attribute\SubscribedService;
-use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 /**
  * @see https://gotenberg.dev/docs/routes#url-into-pdf-route
@@ -20,7 +18,7 @@ use Symfony\Contracts\Service\ServiceSubscriberTrait;
 final class UrlPdfBuilder extends AbstractBuilder implements BuilderAssetInterface
 {
     use ChromiumPdfTrait;
-    use ServiceSubscriberTrait;
+    use RequestContextAwareTrait;
 
     public const ENDPOINT = '/forms/chromium/convert/url';
 
@@ -47,19 +45,6 @@ final class UrlPdfBuilder extends AbstractBuilder implements BuilderAssetInterfa
         $this->getBodyBag()->set('route', [$name, $parameters]);
 
         return $this;
-    }
-
-    #[SubscribedService('.sensiolabs_gotenberg.request_context', nullable: true)]
-    protected function getRequestContext(): RequestContext|null
-    {
-        if (
-            !$this->container->has('.sensiolabs_gotenberg.request_context')
-            || !($requestContext = $this->container->get('.sensiolabs_gotenberg.request_context')) instanceof RequestContext
-        ) {
-            return null;
-        }
-
-        return $requestContext;
     }
 
     protected function getEndpoint(): string

--- a/src/Builder/Screenshot/UrlScreenshotBuilder.php
+++ b/src/Builder/Screenshot/UrlScreenshotBuilder.php
@@ -6,18 +6,16 @@ use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumScreenshotTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\RequestContextAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
-use Symfony\Component\Routing\RequestContext;
-use Symfony\Contracts\Service\Attribute\SubscribedService;
-use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 #[WithBuilderConfiguration(type: 'screenshot', name: 'url')]
 final class UrlScreenshotBuilder extends AbstractBuilder implements BuilderAssetInterface
 {
     use ChromiumScreenshotTrait;
-    use ServiceSubscriberTrait;
+    use RequestContextAwareTrait;
 
     public const ENDPOINT = '/forms/chromium/screenshot/url';
 
@@ -46,19 +44,6 @@ final class UrlScreenshotBuilder extends AbstractBuilder implements BuilderAsset
         $this->getBodyBag()->set('route', [$name, $parameters]);
 
         return $this;
-    }
-
-    #[SubscribedService('.sensiolabs_gotenberg.request_context', nullable: true)]
-    protected function getRequestContext(): RequestContext|null
-    {
-        if (
-            !$this->container->has('.sensiolabs_gotenberg.request_context')
-            || !($requestContext = $this->container->get('.sensiolabs_gotenberg.request_context')) instanceof RequestContext
-        ) {
-            return null;
-        }
-
-        return $requestContext;
     }
 
     protected function getEndpoint(): string


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |

## Before

The first argument of SubscribedService attribute is the key. This key will be the key to fin the service into the container.
SubscribedService inject the service into that container depending of the return of the method. Actually the service ID  router.request_context and not the one we register.

```php
#[SubscribedService('.sensiolabs_gotenberg.request_context', nullable: true))]
protected function getRequestContext(): RequestContext|null
```

We can confirm where our service locator is located in usages. (2 service locators: UrlPdfBuilder and UrlScreenshotBuilder)

```bash
php bin/console debug:container RequestContext

  Usages           Symfony\Component\Routing\RequestContext  
                   .16_int~4wgvcGG                           
                   .15_int~4wgvcGG                           
                   .5_int~4wgvcGG                            
                   .4_int~4wgvcGG                            
                   router.default                            
                   router_listener                           
                   .service_locator.Od8PGek                  
                   .service_locator.U_JikAi  
```             
 ```bash         
php bin/console debug:container .sensiolabs_gotenberg.request_context

  Usages           .sensiolabs_gotenberg.webhook_configuration_registry  
```

## Now

By autowire our service it will be that one who will be injected into the container
```php
#[SubscribedService('.sensiolabs_gotenberg.request_context', nullable: true, attributes: new Autowire(service: '.sensiolabs_gotenberg.request_context'))]
```

```bash
php bin/console debug:container RequestContext

  Usages           Symfony\Component\Routing\RequestContext  
                   .16_int~4wgvcGG                           
                   .15_int~4wgvcGG                           
                   .5_int~4wgvcGG                            
                   .4_int~4wgvcGG                            
                   router.default                            
                   router_listener                           
```
 ```bash                 
php bin/console debug:container .sensiolabs_gotenberg.request_context

  Usages           .sensiolabs_gotenberg.webhook_configuration_registry  
                   .service_locator.xrL3zI0                              
                   .service_locator.3XS1pol     
                   