### PR TITLE
doc: add missing link to EmbedPdfBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ class YourController
 8. [Split Builder](./docs/pdf/SplitPdfBuilder.md)
 9. [Flatten Builder](./docs/pdf/FlattenPdfBuilder.md)
 10. [Encrypt Builder](./docs/pdf/EncryptPdfBuilder.md)
+11. [Embed Builder](./docs/pdf/EmbedPdfBuilder.md)
 
 ### Screenshot
 


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  |  |

## Description

Fix the missing link to `EmbedPdfBuilder` (added in #213) in README.md.
