### PR TITLE
Fully initialize the extension in `Bundle::createContainerExtension()` for compatibility with Symfony 7.4

### DIFF
--- a/src/DependencyInjection/CompilerPass/GotenbergPass.php
+++ b/src/DependencyInjection/CompilerPass/GotenbergPass.php
@@ -2,8 +2,9 @@
 
 namespace Sensiolabs\GotenbergBundle\DependencyInjection\CompilerPass;
 
+use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
 use Sensiolabs\GotenbergBundle\Debug\Builder\TraceableBuilder;
-use Sensiolabs\GotenbergBundle\DependencyInjection\BuilderStack;
+use Sensiolabs\GotenbergBundle\DependencyInjection\SensiolabsGotenbergExtension;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -12,13 +13,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class GotenbergPass implements CompilerPassInterface
 {
-    public function __construct(
-        private readonly BuilderStack $builderStack,
-    ) {
-    }
-
     public function process(ContainerBuilder $container): void
     {
+        /** @var SensiolabsGotenbergExtension $extension */
+        $extension = $container->getExtension('sensiolabs_gotenberg');
         $builderPerType = [];
         foreach ($container->findTaggedServiceIds('sensiolabs_gotenberg.builder') as $serviceId => $tags) {
             $serviceDefinition = $container->getDefinition($serviceId);
@@ -27,9 +25,9 @@ final class GotenbergPass implements CompilerPassInterface
                 ->addTag('container.service_subscriber')
             ;
 
-            /** @var string $class */
+            /** @var class-string<BuilderInterface> $class */
             $class = $serviceDefinition->getClass();
-            $type = $this->builderStack->getBuilders()[$class];
+            $type = $extension->getBuilder($class);
 
             $builderPerType[$type] ??= [];
             $builderPerType[$type][$serviceId] = new Reference($serviceId);

--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -47,6 +47,11 @@ class SensiolabsGotenbergExtension extends Extension
 {
     private BuilderStack $builderStack;
 
+    public function __construct()
+    {
+        $this->builderStack = new BuilderStack();
+    }
+
     /**
      * @param class-string<BuilderInterface> $class
      */
@@ -55,6 +60,17 @@ class SensiolabsGotenbergExtension extends Extension
         $this->builderStack->push($class);
     }
 
+    /**
+     * @param class-string<BuilderInterface> $class
+     */
+    public function getBuilder(string $class): string
+    {
+        return $this->builderStack->getBuilders()[$class] ?? throw new \InvalidArgumentException(\sprintf('The builder "%s" is not registered.', $class));
+    }
+
+    /**
+     * @deprecated The BuilderStack is created by the extension itself
+     */
     public function setBuilderStack(BuilderStack $builderStack): void
     {
         $this->builderStack = $builderStack;

--- a/src/SensiolabsGotenbergBundle.php
+++ b/src/SensiolabsGotenbergBundle.php
@@ -13,7 +13,6 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\HtmlScreenshotBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\MarkdownScreenshotBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\UrlScreenshotBuilder;
-use Sensiolabs\GotenbergBundle\DependencyInjection\BuilderStack;
 use Sensiolabs\GotenbergBundle\DependencyInjection\CompilerPass\GotenbergPass;
 use Sensiolabs\GotenbergBundle\DependencyInjection\SensiolabsGotenbergExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -26,13 +25,9 @@ class SensiolabsGotenbergBundle extends Bundle
         return \dirname(__DIR__);
     }
 
-    public function build(ContainerBuilder $container): void
+    protected function createContainerExtension(): SensiolabsGotenbergExtension
     {
-        $builderStack = new BuilderStack();
-
-        /** @var SensiolabsGotenbergExtension $extension */
-        $extension = $container->getExtension('sensiolabs_gotenberg');
-        $extension->setBuilderStack($builderStack);
+        $extension = new SensiolabsGotenbergExtension();
 
         $extension->registerBuilder(ConvertPdfBuilder::class);
         $extension->registerBuilder(FlattenPdfBuilder::class);
@@ -47,6 +42,11 @@ class SensiolabsGotenbergBundle extends Bundle
         $extension->registerBuilder(MarkdownScreenshotBuilder::class);
         $extension->registerBuilder(UrlScreenshotBuilder::class);
 
-        $container->addCompilerPass(new GotenbergPass($builderStack));
+        return $extension;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new GotenbergPass());
     }
 }

--- a/tests/DependencyInjection/CompilerPass/GotenbergPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/GotenbergPassTest.php
@@ -4,8 +4,8 @@ namespace Sensiolabs\GotenbergBundle\Tests\DependencyInjection\CompilerPass;
 
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
-use Sensiolabs\GotenbergBundle\DependencyInjection\BuilderStack;
 use Sensiolabs\GotenbergBundle\DependencyInjection\CompilerPass\GotenbergPass;
+use Sensiolabs\GotenbergBundle\DependencyInjection\SensiolabsGotenbergExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -33,23 +33,24 @@ class GotenbergPassTest extends TestCase
         return $container;
     }
 
-    private function getBuilderStack(): BuilderStack
+    private function getExtension(): SensiolabsGotenbergExtension
     {
-        $builderStack = new BuilderStack();
-        $builderStack->push(self::BUILDER);
+        $extension = new SensiolabsGotenbergExtension();
+        $extension->registerBuilder(self::BUILDER);
 
-        return $builderStack;
+        return $extension;
     }
 
     public function testItDoesNothingIfDataCollectorNotRegistered(): void
     {
         $container = $this->getContainerBuilder();
+        $container->registerExtension($this->getExtension());
 
         $serviceIds = $container->getServiceIds();
 
         self::assertNotContains('sensiolabs_gotenberg.data_collector', $serviceIds);
 
-        $compilerPass = new GotenbergPass($this->getBuilderStack());
+        $compilerPass = new GotenbergPass();
         $compilerPass->process($container);
 
         self::assertSame($serviceIds, $container->getServiceIds());

--- a/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
+++ b/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
@@ -13,8 +13,6 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\HtmlScreenshotBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\MarkdownScreenshotBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\UrlScreenshotBuilder;
-use Sensiolabs\GotenbergBundle\DependencyInjection\BuilderStack;
-use Sensiolabs\GotenbergBundle\DependencyInjection\CompilerPass\GotenbergPass;
 use Sensiolabs\GotenbergBundle\DependencyInjection\SensiolabsGotenbergExtension;
 use Sensiolabs\GotenbergBundle\Enumeration\EmulatedMediaType;
 use Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI;

--- a/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
+++ b/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
@@ -36,10 +36,7 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
 
     private function getExtension(): SensiolabsGotenbergExtension
     {
-        $builderStack = new BuilderStack();
-
         $extension = new SensiolabsGotenbergExtension();
-        $extension->setBuilderStack($builderStack);
 
         $extension->registerBuilder(ConvertPdfBuilder::class);
         $extension->registerBuilder(HtmlPdfBuilder::class);
@@ -52,8 +49,6 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
         $extension->registerBuilder(HtmlScreenshotBuilder::class);
         $extension->registerBuilder(MarkdownScreenshotBuilder::class);
         $extension->registerBuilder(UrlScreenshotBuilder::class);
-
-        $this->getContainerBuilder()->addCompilerPass(new GotenbergPass($builderStack));
 
         return $extension;
     }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes      |
| New feature ?           | no       |
| BC break ?              | yes      |
| Issues                  | Fix #197 |

## Description

In order to generate array shapes for all environments, Symfony FrameworkBundle needs to get the configuration of all the bundles without initializing the container.

The extension must be fully initialized in `Bundle::createContainerExtension()`.