### PR TITLE
Add compatibility with psr/container ^1.0 & psr/log ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "psr/container": "^2.0",
-        "psr/log": "^3.0",
+        "psr/container": "^1.0 || ^2.0",
+        "psr/log": "^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/filesystem": "^6.4 || ^7.0",


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8      |
| Bug fix ?               | no   |
| New feature ?           | no   |
| BC break ?              | no   |

## Description

This PR adds support for :
- `psr/container` version `1.0` by updating the constraint to `^1.0 || ^2.0`.
- `psr/log` version `2.0` by updating the constraint to `^2.0 || ^3.0`.

This change ensures better compatibility across environments using different PSR versions and prevents dependency conflicts with other Symfony components that rely on `psr/container` & `psr/log`

Tested locally with both versions — no breaking changes observed.
