### PR TITLE
fix: Asset gotenberg runtime for asset mapper or webpack usage

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -38,6 +38,9 @@ $config = $config
     ->ignoreErrorsOnPath(__DIR__.'/docs', [
         ErrorType::UNKNOWN_CLASS, // BuilderParser::class
     ])
+    ->ignoreErrorsOnPackage('symfony/asset-mapper', [
+        ErrorType::DEV_DEPENDENCY_IN_PROD,
+    ])
 ;
 
 if (\PHP_VERSION_ID < 80200) { // TODO: Requires PHP >= 8.2

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "phpunit/phpunit": "^10.5.46",
         "shipmonk/composer-dependency-analyser": "^1.8",
         "symfony/asset": "^6.4 || ^7.0 || ^8.0",
+        "symfony/asset-mapper": "^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^6.4 || ^7.0 || ^8.0",
         "symfony/css-selector": "^6.4 || ^7.0 || ^8.0",
         "symfony/dom-crawler": "^6.4 || ^7.0 || ^8.0",

--- a/config/services.php
+++ b/config/services.php
@@ -43,7 +43,10 @@ return static function (ContainerConfigurator $container): void {
         ->tag('twig.extension')
     ;
     $services->set('sensiolabs_gotenberg.twig.asset_runtime', GotenbergRuntime::class)
-        ->args([service('assets.packages')->nullOnInvalid()])
+        ->args([
+            service('assets.packages')->nullOnInvalid(),
+            service('asset_mapper.repository')->nullOnInvalid(),
+        ])
         ->tag('twig.runtime')
     ;
 

--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Twig;
 
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Symfony\Component\Asset\Packages;
+use Symfony\Component\AssetMapper\AssetMapperRepository;
 
 /**
  * @internal
@@ -15,8 +16,10 @@ final class GotenbergRuntime
 {
     private BuilderAssetInterface|null $builder = null;
 
-    public function __construct(private readonly Packages|null $packages = null)
-    {
+    public function __construct(
+        private readonly Packages|null $packages = null,
+        private readonly AssetMapperRepository|null $assetMapperRepository = null,
+    ) {
     }
 
     public function setBuilder(BuilderAssetInterface|null $builder): void
@@ -73,6 +76,16 @@ final class GotenbergRuntime
 
     private function getVersionedPathIfExist(string $path): string
     {
+
+        $assetRepository = $this->assetMapperRepository;
+        if (null !== $assetRepository) {
+            $mappedPath = $assetRepository->find($path);
+
+            if (null !== $mappedPath) {
+                return $mappedPath;
+            }
+        }
+
         $packages = $this->packages;
         if (null !== $packages) {
             $path = ltrim($packages->getUrl($path), '/');

--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -76,7 +76,6 @@ final class GotenbergRuntime
 
     private function getVersionedPathIfExist(string $path): string
     {
-
         $assetRepository = $this->assetMapperRepository;
         if (null !== $assetRepository) {
             $mappedPath = $assetRepository->find($path);

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -2,7 +2,6 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Twig;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
@@ -69,21 +68,22 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('foo')
+            ->with('/absolute/dir/vendor/package/dist/css/package.min.css')
         ;
 
         $assetMapperRepository = $this->createMock(AssetMapperRepository::class);
         $assetMapperRepository->expects($this->once())
             ->method('find')
-            ->willReturn('foo')
+            ->with('vendor/package/dist/css/package.min.css')
+            ->willReturn('/absolute/dir/vendor/package/dist/css/package.min.css')
         ;
 
         $runtime = new GotenbergRuntime(null, $assetMapperRepository);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('foo');
+        $path = $runtime->getAssetUrl('vendor/package/dist/css/package.min.css');
 
-        $this->assertSame('foo', $path);
+        $this->assertSame('package.min.css', $path);
     }
 
     public function testGetAssetUrlWhenPackages(): void
@@ -91,21 +91,22 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('foo')
+            ->with('image/example.png')
         ;
 
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
             ->method('getUrl')
-            ->willReturn('/foo')
+            ->with('image/example.png')
+            ->willReturn('/image/example.png')
         ;
 
         $runtime = new GotenbergRuntime($packages, null);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('foo');
+        $path = $runtime->getAssetUrl('image/example.png');
 
-        $this->assertSame('foo', $path);
+        $this->assertSame('example.png', $path);
     }
 
     public function testGetAssetUrlWhenAssetMapperRepositoryAndPackages(): void
@@ -113,27 +114,29 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('foo')
+            ->with('image/example.png')
         ;
 
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
             ->method('getUrl')
-            ->willReturn('/foo')
+            ->with('image/example.png')
+            ->willReturn('/image/example.png')
         ;
 
         $assetMapperRepository = $this->createMock(AssetMapperRepository::class);
         $assetMapperRepository->expects($this->once())
             ->method('find')
+            ->with('image/example.png')
             ->willReturn(null)
         ;
 
         $runtime = new GotenbergRuntime($packages, $assetMapperRepository);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('foo');
+        $path = $runtime->getAssetUrl('image/example.png');
 
-        $this->assertSame('foo', $path);
+        $this->assertSame('example.png', $path);
     }
 
     public function testGetAssetUrlWhenMissingAssetMapperRepositoryAndPackages(): void
@@ -141,14 +144,14 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('foo')
+            ->with('image/example.png')
         ;
 
         $runtime = new GotenbergRuntime(null, null);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('foo');
+        $path = $runtime->getAssetUrl('image/example.png');
 
-        $this->assertSame('foo', $path);
+        $this->assertSame('example.png', $path);
     }
 }

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -97,14 +97,14 @@ class GotenbergRuntimeTest extends TestCase
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
             ->method('getUrl')
-            ->with('image/example.png')
+            ->with('asset/example.png')
             ->willReturn('/image/example.png')
         ;
 
         $runtime = new GotenbergRuntime($packages, null);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('image/example.png');
+        $path = $runtime->getAssetUrl('asset/example.png');
 
         $this->assertSame('example.png', $path);
     }

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -68,22 +68,22 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('/absolute/dir/vendor/package/dist/css/package.min.css')
+            ->with('/image/result.png')
         ;
 
         $assetMapperRepository = $this->createMock(AssetMapperRepository::class);
         $assetMapperRepository->expects($this->once())
             ->method('find')
-            ->with('vendor/package/dist/css/package.min.css')
-            ->willReturn('/absolute/dir/vendor/package/dist/css/package.min.css')
+            ->with('image/origin.png')
+            ->willReturn('/image/result.png')
         ;
 
         $runtime = new GotenbergRuntime(null, $assetMapperRepository);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('vendor/package/dist/css/package.min.css');
+        $path = $runtime->getAssetUrl('image/origin.png');
 
-        $this->assertSame('package.min.css', $path);
+        $this->assertSame('result.png', $path);
     }
 
     public function testGetAssetUrlWhenPackages(): void
@@ -91,22 +91,22 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('image/example.png')
+            ->with('image/result.png')
         ;
 
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
             ->method('getUrl')
-            ->with('asset/example.png')
-            ->willReturn('/image/example.png')
+            ->with('image/origin.png')
+            ->willReturn('/image/result.png')
         ;
 
         $runtime = new GotenbergRuntime($packages, null);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('asset/example.png');
+        $path = $runtime->getAssetUrl('image/origin.png');
 
-        $this->assertSame('example.png', $path);
+        $this->assertSame('result.png', $path);
     }
 
     public function testGetAssetUrlWhenAssetMapperRepositoryAndPackages(): void
@@ -114,29 +114,29 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('image/example.png')
+            ->with('image/result.png')
         ;
 
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
             ->method('getUrl')
-            ->with('image/example.png')
-            ->willReturn('/image/example.png')
+            ->with('image/origin.png')
+            ->willReturn('/image/result.png')
         ;
 
         $assetMapperRepository = $this->createMock(AssetMapperRepository::class);
         $assetMapperRepository->expects($this->once())
             ->method('find')
-            ->with('image/example.png')
+            ->with('image/origin.png')
             ->willReturn(null)
         ;
 
         $runtime = new GotenbergRuntime($packages, $assetMapperRepository);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('image/example.png');
+        $path = $runtime->getAssetUrl('image/origin.png');
 
-        $this->assertSame('example.png', $path);
+        $this->assertSame('result.png', $path);
     }
 
     public function testGetAssetUrlWhenMissingAssetMapperRepositoryAndPackages(): void
@@ -144,14 +144,14 @@ class GotenbergRuntimeTest extends TestCase
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
             ->method('addAsset')
-            ->with('image/example.png')
+            ->with('image/origin.png')
         ;
 
         $runtime = new GotenbergRuntime(null, null);
         $runtime->setBuilder($builder);
 
-        $path = $runtime->getAssetUrl('image/example.png');
+        $path = $runtime->getAssetUrl('image/origin.png');
 
-        $this->assertSame('example.png', $path);
+        $this->assertSame('origin.png', $path);
     }
 }

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Twig;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
@@ -128,6 +129,22 @@ class GotenbergRuntimeTest extends TestCase
         ;
 
         $runtime = new GotenbergRuntime($packages, $assetMapperRepository);
+        $runtime->setBuilder($builder);
+
+        $path = $runtime->getAssetUrl('foo');
+
+        $this->assertSame('foo', $path);
+    }
+
+    public function testGetAssetUrlWhenMissingAssetMapperRepositoryAndPackages(): void
+    {
+        $builder = $this->createMock(BuilderAssetInterface::class);
+        $builder->expects($this->once())
+            ->method('addAsset')
+            ->with('foo')
+        ;
+
+        $runtime = new GotenbergRuntime(null, null);
         $runtime->setBuilder($builder);
 
         $path = $runtime->getAssetUrl('foo');

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -5,6 +5,8 @@ namespace Sensiolabs\GotenbergBundle\Tests\Twig;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\AssetMapper\AssetMapperRepository;
 
 class GotenbergRuntimeTest extends TestCase
 {
@@ -59,5 +61,77 @@ class GotenbergRuntimeTest extends TestCase
             '<style>@font-face {font-family: "my_font";src: url("foo.ttf");}</style>',
             $runtime->getFontStyleTag('foo.ttf', 'my_font'),
         );
+    }
+
+    public function testGetAssetUrlWhenAssetMapperRepository(): void
+    {
+        $builder = $this->createMock(BuilderAssetInterface::class);
+        $builder->expects($this->once())
+            ->method('addAsset')
+            ->with('foo')
+        ;
+
+        $assetMapperRepository = $this->createMock(AssetMapperRepository::class);
+        $assetMapperRepository->expects($this->once())
+            ->method('find')
+            ->willReturn('foo')
+        ;
+
+        $runtime = new GotenbergRuntime(null, $assetMapperRepository);
+        $runtime->setBuilder($builder);
+
+        $path = $runtime->getAssetUrl('foo');
+
+        $this->assertSame('foo', $path);
+    }
+
+    public function testGetAssetUrlWhenPackages(): void
+    {
+        $builder = $this->createMock(BuilderAssetInterface::class);
+        $builder->expects($this->once())
+            ->method('addAsset')
+            ->with('foo')
+        ;
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->willReturn('/foo')
+        ;
+
+        $runtime = new GotenbergRuntime($packages, null);
+        $runtime->setBuilder($builder);
+
+        $path = $runtime->getAssetUrl('foo');
+
+        $this->assertSame('foo', $path);
+    }
+
+    public function testGetAssetUrlWhenAssetMapperRepositoryAndPackages(): void
+    {
+        $builder = $this->createMock(BuilderAssetInterface::class);
+        $builder->expects($this->once())
+            ->method('addAsset')
+            ->with('foo')
+        ;
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->willReturn('/foo')
+        ;
+
+        $assetMapperRepository = $this->createMock(AssetMapperRepository::class);
+        $assetMapperRepository->expects($this->once())
+            ->method('find')
+            ->willReturn(null)
+        ;
+
+        $runtime = new GotenbergRuntime($packages, $assetMapperRepository);
+        $runtime->setBuilder($builder);
+
+        $path = $runtime->getAssetUrl('foo');
+
+        $this->assertSame('foo', $path);
     }
 }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #218  |

## Description

Tested with projets running with asset-mapper, webpack, and both when using webpack and symfonycasts/sass-bundle.


