### PR TITLE
fix(ci): remove matrix for PHPStan tests

### DIFF
--- a/.dagger/src/GotenbergBundle.php
+++ b/.dagger/src/GotenbergBundle.php
@@ -20,8 +20,12 @@ use function Dagger\dag;
 #[Doc('Module for GotenbergBundle')]
 class GotenbergBundle
 {
+    private const DEFAULT_PHP_VERSION = '8.4';
+    private const DEFAULT_SYMFONY_VERSION = '7.3.*';
+    private const DEFAULT_GOTENBERG_VERSION = '8.0';
+
     private function gotenbergContainer(
-        string $gotenbergVersion = '8.0',
+        string $gotenbergVersion = self::DEFAULT_GOTENBERG_VERSION,
     ): Container {
         return dag()
             ->container()
@@ -30,7 +34,7 @@ class GotenbergBundle
     }
 
     private function gotenbergService(
-        string $gotenbergVersion = '8.0',
+        string $gotenbergVersion = self::DEFAULT_GOTENBERG_VERSION,
     ): Service {
         return $this->gotenbergContainer($gotenbergVersion)
             ->withExposedPort(3000)
@@ -40,7 +44,7 @@ class GotenbergBundle
 
     private function phpContainer(
         Directory $source,
-        string $phpVersion = '8.4',
+        string $phpVersion = self::DEFAULT_PHP_VERSION,
     ): Container {
         $aptCache = dag()->cacheVolume("apt-cache-{$phpVersion}");
         $composerBin = dag()->container()->from('composer/composer:latest-bin')->file('/composer');
@@ -63,8 +67,8 @@ class GotenbergBundle
 
     private function symfonyContainer(
         Directory $source,
-        string $phpVersion = '8.4',
-        string $symfonyVersion = '7.3.*',
+        string $phpVersion = self::DEFAULT_PHP_VERSION,
+        string $symfonyVersion = self::DEFAULT_SYMFONY_VERSION,
         string $minimumStability = 'stable',
         Container|null $phpContainer = null,
     ): Container {
@@ -120,9 +124,8 @@ class GotenbergBundle
     public function test(
         #[DefaultPath('.')]
         Directory $source,
-
-        string $phpVersion = '8.4',
-        string $symfonyVersion = '7.3.*',
+        string $phpVersion = self::DEFAULT_PHP_VERSION,
+        string $symfonyVersion = self::DEFAULT_SYMFONY_VERSION,
         string $minimumStability = 'stable',
         Container|null $symfonyContainer = null,
     ): TestsGotenbergBundle {

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,17 +10,6 @@ permissions:
   contents: 'read'
 
 jobs:
-  setup:
-    name: 'Setup matrix'
-    runs-on: 'ubuntu-latest'
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: 'actions/checkout@v4'
-      - id: 'set-matrix'
-        run: |
-          echo "matrix=$(jq -c '.' ./.dagger/src/matrix-versions.json)" >> $GITHUB_OUTPUT
-
   php-cs-fixer:
     name: 'PHP CS Fixer'
     runs-on: 'ubuntu-latest'
@@ -40,20 +29,15 @@ jobs:
       - name: 'Run test suite'
         uses: 'dagger/dagger-for-github@8.0.0'
         with:
-          version: "latest"
-          call: "test php-cs-fixer"
+          version: 'latest'
+          args: 'test php-cs-fixer'
           dagger-flags: '--silent'
         env:
           DAGGER_NO_NAG: '1'
 
   phpstan:
-    name: 'PHPStan - ${{ matrix.name }}'
+    name: 'PHPStan'
     runs-on: 'ubuntu-latest'
-    needs: 'setup'
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.setup.outputs.matrix) }}
-    continue-on-error: ${{ matrix.allow-failure }}
     steps:
       - uses: 'actions/checkout@v4'
 
@@ -70,8 +54,8 @@ jobs:
       - name: 'Run test suite'
         uses: 'dagger/dagger-for-github@8.0.0'
         with:
-          version: "latest"
-          call: "test --symfony-version '${{ matrix.symfony-version }}' --php-version '${{ matrix.php }}' --minimum-stability '${{ matrix.minimum-stability }}' phpstan"
+          version: 'latest'
+          call: 'test phpstan'
           dagger-flags: '--silent'
         env:
           DAGGER_NO_NAG: '1'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,7 +30,7 @@ jobs:
         uses: 'dagger/dagger-for-github@8.0.0'
         with:
           version: 'latest'
-          args: 'test php-cs-fixer'
+          call: 'test php-cs-fixer'
           dagger-flags: '--silent'
         env:
           DAGGER_NO_NAG: '1'


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | |

## Description

Remove matrix for PHPStan tests since PR can't be merged when new templates are added for example. Ex: https://github.com/symfony/symfony/commit/3a65283953c0f233401f3afcdc1457638278bae7.

For now, CI is green due to a bug with next versions (ex: `7.4-dev` is ran with `7.3`). See https://github.com/sensiolabs/GotenbergBundle/pull/203.
