### PR TITLE
fix: webhook configurations not added to WebhookConfigurationRegistry

### DIFF
--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -166,11 +166,9 @@ class SensiolabsGotenbergExtension extends Extension
             }
         }
 
-        if ($container->hasDefinition('.sensiolabs_gotenberg.webhook_configuration_registry')) {
-            $registryDefinition = $container->getDefinition('.sensiolabs_gotenberg.webhook_configuration_registry');
-            foreach ($defaultConfiguration['webhook'] as $name => $webhookConfig) {
-                $registryDefinition->addMethodCall('add', [$name, $webhookConfig]);
-            }
+        $registryDefinition = $container->getDefinition('.sensiolabs_gotenberg.webhook_configuration_registry');
+        foreach ($defaultConfiguration['webhook'] as $name => $webhookConfig) {
+            $registryDefinition->addMethodCall('add', [$name, $webhookConfig]);
         }
 
         $container->getDefinition('sensiolabs_gotenberg.builder_configurator')

--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -166,6 +166,13 @@ class SensiolabsGotenbergExtension extends Extension
             }
         }
 
+        if ($container->hasDefinition('.sensiolabs_gotenberg.webhook_configuration_registry')) {
+            $registryDefinition = $container->getDefinition('.sensiolabs_gotenberg.webhook_configuration_registry');
+            foreach ($defaultConfiguration['webhook'] as $name => $webhookConfig) {
+                $registryDefinition->addMethodCall('add', [$name, $webhookConfig]);
+            }
+        }
+
         $container->getDefinition('sensiolabs_gotenberg.builder_configurator')
             ->replaceArgument(0, $this->builderStack->getConfigMapping())
             ->replaceArgument(1, $configValueMapping)

--- a/tests/Functional/Webhook/config/bundles.php
+++ b/tests/Functional/Webhook/config/bundles.php
@@ -1,0 +1,9 @@
+<?php
+
+use Sensiolabs\GotenbergBundle\SensiolabsGotenbergBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    FrameworkBundle::class => ['test' => true],
+    SensiolabsGotenbergBundle::class => ['test' => true],
+];

--- a/tests/Functional/Webhook/config/packages/config.php
+++ b/tests/Functional/Webhook/config/packages/config.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('framework', [
+        'test' => true,
+        'http_client' => [
+            'scoped_clients' => [
+                'gotenberg' => [
+                    'base_uri' => 'http://localhost:9000',
+                ],
+            ],
+        ],
+    ]);
+
+    $container->extension('sensiolabs_gotenberg', [
+        'http_client' => 'gotenberg',
+        'webhook' => [
+            'default' => [
+                'success' => [
+                    'url' => 'http://localhost:9000/default_webhook',
+                ],
+            ],
+            'custom' => [
+                'extra_http_headers' => [
+                    'X-CUSTOM' => 'custom',
+                ],
+                'success' => [
+                    'url' => 'http://localhost:9000/custom_success_webhook',
+                    'method' => 'PUT',
+                ],
+                'error' => [
+                    'url' => 'http://localhost:9000/custom_error_webhook',
+                    'method' => 'POST',
+                ],
+            ],
+        ],
+    ]);
+};

--- a/tests/Functional/Webhook/config/services.php
+++ b/tests/Functional/Webhook/config/services.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->alias('alias.sensiolabs_gotenberg.webhook_configuration_registry', '.sensiolabs_gotenberg.webhook_configuration_registry')
+        ->public()
+    ;
+};

--- a/tests/Functional/WebhookTest.php
+++ b/tests/Functional/WebhookTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Functional;
+
+use Sensiolabs\GotenbergBundle\Tests\Functional\AbstractGotenbergWebTestCase;
+use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistry;
+
+class WebhookTest extends AbstractGotenbergWebTestCase
+{
+    public function testBundleWebhook(): void
+    {
+        static::bootKernel(['test_case' => 'Webhook']);
+
+        /** @var WebhookConfigurationRegistry $registry */
+        $registry = static::getContainer()->get('alias.sensiolabs_gotenberg.webhook_configuration_registry');
+
+        self::assertSame(
+            [
+                'success' => [
+                    'url' => 'http://localhost:9000/default_webhook',
+                    'method' => null,
+                ],
+                'error' => [
+                    'url' => 'http://localhost:9000/default_webhook',
+                    'method' => null,
+                ],
+            ],
+            $registry->get('default'),
+        );
+        self::assertSame(
+            [
+                'success' => [
+                    'url' => 'http://localhost:9000/custom_success_webhook',
+                    'method' => 'PUT',
+                ],
+                'error' => [
+                    'url' => 'http://localhost:9000/custom_error_webhook',
+                    'method' => 'POST',
+                ],
+                'extra_http_headers' => [
+                    'X-CUSTOM' => 'custom',
+                ],
+            ],
+            $registry->get('custom'),
+        );
+    }
+}


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #215  |

## Description

Fix empty $configurations in WebhookConfigurationRegistry causing Webhook configuration not found
