### PR TITLE
fix: unfold header values sent to Gotenberg

### DIFF
--- a/src/Client/GotenbergClient.php
+++ b/src/Client/GotenbergClient.php
@@ -24,12 +24,16 @@ final class GotenbergClient implements GotenbergClientInterface
             $headers->add($header);
         }
 
+        // Unfold header values not accepted by HttpClient
+        // @see https://www.rfc-editor.org/rfc/rfc2822.html#section-2.2.3
+        $unfold = fn (string $v) => str_replace("\r\n", '', $v);
+
         try {
             return $this->client->request(
                 'POST',
                 $endpoint,
                 [
-                    'headers' => $headers->toArray(),
+                    'headers' => array_map($unfold, $headers->toArray()),
                     'body' => $formDataPart->bodyToIterable(),
                 ],
             );

--- a/tests/Client/GotenbergClientTest.php
+++ b/tests/Client/GotenbergClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Client;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\Payload;
 use Sensiolabs\GotenbergBundle\Client\GotenbergClient;
@@ -61,5 +62,31 @@ final class GotenbergClientTest extends TestCase
         self::assertSame('application/pdf', $responseHeaders['content-type'][0]);
         self::assertSame('attachment; filename="simple_pdf.pdf"', $responseHeaders['content-disposition'][0]);
         self::assertSame('13624', $responseHeaders['content-length'][0]);
+    }
+
+    #[DataProvider('provideFilenameIsUnfolded')]
+    public function testFilenameIsUnfolded(string $filename): void
+    {
+        $mockResponse = new MockResponse();
+        $mockClient = new MockHttpClient([$mockResponse], baseUri: 'http://localhost:3000');
+
+        $payload = new Payload(
+            [['url' => 'https://google.com']],
+            ['Gotenberg-Output-Filename' => $filename],
+        );
+
+        $gotenbergClient = new GotenbergClient($mockClient);
+        $gotenbergClient->call('/some/url', $payload);
+
+        self::assertContains("Gotenberg-Output-Filename: $filename", $mockResponse->getRequestOptions()['headers']);
+    }
+
+    public static function provideFilenameIsUnfolded(): \Generator
+    {
+        yield 'Short filename' => ['my_file'];
+        yield 'Long filename' => ['my_file_with_a_very_long_filename_that_should_be_unfolded'];
+        // @see https://github.com/sensiolabs/GotenbergBundle/issues/216
+        yield 'Long filename with spaces' => ['Reservation - Holiday Park The Mooing Cow - 2025-0110'];
+        yield 'Long filename with long spaces' => ['Reservation   -   Holiday   Park   The   Mooing   Cow   -   2025-0110'];
     }
 }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #216 |

## Description

Fix header values folding made by the Symfony Mime component when retrieving headers as an array.