### PR TITLE
Fix Builder already added

### DIFF
--- a/src/DependencyInjection/BuilderStack.php
+++ b/src/DependencyInjection/BuilderStack.php
@@ -46,7 +46,7 @@ final class BuilderStack
         }
 
         if (\array_key_exists($class, $this->builders)) {
-            throw new \LogicException("{$class} has already been added.");
+            return;
         }
 
         $reflection = new \ReflectionClass($class);


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |

## Description

Since https://github.com/sensiolabs/GotenbergBundle/pull/198 we can't add a Custom Builder anymore in the Kernel::build method as 

```php
class Kernel extends BaseKernel
{
    use MicroKernelTrait;

    protected function build($container): void
    {
        /** @var SensiolabsGotenbergExtension $extension */
        $extension = $container->getExtension('sensiolabs_gotenberg');
        $extension->registerBuilder(InvoicePdfBuilder::class);
    }
}
```

During the first call you get an exception about the builder has already been added. And finally pass on the next request.
To fix that remove the exception and add return.
