### PR TITLE
feat: Add flatten field for HtmlPdfBuilder - MarkdownPdfBuilder - UrlPdfBuilder - ConvertPdfBuilder

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,9 @@ sensiolabs_gotenberg:
                         name:
                             name:                 ~
                             value:                ~
+
+                    # Flattening PDFs. - default None. https://gotenberg.dev/docs/routes#flatten-chromium
+                    flatten: null
             url:
 
                 # Add default header to the builder.
@@ -493,6 +496,9 @@ sensiolabs_gotenberg:
 
                         # Or the syntax below is also possible
                         # - { name: 'X-Custom-Header', value: 'custom-header-value' }
+
+                    # Flattening PDFs. - default None. https://gotenberg.dev/docs/routes#flatten-chromium
+                    flatten: null
             markdown:
 
                 # Add default header to the builder.
@@ -692,6 +698,9 @@ sensiolabs_gotenberg:
 
                         # Or the syntax below is also possible
                         # - { name: 'X-Custom-Header', value: 'custom-header-value' }
+
+                    # Flattening PDFs. - default None. https://gotenberg.dev/docs/routes#flatten-chromium
+                    flatten: null
             office:
 
                 # Set the password for opening the source file. https://gotenberg.dev/docs/routes#page-properties-libreoffice
@@ -805,6 +814,9 @@ sensiolabs_gotenberg:
 
                 # Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. - default false. https://gotenberg.dev/docs/routes#split-libreoffice
                 split_unify: null
+
+                # Flatten the resulting PDF. - default None. https://gotenberg.dev/docs/routes#flatten-libreoffice
+                flatten: null
             merge:
 
                 # Convert PDF into the given PDF/A format - default None.
@@ -840,6 +852,9 @@ sensiolabs_gotenberg:
                             name:
                                 name:                 ~
                                 value:                ~
+
+                # Flatten the resulting PDF. - default None. https://gotenberg.dev/docs/routes#merge-pdfs-route
+                flatten: null
             convert:
 
                 # Convert PDF into the given PDF/A format - default None.
@@ -869,6 +884,43 @@ sensiolabs_gotenberg:
 
                 # Specify whether to put extracted pages into a single file or as many files as there are page ranges. Only works with pages mode. - default false. https://gotenberg.dev/docs/routes#split-libreoffice
                 split_unify: null
+
+                # Convert PDF into the given PDF/A format - default None.
+                pdf_format:           null # One of "PDF\/A-1b"; "PDF\/A-2b"; "PDF\/A-3b"
+
+                # Enable PDF for Universal Access for optimal accessibility - default false.
+                pdf_universal_access: null
+
+                # The metadata to write. Not all metadata are writable. Consider taking a look at https://exiftool.org/TagNames/XMP.html#pdf for an (exhaustive?) list of available metadata.
+                metadata:
+                    Author:               ~
+                    Copyright:            ~
+                    CreationDate:         ~
+                    Creator:              ~
+                    Keywords:             ~
+                    Marked:               ~
+                    ModDate:              ~
+                    PDFVersion:           ~
+                    Producer:             ~
+                    Subject:              ~
+                    Title:                ~
+                    Trapped:              ~ # One of "True"; "False"; "Unknown"
+
+                # Flatten the resulting PDF. - default None. https://gotenberg.dev/docs/routes#split-pdfs-route
+                flatten: null
+
+                # URLs to download files from (JSON format). - default None. https://gotenberg.dev/docs/routes#split-pdfs-route
+                download_from:
+
+                    # Prototype
+                    -
+                        url:                  ~
+                        extraHttpHeaders:
+
+                            # Prototype
+                            name:
+                                name:                 ~
+                                value:                ~
         screenshot:
             html:
 

