### PR TITLE
feat: Allow to generate a PDF from a raw html string

### DIFF
--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -744,7 +744,7 @@ return $gotenberg
 ```
 
 ### contentFile(string \$path)
-The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -756,7 +756,7 @@ return $gotenberg
 ```
 
 ### contentRaw(string \$html)
-The raw html string to convert into PDF.<br />
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -781,7 +781,7 @@ return $gotenberg
 ```
 
 ### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -796,6 +796,8 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -822,7 +824,7 @@ return $gotenberg
 ```
 
 ### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -837,6 +839,8 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -125,10 +125,13 @@ class YourController
 - [waitForSelector](#waitforselectorstring-selector)
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
+- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
@@ -752,6 +755,18 @@ return $gotenberg
 ;
 ```
 
+### contentRaw(string \$html)
+The raw html string to convert into PDF.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->contentRaw('<html><body><h2>The content</h2></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -780,6 +795,19 @@ return $gotenberg
 ;
 ```
 
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### header(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -803,6 +831,19 @@ HTML file containing the header.<br /><br />As assets files, by default the HTML
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerFile('../templates/html/header.html')
+    ->generate()
+    ->stream()
+;
+```
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -167,10 +167,13 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
+- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
@@ -803,6 +806,18 @@ return $gotenberg
 ```
 
 
+### contentRaw(string \$html)
+The raw html string to convert into PDF.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->contentRaw('<html><body><h2>The content</h2></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -831,6 +846,19 @@ return $gotenberg
 ;
 ```
 
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### header(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -854,6 +882,19 @@ HTML file containing the header.<br /><br />As assets files, by default the HTML
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerFile('../templates/html/header.html')
+    ->generate()
+    ->stream()
+;
+```
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -807,7 +807,7 @@ return $gotenberg
 
 
 ### contentRaw(string \$html)
-The raw html string to convert into PDF.<br />
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -832,7 +832,7 @@ return $gotenberg
 ```
 
 ### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -847,6 +847,8 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -873,7 +875,7 @@ return $gotenberg
 ```
 
 ### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -888,6 +890,8 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -750,7 +750,7 @@ return $gotenberg
 ```
 
 ### contentFile(string \$path)
-The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -762,7 +762,7 @@ return $gotenberg
 ```
 
 ### contentRaw(string \$html)
-The raw html string to convert into PDF.<br />
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -787,7 +787,7 @@ return $gotenberg
 ```
 
 ### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -802,6 +802,8 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -828,7 +830,7 @@ return $gotenberg
 ```
 
 ### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -843,6 +845,8 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -116,10 +116,13 @@ class YourController
 - [waitForSelector](#waitforselectorstring-selector)
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
+- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
@@ -758,6 +761,18 @@ return $gotenberg
 ;
 ```
 
+### contentRaw(string \$html)
+The raw html string to convert into PDF.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->contentRaw('<html><body><h2>The content</h2></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -786,6 +801,19 @@ return $gotenberg
 ;
 ```
 
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### header(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -809,6 +837,19 @@ HTML file containing the header.<br /><br />As assets files, by default the HTML
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerFile('../templates/html/header.html')
+    ->generate()
+    ->stream()
+;
+```
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -106,10 +106,13 @@ class YourController
 - [waitForSelector](#waitforselectorstring-selector)
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
+- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -469,6 +472,18 @@ return $gotenberg
 ;
 ```
 
+### contentRaw(string \$html)
+The raw html string to convert into PDF.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->contentRaw('<html><body><h2>The content</h2></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -497,6 +512,19 @@ return $gotenberg
 ;
 ```
 
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### header(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -520,6 +548,19 @@ HTML file containing the header.<br /><br />As assets files, by default the HTML
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerFile('../templates/html/header.html')
+    ->generate()
+    ->stream()
+;
+```
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -461,7 +461,7 @@ return $gotenberg
 ```
 
 ### contentFile(string \$path)
-The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -473,7 +473,7 @@ return $gotenberg
 ```
 
 ### contentRaw(string \$html)
-The raw html string to convert into PDF.<br />
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -498,7 +498,7 @@ return $gotenberg
 ```
 
 ### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -513,6 +513,8 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -539,7 +541,7 @@ return $gotenberg
 ```
 
 ### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -554,6 +556,8 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -149,10 +149,13 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
+- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -536,6 +539,18 @@ return $gotenberg
 ```
 
 
+### contentRaw(string \$html)
+The raw html string to convert into PDF.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->contentRaw('<html><body><h2>The content</h2></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -564,6 +579,19 @@ return $gotenberg
 ;
 ```
 
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### header(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -587,6 +615,19 @@ HTML file containing the header.<br /><br />As assets files, by default the HTML
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerFile('../templates/html/header.html')
+    ->generate()
+    ->stream()
+;
+```
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -540,7 +540,7 @@ return $gotenberg
 
 
 ### contentRaw(string \$html)
-The raw html string to convert into PDF.<br />
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -565,7 +565,7 @@ return $gotenberg
 ```
 
 ### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -580,6 +580,8 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -606,7 +608,7 @@ return $gotenberg
 ```
 
 ### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -621,6 +623,8 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -476,7 +476,7 @@ return $gotenberg
 ```
 
 ### contentFile(string \$path)
-The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -488,7 +488,7 @@ return $gotenberg
 ```
 
 ### contentRaw(string \$html)
-The raw html string to convert into PDF.<br />
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 ```php
 return $gotenberg
@@ -513,7 +513,7 @@ return $gotenberg
 ```
 
 ### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -528,6 +528,8 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -554,7 +556,7 @@ return $gotenberg
 ```
 
 ### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
+HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -569,6 +571,8 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
+The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -94,10 +94,13 @@ class YourController
 - [waitForSelector](#waitforselectorstring-selector)
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
+- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -484,6 +487,18 @@ return $gotenberg
 ;
 ```
 
+### contentRaw(string \$html)
+The raw html string to convert into PDF.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->contentRaw('<html><body><h2>The content</h2></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -512,6 +527,19 @@ return $gotenberg
 ;
 ```
 
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
 ### header(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -535,6 +563,19 @@ HTML file containing the header.<br /><br />As assets files, by default the HTML
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerFile('../templates/html/header.html')
+    ->generate()
+    ->stream()
+;
+```
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -41,7 +41,8 @@ trait ContentTrait
     /**
      * The raw html string to convert into PDF.
      *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
      *
      * @example contentRaw('<html><body><h2>The content</h2></body></html>')
      */
@@ -56,6 +57,9 @@ trait ContentTrait
      * As assets files, by default the HTML files are fetch in the assets folder of your application.
      * If your HTML files are in another folder, you can override the default value of assets_directory in your
      * configuration file config/sensiolabs_gotenberg.yml.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
@@ -88,7 +92,8 @@ trait ContentTrait
     /**
      * The raw html string to convert into PDF.
      *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
@@ -121,7 +126,8 @@ trait ContentTrait
     /**
      * The raw html string to convert into PDF.
      *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
@@ -138,6 +144,9 @@ trait ContentTrait
      * As assets files, by default the HTML files are fetch in the assets folder of your application.
      * If your HTML files are in another folder, you can override the default value of assets_directory in your
      * configuration file config/sensiolabs_gotenberg.yml.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
@@ -156,6 +165,9 @@ trait ContentTrait
      * As assets files, by default the HTML files are fetch in the assets folder of your application.
      * If your HTML files are in another folder, you can override the default value of assets_directory in your
      * configuration file config/sensiolabs_gotenberg.yml.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -41,6 +41,8 @@ trait ContentTrait
     /**
      * The raw html string to convert into PDF.
      *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically
+     *
      * @example contentRaw('<html><body><h2>The content</h2></body></html>')
      */
     public function contentRaw(string $html): self
@@ -84,6 +86,10 @@ trait ContentTrait
     }
 
     /**
+     * The raw html string to convert into PDF.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically
+     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @example headerRaw('<html><body><h1>The header</h1></body></html>')
@@ -113,6 +119,10 @@ trait ContentTrait
     }
 
     /**
+     * The raw html string to convert into PDF.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically
+     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @example footerRaw('<html><body><h6>The footer</h6></body></html>')

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -38,6 +38,11 @@ trait ContentTrait
         return $this->withRenderedPart(Part::Body, $template, $context);
     }
 
+    public function contentString(string $html): self
+    {
+        return $this->withRawPart(Part::Body, $html);
+    }
+
     /**
      * The HTML file to convert into PDF.
      *
@@ -74,6 +79,17 @@ trait ContentTrait
     }
 
     /**
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @example headerString('<html><body><h1>The header</h1></body></html>')
+     */
+    #[WithConfigurationNode(new ArrayNodeBuilder('header'))]
+    public function headerString(string $html): static
+    {
+        return $this->withRawPart(Part::Header, $html);
+    }
+
+    /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
@@ -90,6 +106,17 @@ trait ContentTrait
     public function footer(string $template, array $context = []): static
     {
         return $this->withRenderedPart(Part::Footer, $template, $context);
+    }
+
+    /**
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @example footerString('<html><body><h6>The footer</h6></body></html>')
+     */
+    #[WithConfigurationNode(new ArrayNodeBuilder('footer'))]
+    public function footerString(string $html): static
+    {
+        return $this->withRawPart(Part::Footer, $html);
     }
 
     /**
@@ -146,6 +173,13 @@ trait ContentTrait
         }
 
         $this->getBodyBag()->set($part->value, $renderedPart);
+
+        return $this;
+    }
+
+    protected function withRawPart(Part $part, string $html): static
+    {
+        $this->getBodyBag()->set($part->value, new RenderedPart($part, $html));
 
         return $this;
     }

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -38,7 +38,12 @@ trait ContentTrait
         return $this->withRenderedPart(Part::Body, $template, $context);
     }
 
-    public function contentString(string $html): self
+    /**
+     * The raw html string to convert into PDF.
+     *
+     * @example contentRaw('<html><body><h2>The content</h2></body></html>')
+     */
+    public function contentRaw(string $html): self
     {
         return $this->withRawPart(Part::Body, $html);
     }
@@ -81,10 +86,9 @@ trait ContentTrait
     /**
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
-     * @example headerString('<html><body><h1>The header</h1></body></html>')
+     * @example headerRaw('<html><body><h1>The header</h1></body></html>')
      */
-    #[WithConfigurationNode(new ArrayNodeBuilder('header'))]
-    public function headerString(string $html): static
+    public function headerRaw(string $html): static
     {
         return $this->withRawPart(Part::Header, $html);
     }
@@ -111,10 +115,9 @@ trait ContentTrait
     /**
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
-     * @example footerString('<html><body><h6>The footer</h6></body></html>')
+     * @example footerRaw('<html><body><h6>The footer</h6></body></html>')
      */
-    #[WithConfigurationNode(new ArrayNodeBuilder('footer'))]
-    public function footerString(string $html): static
+    public function footerRaw(string $html): static
     {
         return $this->withRawPart(Part::Footer, $html);
     }

--- a/tests/Builder/Pdf/HtmlPdfBuilderTest.php
+++ b/tests/Builder/Pdf/HtmlPdfBuilderTest.php
@@ -125,6 +125,94 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
         $this->assertContentFile('index.html', 'text/html', $expected);
     }
 
+    public function testWithRawHtmlWithHeaderAndFooterParts(): void
+    {
+        $this->getBuilder()
+            ->headerRaw(<<<HTML
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8" />
+                    <title>My PDF Header</title>
+                </head>
+                <body>
+                    <h1>Hello world!</h1>
+                    <img src="logo.png" />
+                </body>
+            </html>
+            HTML)
+            ->contentRaw(<<<HTML
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8" />
+                    <title>My PDF</title>
+                </head>
+                <body>
+                    <h2>Hello world!</h2>
+                    <img src="logo.png" />
+                </body>
+            </html>
+            HTML)
+            ->footerRaw(<<<HTML
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8" />
+                    <title>My PDF Footer</title>
+                </head>
+                <body>
+                    <h6>Hello world!</h6>
+                    <img src="logo.png" />
+                </body>
+            </html>
+            HTML)
+            ->generate()
+        ;
+
+        $this->assertContentFile('header.html', 'text/html', <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <title>My PDF Header</title>
+            </head>
+            <body>
+                <h1>Hello world!</h1>
+                <img src="logo.png" />
+            </body>
+        </html>
+        HTML);
+
+        $this->assertContentFile('index.html', 'text/html', <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <title>My PDF</title>
+            </head>
+            <body>
+                <h2>Hello world!</h2>
+                <img src="logo.png" />
+            </body>
+        </html>
+        HTML);
+
+        $this->assertContentFile('footer.html', 'text/html', <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <title>My PDF Footer</title>
+            </head>
+            <body>
+                <h6>Hello world!</h6>
+                <img src="logo.png" />
+            </body>
+        </html>
+        HTML);
+    }
+
     public function testWithTwigAndHeaderFooterParts(): void
     {
         $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | yes   |
| BC break ?              | no   |
| Issues                  | - |

## Description

Allow to generate a PDF from an html string.
Useful when the template is already rendered and your application receive the final html to render.

```
$this->gotenberg
    ->html()
    ->contentString($htmlContent)
```

Please, tell me if this is something we could consider, and if yes, I can update the documentation and write tests
