### PR TITLE
fix: Add normalize methods into dedicated traits

### DIFF
--- a/docs/pdf/EmbedPdfBuilder.md
+++ b/docs/pdf/EmbedPdfBuilder.md
@@ -79,10 +79,10 @@ return $gotenberg
 ```
 
 ### files(Stringable|string ...\$paths)
-Add PDF files which is the source of embedded file.<br /><br />As assets files, by default the PDF files are fetch in the assets folder<br />of your application. For more information about path resolution go to<br />assets documentation.<br />
+Add PDF files which is the source of embedded file.<br />As assets files, by default the PDF files are fetch in the assets folder<br />of your application. For more information about path resolution go to<br />assets documentation.<br />
 
 > [!TIP]
-> See: [https://gotenberg.dev/docs/manipulate-pdfs/attachments ](https://gotenberg.dev/docs/manipulate-pdfs/attachments )
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/attachments](https://gotenberg.dev/docs/manipulate-pdfs/attachments)
 
 ```php
 return $gotenberg

--- a/docs/pdf/EncryptPdfBuilder.md
+++ b/docs/pdf/EncryptPdfBuilder.md
@@ -62,6 +62,17 @@ return $gotenberg
 ```
 
 ### files(Stringable|string ...\$paths)
+Adds files (overrides any previous files).<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->files('document.pdf', '/absolute/path/document_2.pdf')
+    ->generate()
+    ->stream()
+;
+```
+
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/src/Builder/Behaviors/EmbedTrait.php
+++ b/src/Builder/Behaviors/EmbedTrait.php
@@ -2,9 +2,11 @@
 
 namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
 
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 
 trait EmbedTrait
 {
@@ -38,5 +40,11 @@ trait EmbedTrait
         $this->getBodyBag()->set('embeds', $files ?? null);
 
         return $this;
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizeEmbed(): \Generator
+    {
+        yield 'embeds' => NormalizerFactory::embed();
     }
 }

--- a/src/Builder/Behaviors/FilesTrait.php
+++ b/src/Builder/Behaviors/FilesTrait.php
@@ -2,8 +2,10 @@
 
 namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
 
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 
 trait FilesTrait
@@ -35,5 +37,11 @@ trait FilesTrait
         $this->getBodyBag()->set('files', $files ?? null);
 
         return $this;
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizeFiles(): \Generator
+    {
+        yield 'files' => NormalizerFactory::asset();
     }
 }

--- a/src/Builder/Pdf/ConvertPdfBuilder.php
+++ b/src/Builder/Pdf/ConvertPdfBuilder.php
@@ -3,7 +3,6 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
@@ -11,7 +10,6 @@ use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\FlattenTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\PdfFormatTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
 /**
@@ -58,11 +56,5 @@ final class ConvertPdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('files') === null && $this->getBodyBag()->get('downloadFrom') === null) {
             throw new MissingRequiredFieldException('At least one PDF file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
     }
 }

--- a/src/Builder/Pdf/EmbedPdfBuilder.php
+++ b/src/Builder/Pdf/EmbedPdfBuilder.php
@@ -3,19 +3,23 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EmbedTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
 /**
- * Embed file(s) into pdf files.
+ * @methodDoc files Add PDF files which is the source of embedded file.
+ * As assets files, by default the PDF files are fetch in the assets folder
+ * of your application. For more information about path resolution go to
+ * assets documentation.
  *
  * @see https://gotenberg.dev/docs/manipulate-pdfs/attachments
+ *
+ * @example files('document.pdf','document_2.pdf')
  */
 #[WithBuilderConfiguration(type: 'pdf', name: 'embed')]
 final class EmbedPdfBuilder extends AbstractBuilder
@@ -23,34 +27,18 @@ final class EmbedPdfBuilder extends AbstractBuilder
     use AssetBaseDirFormatterAwareTrait;
     use DownloadFromTrait;
     use EmbedTrait;
+    use FilesTrait;
     use WebhookTrait;
 
     public const ENDPOINT = '/forms/pdfengines/embed';
 
-    /**
-     * Add PDF files which is the source of embedded file.
-     *
-     * As assets files, by default the PDF files are fetch in the assets folder
-     * of your application. For more information about path resolution go to
-     * assets documentation.
-     *
-     * @see https://gotenberg.dev/docs/manipulate-pdfs/attachments
-     *
-     * @example files('document.pdf','document_2.pdf')
-     */
-    public function files(string|\Stringable ...$paths): self
+    private const AVAILABLE_EXTENSIONS = [
+        'pdf',
+    ];
+
+    protected function getAllowedFilesExtensions(): array
     {
-        foreach ($paths as $path) {
-            $path = (string) $path;
-
-            $info = new \SplFileInfo($this->getAssetBaseDirFormatter()->resolve($path));
-
-            $files[$path] = $info;
-        }
-
-        $this->getBodyBag()->set('files', $files ?? null);
-
-        return $this;
+        return self::AVAILABLE_EXTENSIONS;
     }
 
     protected function getEndpoint(): string
@@ -69,12 +57,5 @@ final class EmbedPdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('embeds') === null) {
             throw new MissingRequiredFieldException('At least one embed file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
-        yield 'embeds' => NormalizerFactory::embed();
     }
 }

