### PR TITLE
fix: assert form DataPart name in assertGotenbergFormDataFile

### DIFF
--- a/src/Test/Builder/GotenbergBuilderTestCase.php
+++ b/src/Test/Builder/GotenbergBuilderTestCase.php
@@ -113,7 +113,7 @@ abstract class GotenbergBuilderTestCase extends TestCase
             }
 
             $body = \Closure::bind(static fn (DataPart $part) => $part->body, null, TextPart::class)($part);
-            if ($part->getContentType() === $contentType && $body instanceof File && $body->getPath() === Path::canonicalize($path)) {
+            if ($part->getName() === $name && $part->getContentType() === $contentType && $body instanceof File && $body->getPath() === Path::canonicalize($path)) {
                 $this->addToAssertionCount(1);
 
                 return;


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | maybe   |
| Issues                  |  |

## Description

Fix assertion on form DataPart files by adding a test on its name.

:warning: Is it considered as a BC break since CI may fail after this fix. If so, we could do that before next major?
```php
if ($part->getContentType() === $contentType && $body instanceof File && $body->getPath() === Path::canonicalize($path)) {
    if ($part->getName() !== $name) {
        // warn
    }
    $this->addToAssertionCount(1);
}
```