### PR TITLE
fix(typo): correct LICENSE filename in badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Latest Version](https://img.shields.io/github/release/sensiolabs/GotenbergBundle.svg?style=flat-square)](https://github.com/sensiolabs/GotenbergBundle/releases)
 [![Total Downloads](https://poser.pugx.org/sensiolabs/gotenberg-bundle/downloads)](https://packagist.org/packages/sensiolabs/gotenberg-bundle)
 [![Monthly Downloads](https://poser.pugx.org/sensiolabs/gotenberg-bundle/d/monthly)](https://packagist.org/packages/sensiolabs/gotenberg-bundle)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENCE)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Static analysis](https://github.com/sensiolabs/GotenbergBundle/actions/workflows/static.yml/badge.svg?branch=1.x)](https://github.com/sensiolabs/GotenbergBundle/actions/workflows/static.yml?query=branch%3A1.x)
 [![Tests](https://github.com/sensiolabs/GotenbergBundle/actions/workflows/unit-tests.yml/badge.svg?branch=1.x)](https://github.com/sensiolabs/GotenbergBundle/actions/workflows/unit-tests.yml?query=branch%3A1.x)
 


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes      |
| New feature ?           | no       |
| BC break ?              | no       |
| Issues                  |          |

## Description

The license badge link on line 13 of README.md pointed to `LICENCE` (British spelling), but the actual file is named `LICENSE`. This caused a broken link. Updated to match the correct filename.