### PR TITLE
fix: walk class hierarchy to discover NormalizeGotenbergPayload methods

### DIFF
--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -167,17 +167,23 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
         $normalizers = [];
 
         $reflection = new \ReflectionClass(static::class);
-        foreach (array_reverse($reflection->getMethods()) as $method) {
-            $attributes = $method->getAttributes(NormalizeGotenbergPayload::class);
+        do {
+            foreach (array_reverse($reflection->getMethods()) as $method) {
+                if ($method->getDeclaringClass()->getName() !== $reflection->getName()) {
+                    continue;
+                }
 
-            if (\count($attributes) === 0) {
-                continue;
-            }
+                $attributes = $method->getAttributes(NormalizeGotenbergPayload::class);
 
-            foreach ($method->invoke($this) as $key => $value) {
-                $normalizers[$key] = $value;
+                if (\count($attributes) === 0) {
+                    continue;
+                }
+
+                foreach ($method->invoke($this) as $key => $value) {
+                    $normalizers[$key] = $value;
+                }
             }
-        }
+        } while ($reflection = $reflection->getParentClass());
 
         $version = $this->getVersion();
         $logger = $this->getLogger();

--- a/tests/Builder/AbstractBuilderNormalizeTest.php
+++ b/tests/Builder/AbstractBuilderNormalizeTest.php
@@ -18,10 +18,10 @@ final class AbstractBuilderNormalizeTest extends GotenbergBuilderTestCase
     public function testNormalizePayloadFromTraitUsedInAbstractParent(): void
     {
         $this->getBuilder()
-            ->setValue(true)
+            ->enableFeature()
             ->generate()
         ;
 
-        $this->assertGotenbergFormData('key', 'true');
+        $this->assertGotenbergFormData('feature', 'true');
     }
 }

--- a/tests/Builder/AbstractBuilderNormalizeTest.php
+++ b/tests/Builder/AbstractBuilderNormalizeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder;
+
+use Sensiolabs\GotenbergBundle\Test\Builder\GotenbergBuilderTestCase;
+use Sensiolabs\GotenbergBundle\Tests\Builder\Fixtures\ConcreteTestBuilder;
+
+/**
+ * @extends GotenbergBuilderTestCase<ConcreteTestBuilder>
+ */
+final class AbstractBuilderNormalizeTest extends GotenbergBuilderTestCase
+{
+    protected function createBuilder(): ConcreteTestBuilder
+    {
+        return new ConcreteTestBuilder();
+    }
+
+    public function testNormalizePayloadFromTraitUsedInAbstractParent(): void
+    {
+        $this->getBuilder()
+            ->setValue(true)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('key', 'true');
+    }
+}

--- a/tests/Builder/Fixtures/AbstractTestBuilder.php
+++ b/tests/Builder/Fixtures/AbstractTestBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Fixtures;
+
+use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
+
+abstract class AbstractTestBuilder extends AbstractBuilder
+{
+    use BehaviorTestTrait;
+
+    protected function getEndpoint(): string
+    {
+        return '/test';
+    }
+}

--- a/tests/Builder/Fixtures/BehaviorTestTrait.php
+++ b/tests/Builder/Fixtures/BehaviorTestTrait.php
@@ -10,16 +10,16 @@ trait BehaviorTestTrait
 {
     abstract protected function getBodyBag(): BodyBag;
 
-    public function setValue(bool $value): static
+    public function enableFeature(): static
     {
-        $this->getBodyBag()->set('key', $value);
+        $this->getBodyBag()->set('feature', true);
 
         return $this;
     }
 
     #[NormalizeGotenbergPayload]
-    private function normalizeValue(): \Generator
+    private function normalizeFeature(): \Generator
     {
-        yield 'key' => NormalizerFactory::bool();
+        yield 'feature' => NormalizerFactory::bool();
     }
 }

--- a/tests/Builder/Fixtures/BehaviorTestTrait.php
+++ b/tests/Builder/Fixtures/BehaviorTestTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Fixtures;
+
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
+use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+
+trait BehaviorTestTrait
+{
+    abstract protected function getBodyBag(): BodyBag;
+
+    public function setValue(bool $value): static
+    {
+        $this->getBodyBag()->set('key', $value);
+
+        return $this;
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizeValue(): \Generator
+    {
+        yield 'key' => NormalizerFactory::bool();
+    }
+}

--- a/tests/Builder/Fixtures/ConcreteTestBuilder.php
+++ b/tests/Builder/Fixtures/ConcreteTestBuilder.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Fixtures;
+
+final class ConcreteTestBuilder extends AbstractTestBuilder
+{
+}


### PR DESCRIPTION
## Summary

- `ReflectionClass::getMethods()` on a child class does not return private methods from traits used in a parent abstract class (see https://3v4l.org/93481#v8.5.3)
- Instead of changing method visibility, the fix walks up the class hierarchy via `ReflectionClass::getParentClass()` to collect all `#[NormalizeGotenbergPayload]` methods from each level
- Added a unit test with dedicated fixture classes that reproduces the issue