### PR TITLE
feat: Allow custom XMP metadata keys for Factur-X

### DIFF
--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -205,12 +205,12 @@ Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).](https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).)
 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -422,12 +422,12 @@ Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).](https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).)
 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -247,12 +247,12 @@ Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).](https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).)
 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -133,12 +133,12 @@ Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).](https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).)
 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/SplitPdfBuilder.md
+++ b/docs/pdf/SplitPdfBuilder.md
@@ -139,12 +139,12 @@ Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).](https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).)
 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -181,12 +181,12 @@ Resets the metadata.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines)<br />
-> See: [https://exiftool.org/TagNames/XMP.html#pdf](https://exiftool.org/TagNames/XMP.html#pdf)
+> See: [https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).](https://exiftool.org/TagNames/XMP.html#pdf  Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords, Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.  Any ExifTool-compatible key is accepted, including custom XMP namespaces (e.g., 'XMP-fx:DocumentType' for Factur-X).)
 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+    ->metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/MetadataTrait.php
+++ b/src/Builder/Behaviors/MetadataTrait.php
@@ -21,22 +21,28 @@ trait MetadataTrait
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#metadata-pdf-engines
      * @see https://exiftool.org/TagNames/XMP.html#pdf
      *
-     * @param array{
-     *     Author?: string,
-     *     Copyright?: string,
-     *     CreationDate?: string,
-     *     Creator?: string,
-     *     Keywords?: string,
-     *     Marked?: bool,
-     *     ModDate?: string,
-     *     PDFVersion?: string,
-     *     Producer?: string,
-     *     Subject?: string,
-     *     Title?: string,
-     *     Trapped?: 'True'|'False'|'Unknown',
-     * } $metadata
+     * Common PDF metadata keys: Author, Copyright, CreationDate, Creator, Keywords,
+     * Marked, ModDate, PDFVersion, Producer, Subject, Title, Trapped.
      *
-     * @example metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg'])
+     * Any ExifTool-compatible key is accepted, including custom XMP namespaces
+     * (e.g., 'XMP-fx:DocumentType' for Factur-X).
+     *
+     * @param array<string, mixed>&array{
+     *      Author?: string,
+     *      Copyright?: string,
+     *      CreationDate?: string,
+     *      Creator?: string,
+     *      Keywords?: string,
+     *      Marked?: bool,
+     *      ModDate?: string,
+     *      PDFVersion?: string,
+     *      Producer?: string,
+     *      Subject?: string,
+     *      Title?: string,
+     *      Trapped?: 'True'|'False'|'Unknown',
+     *  } $metadata
+     *
+     * @example metadata(['Author' => 'SensioLabs', 'Subject' => 'Gotenberg', 'XMP-fx:DocumentType' => 'INVOICE', 'XMP-fx:DocumentFileName' => 'factur-x.xml'])
      */
     #[WithConfigurationNode(new MetadataNodeBuilder('metadata', children: [
         new ScalarNodeBuilder('Author'),

--- a/src/NodeBuilder/ArrayNodeBuilder.php
+++ b/src/NodeBuilder/ArrayNodeBuilder.php
@@ -8,16 +8,13 @@ class ArrayNodeBuilder extends NodeBuilder implements NodeBuilderInterface
 {
     public function __construct(
         protected string $name,
-
         public bool $normalizeKeys = true,
-
         public string|null $useAttributeAsKey = null,
-
         /** @var 'integer'|'array'|'variable'|'scalar'|null */
         public string|null $prototype = null,
-
         /** @var NodeBuilderInterface[] */
         public array $children = [],
+        public bool $ignoreExtraKeys = false,
     ) {
         parent::__construct($name);
     }
@@ -27,6 +24,10 @@ class ArrayNodeBuilder extends NodeBuilder implements NodeBuilderInterface
         $node = new ArrayNodeDefinition($this->name);
 
         $node->normalizeKeys($this->normalizeKeys);
+
+        if ($this->ignoreExtraKeys) {
+            $node->ignoreExtraKeys(false);
+        }
 
         if (\is_string($this->useAttributeAsKey)) {
             $node->useAttributeAsKey($this->useAttributeAsKey);

--- a/src/NodeBuilder/MetadataNodeBuilder.php
+++ b/src/NodeBuilder/MetadataNodeBuilder.php
@@ -8,7 +8,6 @@ class MetadataNodeBuilder extends NodeBuilder implements NodeBuilderInterface
 {
     public function __construct(
         protected string $name,
-
         /** @var NodeBuilderInterface[] */
         public array $children = [],
     ) {
@@ -17,6 +16,11 @@ class MetadataNodeBuilder extends NodeBuilder implements NodeBuilderInterface
 
     public function create(): NodeDefinition
     {
-        return (new ArrayNodeBuilder($this->name, children: $this->children))->create();
+        return (new ArrayNodeBuilder(
+            name: $this->name,
+            normalizeKeys: false,
+            children: $this->children,
+            ignoreExtraKeys: true,
+        ))->create();
     }
 }

--- a/tests/Builder/Behaviors/MetadataTestCaseTrait.php
+++ b/tests/Builder/Behaviors/MetadataTestCaseTrait.php
@@ -44,4 +44,31 @@ trait MetadataTestCaseTrait
 
         $this->assertGotenbergFormData('metadata', '{"Title":"MyBundle","Author":"SensioLabs","Creator":"SensioLabs"}');
     }
+
+    public function testSetCustomXmpMetadata(): void
+    {
+        $this->getDefaultBuilder()
+            ->metadata([
+                'Author' => 'SensioLabs',
+                'XMP-fx:DocumentType' => 'INVOICE',
+                'XMP-fx:DocumentFileName' => 'factur-x.xml',
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('metadata', '{"Author":"SensioLabs","XMP-fx:DocumentType":"INVOICE","XMP-fx:DocumentFileName":"factur-x.xml"}');
+    }
+
+    public function testAddCustomXmpMetadataToExisting(): void
+    {
+        $this->getDefaultBuilder()
+            ->metadata([
+                'Author' => 'SensioLabs',
+            ])
+            ->addMetadata('XMP-fx:DocumentType', 'INVOICE')
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('metadata', '{"XMP-fx:DocumentType":"INVOICE","Author":"SensioLabs"}');
+    }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -216,6 +216,33 @@ final class ConfigurationTest extends TestCase
         );
     }
 
+    public function testWithExtraMetadataConfiguration(): void
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(self::getWithBuilders(['pdf' => [HtmlPdfBuilder::class]]), [
+            [
+                'http_client' => 'http_client',
+                'default_options' => [
+                    'pdf' => [
+                        'html' => ['metadata' => [
+                            'Author' => 'SensioLabs',
+                            'Subject' => 'Gotenberg',
+                            'XMP-fx:DocumentType' => 'INVOICE',
+                            'XMP-fx:DocumentFileName' => 'factur-x.xml',
+                        ]],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertEquals([
+            'Author' => 'SensioLabs',
+            'Subject' => 'Gotenberg',
+            'XMP-fx:DocumentType' => 'INVOICE',
+            'XMP-fx:DocumentFileName' => 'factur-x.xml',
+        ], $config['default_options']['pdf']['html']['metadata'] ?? []);
+    }
+
     /**
      * @return array{
      *     'assets_directory': string[],


### PR DESCRIPTION
## Summary
- Allow arbitrary ExifTool-compatible metadata keys (e.g., `XMP-fx:DocumentType` for Factur-X) in both the `metadata()` PHP API and Symfony configuration
- Update `MetadataNodeBuilder` to use a variable prototype with `ignoreExtraKeys: false`, so custom keys pass through alongside the standard PDF metadata children
- Add tests for custom XMP metadata via `metadata()` and `addMetadata()`

## Test plan
- [x] `testSetCustomXmpMetadata` — verifies arbitrary XMP keys in `metadata()` are serialized correctly
- [x] `testAddCustomXmpMetadataToExisting` — verifies `addMetadata()` with custom keys merges properly
- [x] Full test suite passes (751 tests)
- [x] PHPStan passes with no errors