--- a/docs/pdf/ConvertPdfBuilder.md
+++ b/docs/pdf/ConvertPdfBuilder.md
@@ -45,6 +45,7 @@ class YourController
 
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [files](#filesstringablestring-paths)
+- [flatten](#flattenbool-bool)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
 - [webhook](#webhookarray-webhook)
@@ -77,6 +78,21 @@ If you provide multiple PDF files you will get ZIP folder containing all the con
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->files('document.pdf', __DIR__'/../../public/document_2.pdf')
+    ->generate()
+    ->stream()
+;
+```
+
+### flatten(bool \$bool)
+Flattening a PDF combines all its contents into a single layer. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#flatten-libreoffice](https://gotenberg.dev/docs/routes#flatten-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->flatten() // is same as `->flatten(true)`
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -81,6 +81,7 @@ class YourController
 
 - [addMetadata](#addmetadatastring-key-string-value)
 - [downloadFrom](#downloadfromarray-downloadfrom)
+- [flatten](#flattenbool-bool)
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
@@ -158,6 +159,21 @@ Sets download from to download each entry (file) in parallel (URLs MUST return a
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->downloadFrom([['url' => 'http://example.com/url/to/file', 'extraHttpHeaders' => ['MyHeader' => 'MyValue']], ['url' => 'http://example.com/url/to/file', 'extraHttpHeaders' => ['MyHeaderOne' => 'MyValue', 'MyHeaderTwo' => 'MyValue']]])
+    ->generate()
+    ->stream()
+;
+```
+
+### flatten(bool \$bool)
+Flattening a PDF combines all its contents into a single layer. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#flatten-libreoffice](https://gotenberg.dev/docs/routes#flatten-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->flatten() // is same as `->flatten(true)`
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -124,6 +124,7 @@ class YourController
 - [addMetadata](#addmetadatastring-key-string-value)
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [files](#filesstringablestring-paths)
+- [flatten](#flattenbool-bool)
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
@@ -216,6 +217,21 @@ Add Markdown into a PDF.<br /><br />Required to generate a PDF from Markdown bui
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->files('header.md','content.md','footer.md')
+    ->generate()
+    ->stream()
+;
+```
+
+### flatten(bool \$bool)
+Flattening a PDF combines all its contents into a single layer. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#flatten-libreoffice](https://gotenberg.dev/docs/routes#flatten-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->flatten() // is same as `->flatten(true)`
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -71,6 +71,7 @@ class YourController
 
 - [addMetadata](#addmetadatastring-key-string-value)
 - [downloadFrom](#downloadfromarray-downloadfrom)
+- [flatten](#flattenbool-bool)
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
@@ -150,6 +151,21 @@ Sets download from to download each entry (file) in parallel (URLs MUST return a
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->downloadFrom([['url' => 'http://example.com/url/to/file', 'extraHttpHeaders' => ['MyHeader' => 'MyValue']], ['url' => 'http://example.com/url/to/file', 'extraHttpHeaders' => ['MyHeaderOne' => 'MyValue', 'MyHeaderTwo' => 'MyValue']]])
+    ->generate()
+    ->stream()
+;
+```
+
+### flatten(bool \$bool)
+Flattening a PDF combines all its contents into a single layer. (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/routes#flatten-libreoffice](https://gotenberg.dev/docs/routes#flatten-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->flatten() // is same as `->flatten(true)`
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/ChromiumPdfTrait.php
+++ b/src/Builder/Behaviors/ChromiumPdfTrait.php
@@ -14,6 +14,7 @@ trait ChromiumPdfTrait
     use Chromium\PerformanceModeTrait;
     use Chromium\WaitBeforeRenderingTrait;
     use DownloadFromTrait;
+    use FlattenTrait;
     use MetadataTrait;
     use PdfFormatTrait;
     use SplitTrait;

--- a/src/Builder/Pdf/ConvertPdfBuilder.php
+++ b/src/Builder/Pdf/ConvertPdfBuilder.php
@@ -7,6 +7,7 @@ use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\FlattenTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\PdfFormatTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
@@ -23,6 +24,7 @@ final class ConvertPdfBuilder extends AbstractBuilder
 {
     use AssetBaseDirFormatterAwareTrait;
     use DownloadFromTrait;
+    use FlattenTrait;
     use PdfFormatTrait;
     use WebhookTrait;
 

--- a/tests/Builder/Behaviors/ChromiumPdfTestCaseTrait.php
+++ b/tests/Builder/Behaviors/ChromiumPdfTestCaseTrait.php
@@ -36,6 +36,9 @@ trait ChromiumPdfTestCaseTrait
     /** @use DownloadFromTestCaseTrait<T> */
     use DownloadFromTestCaseTrait;
 
+    /** @use FlattenTestCaseTrait<T> */
+    use FlattenTestCaseTrait;
+
     /** @use MetadataTestCaseTrait<T> */
     use MetadataTestCaseTrait;
 

--- a/tests/Builder/Pdf/ConvertPdfBuilderTest.php
+++ b/tests/Builder/Pdf/ConvertPdfBuilderTest.php
@@ -8,6 +8,7 @@ use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Test\Builder\GotenbergBuilderTestCase;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\DownloadFromTestCaseTrait;
+use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\FlattenTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\PdfFormatTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\WebhookTestCaseTrait;
 use Symfony\Component\DependencyInjection\Container;
@@ -19,6 +20,9 @@ final class ConvertPdfBuilderTest extends GotenbergBuilderTestCase
 {
     /** @use DownloadFromTestCaseTrait<ConvertPdfBuilder> */
     use DownloadFromTestCaseTrait;
+
+    /** @use FlattenTestCaseTrait<ConvertPdfBuilder> */
+    use FlattenTestCaseTrait;
 
     /** @use PdfFormatTestCaseTrait<ConvertPdfBuilder> */
     use PdfFormatTestCaseTrait;

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -262,7 +262,6 @@ final class ConfigurationTest extends TestCase
                         'header' => [
                             'context' => [],
                         ],
-                        'flatten' => null,
                     ],
                     'url' => [
                         'cookies' => [],
@@ -285,7 +284,6 @@ final class ConfigurationTest extends TestCase
                         'header' => [
                             'context' => [],
                         ],
-                        'flatten' => null,
                     ],
                     'markdown' => [
                         'cookies' => [],
@@ -308,7 +306,6 @@ final class ConfigurationTest extends TestCase
                         'header' => [
                             'context' => [],
                         ],
-                        'flatten' => null,
                     ],
                     'office' => [
                         'download_from' => [],
@@ -343,7 +340,6 @@ final class ConfigurationTest extends TestCase
                             ],
                             'extra_http_headers' => [],
                         ],
-                        'flatten' => null,
                     ],
                     'split' => [
                         'download_from' => [],

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -262,6 +262,7 @@ final class ConfigurationTest extends TestCase
                         'header' => [
                             'context' => [],
                         ],
+                        'flatten' => null,
                     ],
                     'url' => [
                         'cookies' => [],
@@ -284,6 +285,7 @@ final class ConfigurationTest extends TestCase
                         'header' => [
                             'context' => [],
                         ],
+                        'flatten' => null,
                     ],
                     'markdown' => [
                         'cookies' => [],
@@ -306,6 +308,7 @@ final class ConfigurationTest extends TestCase
                         'header' => [
                             'context' => [],
                         ],
+                        'flatten' => null,
                     ],
                     'office' => [
                         'download_from' => [],
@@ -340,6 +343,7 @@ final class ConfigurationTest extends TestCase
                             ],
                             'extra_http_headers' => [],
                         ],
+                        'flatten' => null,
                     ],
                     'split' => [
                         'download_from' => [],


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.16.0  |
| Bug fix ?               | no   |
| New feature ?           | yes   |
| BC break ?              | no   |
| Issues                  | Fix #191  |

## Description

Add flatten for `HtmlPdfBuilder` - `MarkdownPdfBuilder` - `UrlPdfBuilder` and  `ConvertPdfBuilder` 
