### PR TITLE
feat: Allow to pass a custom callback on pdf stream process

### DIFF
--- a/src/Builder/Result/GotenbergFileResult.php
+++ b/src/Builder/Result/GotenbergFileResult.php
@@ -106,7 +106,7 @@ class GotenbergFileResult extends AbstractGotenbergResult
         return $generator->getReturn();
     }
 
-    public function stream(): StreamedResponse
+    public function stream(callable $streamCallback = null): StreamedResponse
     {
         $this->ensureExecution();
         $this->processed = true;
@@ -119,19 +119,25 @@ class GotenbergFileResult extends AbstractGotenbergResult
             $headers['Content-Disposition'] = [HeaderUtils::makeDisposition($this->disposition, $filename)];
         }
 
+        $stream = $this->stream;
+
         return new StreamedResponse(
-            function () use ($filename): void {
-                if (!$this->stream->valid()) {
-                    throw new ProcessorException('Already processed query.');
+            $streamCallback
+                ? function () use ($streamCallback, $stream) {
+                    return $streamCallback($stream);
                 }
+                : function () use ($stream, $filename): void {
+                    if (!$stream->valid()) {
+                        throw new ProcessorException('Already processed query.');
+                    }
 
-                $generator = ($this->processor)($filename);
+                    $generator = ($this->processor)($filename);
 
-                foreach ($this->stream as $chunk) {
-                    $generator->send($chunk);
-                    echo $chunk->getContent();
-                    flush();
-                }
+                    foreach ($stream as $chunk) {
+                        $generator->send($chunk);
+                        echo $chunk->getContent();
+                        flush();
+                    }
             },
             $this->getStatusCode(),
             $headers,


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | yes   |
| BC break ?              | yes   |
| Issues                  | - |

## Description

This allow the user to give a custom callback, to override the default stream process if needed.

To give an example, I need to save the generated PDF to an S3 before sending it to the client.
I am able to do it with this code change and this callback in my app:

```
->stream(function (ResponseStreamInterface $stream) use ($storagePath): void {
      $tempFile = tmpfile();

      foreach ($stream as $chunk) {
          $content = $chunk->getContent();
          echo $content;
          flush();
          fwrite($tempFile, $content);
      }

      rewind($tempFile);
      $this->storage->writeStream($storagePath, $tempFile);
      fclose($tempFile);
  })
```

Please let me know what you think of this :)