--- a/src/Builder/Pdf/EncryptPdfBuilder.php
+++ b/src/Builder/Pdf/EncryptPdfBuilder.php
@@ -3,14 +3,12 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EncryptTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
-use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
 /**
@@ -26,23 +24,18 @@ final class EncryptPdfBuilder extends AbstractBuilder
     use AssetBaseDirFormatterAwareTrait;
     use DownloadFromTrait;
     use EncryptTrait;
+    use FilesTrait;
     use WebhookTrait;
 
     public const ENDPOINT = '/forms/pdfengines/encrypt';
 
-    public function files(string|\Stringable ...$paths): self
+    private const AVAILABLE_EXTENSIONS = [
+        'pdf',
+    ];
+
+    protected function getAllowedFilesExtensions(): array
     {
-        foreach ($paths as $path) {
-            $path = (string) $path;
-            $info = new \SplFileInfo($this->getAssetBaseDirFormatter()->resolve($path));
-            ValidatorFactory::filesExtension([$info], ['pdf']);
-
-            $files[$path] = $info;
-        }
-
-        $this->getBodyBag()->set('files', $files ?? null);
-
-        return $this;
+        return self::AVAILABLE_EXTENSIONS;
     }
 
     protected function getEndpoint(): string
@@ -61,11 +54,5 @@ final class EncryptPdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('files') === null && $this->getBodyBag()->get('downloadFrom') === null) {
             throw new MissingRequiredFieldException('At least one PDF file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
     }
 }

--- a/src/Builder/Pdf/FlattenPdfBuilder.php
+++ b/src/Builder/Pdf/FlattenPdfBuilder.php
@@ -3,13 +3,11 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
 /**
@@ -54,11 +52,5 @@ final class FlattenPdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('files') === null) {
             throw new MissingRequiredFieldException('At least one PDF file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
     }
 }

--- a/src/Builder/Pdf/HtmlPdfBuilder.php
+++ b/src/Builder/Pdf/HtmlPdfBuilder.php
@@ -3,12 +3,10 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumPdfTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EmbedTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
@@ -35,11 +33,5 @@ final class HtmlPdfBuilder extends AbstractBuilder implements BuilderAssetInterf
         if ($this->getBodyBag()->get(Part::Body->value) === null && $this->getBodyBag()->get('downloadFrom') === null) {
             throw new MissingRequiredFieldException('Content is required');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'embeds' => NormalizerFactory::embed();
     }
 }

--- a/src/Builder/Pdf/LibreOfficePdfBuilder.php
+++ b/src/Builder/Pdf/LibreOfficePdfBuilder.php
@@ -3,14 +3,12 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EmbedTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EncryptTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\LibreOfficeTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\SplitMode;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
@@ -67,12 +65,5 @@ final class LibreOfficePdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('splitUnify') === true && $this->getBodyBag()->get('splitMode') === SplitMode::Intervals) {
             throw new InvalidBuilderConfiguration('"splitUnify" can only be at "true" with "pages" mode for "splitMode".');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
-        yield 'embeds' => NormalizerFactory::embed();
     }
 }

--- a/src/Builder/Pdf/MarkdownPdfBuilder.php
+++ b/src/Builder/Pdf/MarkdownPdfBuilder.php
@@ -3,12 +3,10 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumPdfTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Exception\PartRenderingException;
@@ -99,11 +97,5 @@ final class MarkdownPdfBuilder extends AbstractBuilder implements BuilderAssetIn
         if ($this->getBodyBag()->get('files') === null && $this->getBodyBag()->get('downloadFrom') === null) {
             throw new MissingRequiredFieldException('At least one markdown file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
     }
 }

--- a/src/Builder/Pdf/MergePdfBuilder.php
+++ b/src/Builder/Pdf/MergePdfBuilder.php
@@ -3,7 +3,6 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
@@ -14,7 +13,6 @@ use Sensiolabs\GotenbergBundle\Builder\Behaviors\FlattenTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\MetadataTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\PdfFormatTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
 /**
@@ -65,12 +63,5 @@ final class MergePdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('files') === null && $this->getBodyBag()->get('downloadFrom') === null) {
             throw new MissingRequiredFieldException('At least one PDF file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
-        yield 'embeds' => NormalizerFactory::embed();
     }
 }

--- a/src/Builder/Pdf/SplitPdfBuilder.php
+++ b/src/Builder/Pdf/SplitPdfBuilder.php
@@ -3,7 +3,6 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
@@ -15,7 +14,6 @@ use Sensiolabs\GotenbergBundle\Builder\Behaviors\MetadataTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\PdfFormatTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\SplitTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 
 /**
@@ -76,12 +74,5 @@ final class SplitPdfBuilder extends AbstractBuilder
         if ($this->getBodyBag()->get('splitSpan') === null) {
             throw new MissingRequiredFieldException('Field "splitSpan" must be provided.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
-        yield 'embeds' => NormalizerFactory::embed();
     }
 }

--- a/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
+++ b/src/Builder/Screenshot/MarkdownScreenshotBuilder.php
@@ -3,12 +3,10 @@
 namespace Sensiolabs\GotenbergBundle\Builder\Screenshot;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
-use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumScreenshotTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
-use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Exception\PartRenderingException;
@@ -99,11 +97,5 @@ final class MarkdownScreenshotBuilder extends AbstractBuilder implements Builder
         if ($this->getBodyBag()->get('files') === null && $this->getBodyBag()->get('downloadFrom') === null) {
             throw new MissingRequiredFieldException('At least one markdown file is required.');
         }
-    }
-
-    #[NormalizeGotenbergPayload]
-    private function normalizeFiles(): \Generator
-    {
-        yield 'files' => NormalizerFactory::asset();
     }
 }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |

## Description

When using `EmbedTrait` in a custom builder, I encountered an error with gotenberg.

After investigation, I found that the trait did not contain its `normalize` method as expected.

A fix was necessary wherever the `normalize` method was not implemented in the dedicated traits.
Some `files` methods were not being used by the dedicated trait.
