### PR TITLE
feat: add Rotate (release 8.28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 .phpunit.result.cache
 composer.lock
 phpstan.neon
-/config/reference.php

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -4,3 +4,4 @@
 
 * `Sensiolabs\GotenbergBundle\GotenbergPdfInterface` new method `watermark` added
 * `Sensiolabs\GotenbergBundle\GotenbergPdfInterface` new method `stamp` added
+* `Sensiolabs\GotenbergBundle\GotenbergPdfInterface` new method `rotate` added

--- a/config/builder_pdf.php
+++ b/config/builder_pdf.php
@@ -8,6 +8,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -112,6 +113,14 @@ return static function (ContainerConfigurator $container): void {
 
     // Stamp
     $services->set('.sensiolabs_gotenberg.pdf_builder.stamp', StampPdfBuilder::class)
+        ->share(false)
+        ->parent('.sensiolabs_gotenberg.abstract_builder')
+        ->tag('sensiolabs_gotenberg.builder')
+        ->configurator(service('sensiolabs_gotenberg.builder_configurator'))
+    ;
+
+    // Rotate
+    $services->set('.sensiolabs_gotenberg.pdf_builder.rotate', RotatePdfBuilder::class)
         ->share(false)
         ->parent('.sensiolabs_gotenberg.abstract_builder')
         ->tag('sensiolabs_gotenberg.builder')

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -10,6 +10,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -70,6 +71,7 @@ class BuilderParser
             LibreOfficePdfBuilder::class,
             MarkdownPdfBuilder::class,
             MergePdfBuilder::class,
+            RotatePdfBuilder::class,
             SplitPdfBuilder::class,
             StampPdfBuilder::class,
             UrlPdfBuilder::class,

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -86,6 +86,8 @@ class YourController
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
+- [rotateAngle](#rotateanglesensiolabsgotenbergbundleenumerationrotateangle-rotateangle)
+- [rotatePages](#rotatepagesstring-rotatepages)
 - [splitMode](#splitmodesensiolabsgotenbergbundleenumerationsplitmode-splitmode)
 - [splitSpan](#splitspanstring-splitspan)
 - [splitUnify](#splitunifybool-bool)
@@ -267,6 +269,36 @@ Enable PDF for Universal Access for optimal accessibility.<br />
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->pdfUniversalAccess()  // is same as `->pdfUniversalAccess(true)`
+    ->generate()
+    ->stream()
+;
+```
+
+### rotateAngle(?Sensiolabs\GotenbergBundle\Enumeration\RotateAngle \$rotateAngle)
+The rotation angle.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotateAngle(RotateAngle::Rotate90)
+    ->generate()
+    ->stream()
+;
+```
+
+### rotatePages(?string \$rotatePages)
+Page ranges to rotate (e.g., '1-3', '5'). Empty means all pages.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotatePages('1-2')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -99,6 +99,8 @@ class YourController
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
 - [quality](#qualityint-quality)
 - [reduceImageResolution](#reduceimageresolutionbool-bool)
+- [rotateAngle](#rotateanglesensiolabsgotenbergbundleenumerationrotateangle-rotateangle)
+- [rotatePages](#rotatepagesstring-rotatepages)
 - [singlePageSheets](#singlepagesheetsbool-bool)
 - [skipEmptyPages](#skipemptypagesbool-bool)
 - [splitMode](#splitmodesensiolabsgotenbergbundleenumerationsplitmode-splitmode)
@@ -537,6 +539,36 @@ Specify if the resolution of each image is reduced to the resolution specified b
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->reduceImageResolution()  // is same as `->reduceImageResolution(true)`
+    ->generate()
+    ->stream()
+;
+```
+
+### rotateAngle(?Sensiolabs\GotenbergBundle\Enumeration\RotateAngle \$rotateAngle)
+The rotation angle.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotateAngle(RotateAngle::Rotate90)
+    ->generate()
+    ->stream()
+;
+```
+
+### rotatePages(?string \$rotatePages)
+Page ranges to rotate (e.g., '1-3', '5'). Empty means all pages.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotatePages('1-2')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -128,6 +128,8 @@ class YourController
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
+- [rotateAngle](#rotateanglesensiolabsgotenbergbundleenumerationrotateangle-rotateangle)
+- [rotatePages](#rotatepagesstring-rotatepages)
 - [splitMode](#splitmodesensiolabsgotenbergbundleenumerationsplitmode-splitmode)
 - [splitSpan](#splitspanstring-splitspan)
 - [splitUnify](#splitunifybool-bool)
@@ -300,6 +302,36 @@ Enable PDF for Universal Access for optimal accessibility.<br />
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->pdfUniversalAccess()  // is same as `->pdfUniversalAccess(true)`
+    ->generate()
+    ->stream()
+;
+```
+
+### rotateAngle(?Sensiolabs\GotenbergBundle\Enumeration\RotateAngle \$rotateAngle)
+The rotation angle.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotateAngle(RotateAngle::Rotate90)
+    ->generate()
+    ->stream()
+;
+```
+
+### rotatePages(?string \$rotatePages)
+Page ranges to rotate (e.g., '1-3', '5'). Empty means all pages.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotatePages('1-2')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/RotatePdfBuilder.md
+++ b/docs/pdf/RotatePdfBuilder.md
@@ -1,0 +1,162 @@
+## Customization
+
+### Available methods
+
+- [downloadFrom](#downloadfromarray-downloadfrom)
+- [files](#filesstringablestring-paths)
+- [rotateAngle](#rotateanglesensiolabsgotenbergbundleenumerationrotateangle-rotateangle)
+- [rotatePages](#rotatepagesstring-rotatepages)
+- [webhook](#webhookarray-webhook)
+- [webhookConfiguration](#webhookconfigurationstring-name)
+- [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
+- [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
+- [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
+- [webhookUrl](#webhookurlstring-url-string-method)
+
+### downloadFrom(array \$downloadFrom)
+Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#download-from](https://gotenberg.dev/docs/webhook-download#download-from)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->downloadFrom([['url' => 'http://example.com/url/to/file', 'extraHttpHeaders' => ['MyHeader' => 'MyValue']], ['url' => 'http://example.com/url/to/file', 'extraHttpHeaders' => ['MyHeaderOne' => 'MyValue', 'MyHeaderTwo' => 'MyValue']]])
+    ->generate()
+    ->stream()
+;
+```
+
+### files(Stringable|string ...\$paths)
+Add PDF files to rotate.<br />As assets files, by default the PDF files are fetched in the assets folder<br />of your application. For more information about path resolution go to<br />assets documentation.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->files('document.pdf','document_2.pdf')
+    ->generate()
+    ->stream()
+;
+```
+
+### rotateAngle(?Sensiolabs\GotenbergBundle\Enumeration\RotateAngle \$rotateAngle)
+The rotation angle.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotateAngle(RotateAngle::Rotate90)
+    ->generate()
+    ->stream()
+;
+```
+
+### rotatePages(?string \$rotatePages)
+Page ranges to rotate (e.g., '1-3', '5'). Empty means all pages.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotatePages('1-2')
+    ->generate()
+    ->stream()
+;
+```
+
+
+### webhook(array \$webhook)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookConfiguration(string \$name)
+Providing an existing $name from the configuration file, it will correctly set both success and error webhook URLs as well as extra_http_headers if defined.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookConfiguration('my_webhook_config')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookErrorRoute(string \$route, array \$parameters, ?string \$method)
+Sets the webhook route with params and method for cases of error.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookErrorRoute('my_route_error', ['foo' => 'bar'], 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookErrorUrl(string \$url, ?string \$method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookExtraHeaders(array \$extraHttpHeaders)
+Extra headers that will be provided to the webhook endpoint. May it either be Success or Error.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookExtraHeaders(['Authorization' => 'Bearer my-secret-token','X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookRoute(string \$route, array \$parameters, ?string \$method)
+Sets the webhook route with params and method for cases of success.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookRoute('my_route_success', ['foo' => 'bar'], 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookUrl(string \$url, ?string \$method)
+Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method for such endpoint among : POST, PUT or PATCH.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+

--- a/docs/pdf/RotatePdfBuilder.md
+++ b/docs/pdf/RotatePdfBuilder.md
@@ -6,10 +6,13 @@
 - [files](#filesstringablestring-paths)
 - [rotateAngle](#rotateanglesensiolabsgotenbergbundleenumerationrotateangle-rotateangle)
 - [rotatePages](#rotatepagesstring-rotatepages)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -75,6 +78,18 @@ return $gotenberg
 ```
 
 
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
+
 ### webhook(array \$webhook)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
@@ -82,7 +97,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -119,6 +134,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -75,6 +75,8 @@ class YourController
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
+- [rotateAngle](#rotateanglesensiolabsgotenbergbundleenumerationrotateangle-rotateangle)
+- [rotatePages](#rotatepagesstring-rotatepages)
 - [route](#routestring-name-array-parameters)
 - [splitMode](#splitmodesensiolabsgotenbergbundleenumerationsplitmode-splitmode)
 - [splitSpan](#splitspanstring-splitspan)
@@ -234,6 +236,36 @@ Enable PDF for Universal Access for optimal accessibility.<br />
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->pdfUniversalAccess()  // is same as `->pdfUniversalAccess(true)`
+    ->generate()
+    ->stream()
+;
+```
+
+### rotateAngle(?Sensiolabs\GotenbergBundle\Enumeration\RotateAngle \$rotateAngle)
+The rotation angle.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotateAngle(RotateAngle::Rotate90)
+    ->generate()
+    ->stream()
+;
+```
+
+### rotatePages(?string \$rotatePages)
+Page ranges to rotate (e.g., '1-3', '5'). Empty means all pages.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->rotatePages('1-2')
     ->generate()
     ->stream()
 ;

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -185,6 +185,18 @@ parameters:
 			message: '#^Call to function is_array\(\) with array\<string, mixed\> will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
+			path: src/Builder/Pdf/RotatePdfBuilder.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Builder/Pdf/RotatePdfBuilder.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\<string, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
 			path: src/Builder/Screenshot/HtmlScreenshotBuilder.php
 
 		-

--- a/src/Builder/Behaviors/ChromiumPdfTrait.php
+++ b/src/Builder/Behaviors/ChromiumPdfTrait.php
@@ -19,6 +19,7 @@ trait ChromiumPdfTrait
     use FlattenTrait;
     use MetadataTrait;
     use PdfFormatTrait;
+    use RotateTrait;
     use SplitTrait;
     use StampTrait;
     use WatermarkTrait;

--- a/src/Builder/Behaviors/LibreOfficeTrait.php
+++ b/src/Builder/Behaviors/LibreOfficeTrait.php
@@ -9,6 +9,7 @@ trait LibreOfficeTrait
     use LibreOffice\PagePropertiesTrait;
     use MetadataTrait;
     use PdfFormatTrait;
+    use RotateTrait;
     use SplitTrait;
     use StampTrait;
     use WatermarkTrait;

--- a/src/Builder/Behaviors/RotateTrait.php
+++ b/src/Builder/Behaviors/RotateTrait.php
@@ -4,14 +4,18 @@ namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
 
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\RotateAngle;
 use Sensiolabs\GotenbergBundle\NodeBuilder\NativeEnumNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
 
 trait RotateTrait
 {
+    use LoggerAwareTrait;
+
     abstract protected function getBodyBag(): BodyBag;
 
     /**
@@ -24,6 +28,8 @@ trait RotateTrait
     #[WithConfigurationNode(new NativeEnumNodeBuilder('rotate_angle', enumClass: RotateAngle::class))]
     public function rotateAngle(RotateAngle|null $rotateAngle = null): static
     {
+        $this->logWarningIfVersionIs('<', '8.28', 'The rotateAngle option is not available.');
+
         if (null === $rotateAngle) {
             $this->getBodyBag()->unset('rotateAngle');
 
@@ -45,13 +51,14 @@ trait RotateTrait
     #[WithConfigurationNode(new ScalarNodeBuilder('rotate_pages'))]
     public function rotatePages(string|null $rotatePages = null): static
     {
-        if (null === $rotatePages) {
+        $this->logWarningIfVersionIs('<', '8.28', 'The rotatePages option is not available.');
+
+        if (!$rotatePages) {
             $this->getBodyBag()->unset('rotatePages');
-
-            return $this;
+        } else {
+            ValidatorFactory::range($rotatePages);
+            $this->getBodyBag()->set('rotatePages', $rotatePages);
         }
-
-        $this->getBodyBag()->set('rotatePages', $rotatePages);
 
         return $this;
     }

--- a/src/Builder/Behaviors/RotateTrait.php
+++ b/src/Builder/Behaviors/RotateTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
+
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
+use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Enumeration\RotateAngle;
+use Sensiolabs\GotenbergBundle\NodeBuilder\NativeEnumNodeBuilder;
+use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
+
+trait RotateTrait
+{
+    abstract protected function getBodyBag(): BodyBag;
+
+    /**
+     * The rotation angle.
+     *
+     * @see https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs
+     *
+     * @example rotateAngle(RotateAngle::Rotate90)
+     */
+    #[WithConfigurationNode(new NativeEnumNodeBuilder('rotate_angle', enumClass: RotateAngle::class))]
+    public function rotateAngle(RotateAngle|null $rotateAngle = null): static
+    {
+        if (null === $rotateAngle) {
+            $this->getBodyBag()->unset('rotateAngle');
+
+            return $this;
+        }
+
+        $this->getBodyBag()->set('rotateAngle', $rotateAngle);
+
+        return $this;
+    }
+
+    /**
+     * Page ranges to rotate (e.g., '1-3', '5'). Empty means all pages.
+     *
+     * @see https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs
+     *
+     * @example rotatePages('1-2')
+     */
+    #[WithConfigurationNode(new ScalarNodeBuilder('rotate_pages'))]
+    public function rotatePages(string|null $rotatePages = null): static
+    {
+        if (null === $rotatePages) {
+            $this->getBodyBag()->unset('rotatePages');
+
+            return $this;
+        }
+
+        $this->getBodyBag()->set('rotatePages', $rotatePages);
+
+        return $this;
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizeRotate(): \Generator
+    {
+        yield 'rotateAngle' => NormalizerFactory::enum();
+    }
+}

--- a/src/Builder/Pdf/RotatePdfBuilder.php
+++ b/src/Builder/Pdf/RotatePdfBuilder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
+
+use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\RotateTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\WebhookTrait;
+use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
+
+/**
+ * You may have the possibility to rotate PDF pages by 90°, 180°, or 270°.
+ *
+ * @see https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs
+ *
+ * @methodDoc files Add PDF files to rotate.
+ * As assets files, by default the PDF files are fetched in the assets folder
+ * of your application. For more information about path resolution go to
+ * assets documentation.
+ *
+ * @see https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs
+ *
+ * @example files('document.pdf','document_2.pdf')
+ */
+#[WithBuilderConfiguration(type: 'pdf', name: 'rotate')]
+final class RotatePdfBuilder extends AbstractBuilder
+{
+    use AssetBaseDirFormatterAwareTrait;
+    use DownloadFromTrait;
+    use FilesTrait;
+    use RotateTrait;
+    use WebhookTrait;
+
+    public const ENDPOINT = '/forms/pdfengines/rotate';
+
+    private const AVAILABLE_EXTENSIONS = [
+        'pdf',
+    ];
+
+    protected function getAllowedFilesExtensions(): array
+    {
+        return self::AVAILABLE_EXTENSIONS;
+    }
+
+    protected function getEndpoint(): string
+    {
+        return self::ENDPOINT;
+    }
+
+    protected function validatePayloadBody(): void
+    {
+        $this->introducedIn('8.28');
+
+        if ($this->getBodyBag()->get('files') === null && $this->getBodyBag()->get('downloadFrom') === null) {
+            throw new MissingRequiredFieldException('At least one PDF file is required.');
+        }
+
+        if ($this->getBodyBag()->get('rotateAngle') === null) {
+            throw new MissingRequiredFieldException('Field "rotateAngle" must be provided.');
+        }
+    }
+}

--- a/src/Debug/TraceableGotenbergPdf.php
+++ b/src/Debug/TraceableGotenbergPdf.php
@@ -11,6 +11,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -243,6 +244,23 @@ final class TraceableGotenbergPdf implements GotenbergPdfInterface
         }
 
         $this->builders[] = ['watermark', $traceableBuilder];
+
+        return $traceableBuilder;
+    }
+
+    /**
+     * @return RotatePdfBuilder|TraceableBuilder
+     */
+    public function rotate(): BuilderInterface
+    {
+        /** @var RotatePdfBuilder|TraceableBuilder $traceableBuilder */
+        $traceableBuilder = $this->inner->rotate();
+
+        if (!$traceableBuilder instanceof TraceableBuilder) {
+            return $traceableBuilder;
+        }
+
+        $this->builders[] = ['rotate', $traceableBuilder];
 
         return $traceableBuilder;
     }

--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -34,6 +34,7 @@ use Symfony\Component\Routing\RequestContext;
  *              merge: array<string, mixed>,
  *              convert: array<string, mixed>,
  *              split: array<string, mixed>,
+ *              rotate: array<string, mixed>,
  *              encrypt: array<string, mixed>,
  *              embed: array<string, mixed>,
  *              stamp: array<string, mixed>,

--- a/src/Enumeration/RotateAngle.php
+++ b/src/Enumeration/RotateAngle.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Enumeration;
+
+enum RotateAngle: int
+{
+    case Rotate90 = 90;
+    case Rotate180 = 180;
+    case Rotate270 = 270;
+}

--- a/src/GotenbergPdf.php
+++ b/src/GotenbergPdf.php
@@ -12,6 +12,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -30,7 +31,7 @@ final class GotenbergPdf implements GotenbergPdfInterface
     }
 
     /**
-     * @param 'html'|'url'|'markdown'|'office'|'merge'|'convert'|'split'|'flatten'|'encrypt'|'embed'|'stamp'|'watermark' $key
+     * @param 'html'|'url'|'markdown'|'office'|'merge'|'convert'|'split'|'flatten'|'encrypt'|'embed'|'stamp'|'watermark'|'rotate' $key
      *
      * @return (
      *   $key is 'html' ? HtmlPdfBuilder :
@@ -45,6 +46,7 @@ final class GotenbergPdf implements GotenbergPdfInterface
      *   $key is 'embed' ? EmbedPdfBuilder :
      *   $key is 'stamp' ? StampPdfBuilder :
      *   $key is 'watermark' ? WatermarkPdfBuilder :
+     *   $key is 'rotate' ? RotatePdfBuilder :
      *   BuilderInterface
      * )
      */
@@ -111,5 +113,10 @@ final class GotenbergPdf implements GotenbergPdfInterface
     public function watermark(): BuilderInterface
     {
         return $this->getInternal('watermark');
+    }
+
+    public function rotate(): BuilderInterface
+    {
+        return $this->getInternal('rotate');
     }
 }

--- a/src/GotenbergPdfInterface.php
+++ b/src/GotenbergPdfInterface.php
@@ -11,6 +11,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -86,4 +87,9 @@ interface GotenbergPdfInterface
      * @return WatermarkPdfBuilder
      */
     public function watermark(): BuilderInterface;
+
+    /**
+     * @return RotatePdfBuilder
+     */
+    public function rotate(): BuilderInterface;
 }

--- a/src/SensiolabsGotenbergBundle.php
+++ b/src/SensiolabsGotenbergBundle.php
@@ -10,6 +10,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -41,6 +42,7 @@ class SensiolabsGotenbergBundle extends Bundle
         $extension->registerBuilder(LibreOfficePdfBuilder::class);
         $extension->registerBuilder(MarkdownPdfBuilder::class);
         $extension->registerBuilder(MergePdfBuilder::class);
+        $extension->registerBuilder(RotatePdfBuilder::class);
         $extension->registerBuilder(SplitPdfBuilder::class);
         $extension->registerBuilder(StampPdfBuilder::class);
         $extension->registerBuilder(UrlPdfBuilder::class);

--- a/tests/Builder/Behaviors/RotateTestCaseTrait.php
+++ b/tests/Builder/Behaviors/RotateTestCaseTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors;
+
+use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
+use Sensiolabs\GotenbergBundle\Enumeration\RotateAngle;
+
+/**
+ * @template T of BuilderInterface
+ */
+trait RotateTestCaseTrait
+{
+    /** @use BehaviorTrait<T> */
+    use BehaviorTrait;
+
+    abstract protected function assertGotenbergFormData(string $field, string $expectedValue): void;
+
+    public function testRotateAngle90(): void
+    {
+        $this->getDefaultBuilder()
+            ->rotateAngle(RotateAngle::Rotate90)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('rotateAngle', '90');
+    }
+
+    public function testRotateAngle180(): void
+    {
+        $this->getDefaultBuilder()
+            ->rotateAngle(RotateAngle::Rotate180)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('rotateAngle', '180');
+    }
+
+    public function testRotateAngle270(): void
+    {
+        $this->getDefaultBuilder()
+            ->rotateAngle(RotateAngle::Rotate270)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('rotateAngle', '270');
+    }
+
+    public function testRotatePages(): void
+    {
+        $this->getDefaultBuilder()
+            ->rotatePages('1-2')
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('rotatePages', '1-2');
+    }
+
+    public function testUnsetRotateAngle(): void
+    {
+        $builder = $this->getDefaultBuilder()
+            ->rotateAngle(RotateAngle::Rotate90)
+        ;
+
+        self::assertArrayHasKey('rotateAngle', $builder->getBodyBag()->all());
+
+        $builder->rotateAngle(null);
+        self::assertArrayNotHasKey('rotateAngle', $builder->getBodyBag()->all());
+    }
+
+    public function testUnsetRotatePages(): void
+    {
+        $builder = $this->getDefaultBuilder()
+            ->rotatePages('1-2')
+        ;
+
+        self::assertArrayHasKey('rotatePages', $builder->getBodyBag()->all());
+
+        $builder->rotatePages(null);
+        self::assertArrayNotHasKey('rotatePages', $builder->getBodyBag()->all());
+    }
+}

--- a/tests/Builder/Pdf/RotatePdfBuilderTest.php
+++ b/tests/Builder/Pdf/RotatePdfBuilderTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Pdf;
+
+use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
+use Sensiolabs\GotenbergBundle\Enumeration\RotateAngle;
+use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
+use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
+use Sensiolabs\GotenbergBundle\Test\Builder\GotenbergBuilderTestCase;
+use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\DownloadFromTestCaseTrait;
+use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\RotateTestCaseTrait;
+use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\WebhookTestCaseTrait;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @extends GotenbergBuilderTestCase<RotatePdfBuilder>
+ */
+final class RotatePdfBuilderTest extends GotenbergBuilderTestCase
+{
+    /** @use DownloadFromTestCaseTrait<RotatePdfBuilder> */
+    use DownloadFromTestCaseTrait;
+
+    /** @use RotateTestCaseTrait<RotatePdfBuilder> */
+    use RotateTestCaseTrait;
+
+    /** @use WebhookTestCaseTrait<RotatePdfBuilder> */
+    use WebhookTestCaseTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withGotenbergVersion('8.28.0');
+    }
+
+    protected function createBuilder(): RotatePdfBuilder
+    {
+        return new RotatePdfBuilder();
+    }
+
+    /**
+     * @param RotatePdfBuilder $builder
+     */
+    protected function initializeBuilder(BuilderInterface $builder, Container $container): RotatePdfBuilder
+    {
+        return $builder
+            ->files('pdf/simple_pdf.pdf')
+            ->rotateAngle(RotateAngle::Rotate90)
+        ;
+    }
+
+    public function testEndpointIsCorrect(): void
+    {
+        $this->getBuilder()
+            ->files('pdf/simple_pdf.pdf')
+            ->rotateAngle(RotateAngle::Rotate90)
+            ->generate()
+        ;
+
+        $this->assertGotenbergEndpoint('/forms/pdfengines/rotate');
+    }
+
+    public function testAddFilesAsContent(): void
+    {
+        $this->getBuilder()
+            ->files('pdf/simple_pdf.pdf')
+            ->rotateAngle(RotateAngle::Rotate90)
+            ->generate()
+        ;
+
+        $this->assertGotenbergEndpoint('/forms/pdfengines/rotate');
+        $this->assertGotenbergFormDataFile('files', 'application/pdf', self::FIXTURE_DIR.'/pdf/simple_pdf.pdf');
+    }
+
+    public function testWithStringableObject(): void
+    {
+        $class = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'pdf/simple_pdf.pdf';
+            }
+        };
+
+        $this->getBuilder()
+            ->files($class)
+            ->rotateAngle(RotateAngle::Rotate90)
+            ->generate()
+        ;
+
+        $this->assertGotenbergEndpoint('/forms/pdfengines/rotate');
+        $this->assertGotenbergFormDataFile('files', 'application/pdf', self::FIXTURE_DIR.'/pdf/simple_pdf.pdf');
+    }
+
+    public function testFilesExtensionRequirement(): void
+    {
+        $this->expectException(InvalidBuilderConfiguration::class);
+        $this->expectExceptionMessage('The file extension "png" is not valid in this context.');
+
+        $this->getBuilder()
+            ->files(self::FIXTURE_DIR.'/assets/logo.png')
+            ->rotateAngle(RotateAngle::Rotate90)
+            ->generate()
+        ;
+    }
+
+    public function testRequiredFileContent(): void
+    {
+        $this->expectException(MissingRequiredFieldException::class);
+        $this->expectExceptionMessage('At least one PDF file is required.');
+
+        $this->getBuilder()
+            ->rotateAngle(RotateAngle::Rotate90)
+            ->generate()
+        ;
+    }
+
+    public function testRequiredRotateAngleField(): void
+    {
+        $this->expectException(MissingRequiredFieldException::class);
+        $this->expectExceptionMessage('Field "rotateAngle" must be provided.');
+
+        $this->getBuilder()
+            ->files('pdf/simple_pdf.pdf')
+            ->generate()
+        ;
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -11,6 +11,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\StampPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
@@ -57,6 +58,7 @@ final class ConfigurationTest extends TestCase
                     StampPdfBuilder::class,
                     EncryptPdfBuilder::class,
                     WatermarkPdfBuilder::class,
+                    RotatePdfBuilder::class,
                 ],
                 'screenshot' => [
                     HtmlScreenshotBuilder::class,
@@ -446,6 +448,16 @@ final class ConfigurationTest extends TestCase
                             'events' => [],
                         ],
                         'watermark_options' => [],
+                    ],
+                    'rotate' => [
+                        'download_from' => [],
+                        'webhook' => [
+                            'success' => [
+                            ],
+                            'error' => [
+                            ],
+                            'extra_http_headers' => [],
+                        ],
                     ],
                 ],
                 'screenshot' => [

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -457,6 +457,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                     ],
                 ],

--- a/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
+++ b/tests/DependencyInjection/SensiolabsGotenbergExtensionTest.php
@@ -10,6 +10,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\LibreOfficePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MarkdownPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\RotatePdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\SplitPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\UrlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Screenshot\HtmlScreenshotBuilder;
@@ -47,6 +48,7 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
         $extension->registerBuilder(UrlPdfBuilder::class);
         $extension->registerBuilder(EncryptPdfBuilder::class);
         $extension->registerBuilder(EmbedPdfBuilder::class);
+        $extension->registerBuilder(RotatePdfBuilder::class);
 
         $extension->registerBuilder(HtmlScreenshotBuilder::class);
         $extension->registerBuilder(MarkdownScreenshotBuilder::class);
@@ -242,6 +244,9 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
                     'split_mode' => SplitMode::Intervals,
                     'split_span' => 1,
                 ],
+                'rotate' => [
+                    'rotate_angle' => 90,
+                ],
             ],
             'screenshot' => [
                 'html' => [
@@ -408,6 +413,7 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
                     ],
                     'encrypt' => [],
                     'embed' => [],
+                    'rotate' => [],
                 ],
             ],
         ]], $containerBuilder);
@@ -452,6 +458,7 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
                 ],
                 'encrypt' => [],
                 'embed' => [],
+                'rotate' => [],
             ],
             'screenshot' => [
                 'html' => [],
@@ -595,6 +602,7 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
      *                  'merge': array<string, mixed>,
      *                  'convert': array<string, mixed>,
      *                  'split': array<string, mixed>,
+     *                  'rotate': array<string, mixed>,
      *                  'encrypt': array<string, mixed>,
      *                  'embed': array<string, mixed>,
      *              },
@@ -797,6 +805,9 @@ final class SensiolabsGotenbergExtensionTest extends KernelTestCase
                         'split' => [
                             'split_mode' => SplitMode::Intervals->value,
                             'split_span' => 1,
+                        ],
+                        'rotate' => [
+                            'rotate_angle' => 90,
                         ],
                         'encrypt' => [
                             'user_password' => 'user_secret',


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.28      |
| Bug fix ?               | no   |
| New feature ?           | yes|
| BC break ?              | no   |

## Description

● Implements support for the new POST /forms/pdfengines/rotate route introduced in https://github.com/gotenberg/gotenberg/releases/tag/v8.28.0.

  - Adds RotatePdfBuilder composing FilesTrait, DownloadFromTrait, and WebhookTrait — intentionally minimal to match the route's actual field support                                                                               
  - Adds RotateTrait exposing two fields: rotateAngle (required) and rotatePages (optional page range)
  - Adds RotateAngle enum (90 | 180 | 270) backed by int, normalized to string via NormalizerFactory::enum()                                                                                                                        
  - Registers rotate() on GotenbergPdf, GotenbergPdfInterface, and TraceableGotenbergPdf                                                                                                                                            
  - Full test coverage: RotateTestCaseTrait + RotatePdfBuilderTest (all three angles, page range, unsetting fields, missing file/angle validation errors)                                                                           
  - Documentation generated via docs/generate.php  
