### PR TITLE
fix(ci): disable static_lambda rule for now

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -32,6 +32,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_no_package' => false,
         'return_assignment' => true,
         'single_line_throw' => false,
+        'static_lambda' => false,
         'strict_param' => true,
         'trailing_comma_in_multiline' => [
             'elements' => ['arguments', 'arrays', 'match', 'parameters'],


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | |

## Description

Disable explicitly `static_lambda` rule to make CI happy again.
