### PR TITLE
feat: Add LibreOffice new fields (release 8.28)

### DIFF
--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -94,12 +94,6 @@ class YourController
 - [merge](#mergebool-bool)
 - [metadata](#metadataarray-metadata)
 - [nativePageRanges](#nativepagerangesstring-ranges)
-- [nativeTiledWatermarkText](#nativetiledwatermarktextstring-text)
-- [nativeWatermarkColor](#nativewatermarkcolorstring-color)
-- [nativeWatermarkFontHeight](#nativewatermarkfontheightfloat-height)
-- [nativeWatermarkFontName](#nativewatermarkfontnamestring-fontname)
-- [nativeWatermarkRotateAngle](#nativewatermarkrotateanglefloat-angle)
-- [nativeWatermarkText](#nativewatermarktextstring-text)
 - [password](#passwordstring-password)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
@@ -110,6 +104,12 @@ class YourController
 - [splitMode](#splitmodesensiolabsgotenbergbundleenumerationsplitmode-splitmode)
 - [splitSpan](#splitspanstring-splitspan)
 - [splitUnify](#splitunifybool-bool)
+- [tiledWatermarkText](#tiledwatermarktextstring-text)
+- [watermarkColor](#watermarkcolorstring-color)
+- [watermarkFontHeight](#watermarkfontheightint-height)
+- [watermarkFontName](#watermarkfontnamestring-fontname)
+- [watermarkRotateAngle](#watermarkrotateangleint-angle)
+- [watermarkText](#watermarktextstring-text)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -456,96 +456,6 @@ return $gotenberg
 ;
 ```
 
-### nativeTiledWatermarkText(string \$text)
-Set a tiled watermark text rendered across every page during PDF export.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->nativeTiledWatermarkText('DRAFT')
-    ->generate()
-    ->stream()
-;
-```
-
-### nativeWatermarkColor(string \$color)
-Set the watermark text color (e.g., '#000000').<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->nativeWatermarkColor('#FF0000')
-    ->generate()
-    ->stream()
-;
-```
-
-### nativeWatermarkFontHeight(float \$height)
-Set the watermark font height in points.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->nativeWatermarkFontHeight(50.0)
-    ->generate()
-    ->stream()
-;
-```
-
-### nativeWatermarkFontName(string \$fontName)
-Set the watermark font name.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->nativeWatermarkFontName('Liberation Sans')
-    ->generate()
-    ->stream()
-;
-```
-
-### nativeWatermarkRotateAngle(float \$angle)
-Set the watermark rotation angle in degrees.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->nativeWatermarkRotateAngle(-45.0)
-    ->generate()
-    ->stream()
-;
-```
-
-### nativeWatermarkText(string \$text)
-Set the watermark text to render on every page during PDF export.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->nativeWatermarkText('CONFIDENTIAL')
-    ->generate()
-    ->stream()
-;
-```
-
 ### password(string \$password)
 Set the password for opening the source file.<br />
 
@@ -679,6 +589,96 @@ Specify whether to put extracted pages into a single file or as many files as th
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->splitUnify() // is same as `->splitUnify(true)`
+    ->generate()
+    ->stream()
+;
+```
+
+### tiledWatermarkText(string \$text)
+Set a tiled watermark text rendered across every page during PDF export.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->tiledWatermarkText('DRAFT')
+    ->generate()
+    ->stream()
+;
+```
+
+### watermarkColor(string \$color)
+Set the watermark text color as a hex string (e.g., '#FF0000').<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->watermarkColor('#FF0000')
+    ->generate()
+    ->stream()
+;
+```
+
+### watermarkFontHeight(int \$height)
+Set the watermark font height in points.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->watermarkFontHeight(50)
+    ->generate()
+    ->stream()
+;
+```
+
+### watermarkFontName(string \$fontName)
+Set the watermark font name.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->watermarkFontName('Liberation Sans')
+    ->generate()
+    ->stream()
+;
+```
+
+### watermarkRotateAngle(int \$angle)
+Set the watermark rotation angle in tenths of a degree (e.g., 450 = 45°).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->watermarkRotateAngle(-450)
+    ->generate()
+    ->stream()
+;
+```
+
+### watermarkText(string \$text)
+Set the watermark text to render on every page during PDF export.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->watermarkText('CONFIDENTIAL')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -94,6 +94,12 @@ class YourController
 - [merge](#mergebool-bool)
 - [metadata](#metadataarray-metadata)
 - [nativePageRanges](#nativepagerangesstring-ranges)
+- [nativeTiledWatermarkText](#nativetiledwatermarktextstring-text)
+- [nativeWatermarkColor](#nativewatermarkcolorstring-color)
+- [nativeWatermarkFontHeight](#nativewatermarkfontheightfloat-height)
+- [nativeWatermarkFontName](#nativewatermarkfontnamestring-fontname)
+- [nativeWatermarkRotateAngle](#nativewatermarkrotateanglefloat-angle)
+- [nativeWatermarkText](#nativewatermarktextstring-text)
 - [password](#passwordstring-password)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
@@ -445,6 +451,96 @@ Page ranges to print, e.g., '1-4' - empty means all pages.<br />
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->nativePageRanges('1-5')
+    ->generate()
+    ->stream()
+;
+```
+
+### nativeTiledWatermarkText(string \$text)
+Set a tiled watermark text rendered across every page during PDF export.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->nativeTiledWatermarkText('DRAFT')
+    ->generate()
+    ->stream()
+;
+```
+
+### nativeWatermarkColor(string \$color)
+Set the watermark text color (e.g., '#000000').<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->nativeWatermarkColor('#FF0000')
+    ->generate()
+    ->stream()
+;
+```
+
+### nativeWatermarkFontHeight(float \$height)
+Set the watermark font height in points.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->nativeWatermarkFontHeight(50.0)
+    ->generate()
+    ->stream()
+;
+```
+
+### nativeWatermarkFontName(string \$fontName)
+Set the watermark font name.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->nativeWatermarkFontName('Liberation Sans')
+    ->generate()
+    ->stream()
+;
+```
+
+### nativeWatermarkRotateAngle(float \$angle)
+Set the watermark rotation angle in degrees.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->nativeWatermarkRotateAngle(-45.0)
+    ->generate()
+    ->stream()
+;
+```
+
+### nativeWatermarkText(string \$text)
+Set the watermark text to render on every page during PDF export.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->nativeWatermarkText('CONFIDENTIAL')
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/LibreOffice/PagePropertiesTrait.php
+++ b/src/Builder/Behaviors/LibreOffice/PagePropertiesTrait.php
@@ -10,7 +10,6 @@ use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI;
 use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
-use Sensiolabs\GotenbergBundle\NodeBuilder\FloatNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\IntegerNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\NativeEnumNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
@@ -406,10 +405,10 @@ trait PagePropertiesTrait
      *
      * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
      *
-     * @example nativeWatermarkText('CONFIDENTIAL')
+     * @example watermarkText('CONFIDENTIAL')
      */
-    #[WithConfigurationNode(new ScalarNodeBuilder('native_watermark_text'))]
-    public function nativeWatermarkText(string $text): static
+    #[WithConfigurationNode(new ScalarNodeBuilder('watermark_text'))]
+    public function watermarkText(string $text): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkText is not available.');
 
@@ -419,14 +418,14 @@ trait PagePropertiesTrait
     }
 
     /**
-     * Set the watermark text color (e.g., '#000000').
+     * Set the watermark text color as a hex string (e.g., '#FF0000').
      *
      * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
      *
-     * @example nativeWatermarkColor('#FF0000')
+     * @example watermarkColor('#FF0000')
      */
-    #[WithConfigurationNode(new ScalarNodeBuilder('native_watermark_color'))]
-    public function nativeWatermarkColor(string $color): static
+    #[WithConfigurationNode(new ScalarNodeBuilder('watermark_color'))]
+    public function watermarkColor(string $color): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkColor is not available.');
 
@@ -440,10 +439,10 @@ trait PagePropertiesTrait
      *
      * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
      *
-     * @example nativeWatermarkFontHeight(50.0)
+     * @example watermarkFontHeight(50)
      */
-    #[WithConfigurationNode(new FloatNodeBuilder('native_watermark_font_height'))]
-    public function nativeWatermarkFontHeight(float $height): static
+    #[WithConfigurationNode(new IntegerNodeBuilder('watermark_font_height'))]
+    public function watermarkFontHeight(int $height): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkFontHeight is not available.');
 
@@ -453,14 +452,14 @@ trait PagePropertiesTrait
     }
 
     /**
-     * Set the watermark rotation angle in degrees.
+     * Set the watermark rotation angle in tenths of a degree (e.g., 450 = 45°).
      *
      * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
      *
-     * @example nativeWatermarkRotateAngle(-45.0)
+     * @example watermarkRotateAngle(-450)
      */
-    #[WithConfigurationNode(new FloatNodeBuilder('native_watermark_rotate_angle'))]
-    public function nativeWatermarkRotateAngle(float $angle): static
+    #[WithConfigurationNode(new IntegerNodeBuilder('watermark_rotate_angle'))]
+    public function watermarkRotateAngle(int $angle): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkRotateAngle is not available.');
 
@@ -474,10 +473,10 @@ trait PagePropertiesTrait
      *
      * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
      *
-     * @example nativeWatermarkFontName('Liberation Sans')
+     * @example watermarkFontName('Liberation Sans')
      */
-    #[WithConfigurationNode(new ScalarNodeBuilder('native_watermark_font_name'))]
-    public function nativeWatermarkFontName(string $fontName): static
+    #[WithConfigurationNode(new ScalarNodeBuilder('watermark_font_name'))]
+    public function watermarkFontName(string $fontName): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkFontName is not available.');
 
@@ -491,10 +490,10 @@ trait PagePropertiesTrait
      *
      * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
      *
-     * @example nativeTiledWatermarkText('DRAFT')
+     * @example tiledWatermarkText('DRAFT')
      */
-    #[WithConfigurationNode(new ScalarNodeBuilder('native_tiled_watermark_text'))]
-    public function nativeTiledWatermarkText(string $text): static
+    #[WithConfigurationNode(new ScalarNodeBuilder('tiled_watermark_text'))]
+    public function tiledWatermarkText(string $text): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option nativeTiledWatermarkText is not available.');
 
@@ -528,7 +527,8 @@ trait PagePropertiesTrait
         yield 'reduceImageResolution' => NormalizerFactory::bool();
         yield 'maxImageResolution' => NormalizerFactory::enum();
         yield 'updateIndexes' => NormalizerFactory::bool();
-        yield 'nativeWatermarkFontHeight' => NormalizerFactory::float();
-        yield 'nativeWatermarkRotateAngle' => NormalizerFactory::float();
+        yield 'nativeWatermarkColor' => NormalizerFactory::hexColor();
+        yield 'nativeWatermarkFontHeight' => NormalizerFactory::int();
+        yield 'nativeWatermarkRotateAngle' => NormalizerFactory::int();
     }
 }

--- a/src/Builder/Behaviors/LibreOffice/PagePropertiesTrait.php
+++ b/src/Builder/Behaviors/LibreOffice/PagePropertiesTrait.php
@@ -10,6 +10,7 @@ use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 use Sensiolabs\GotenbergBundle\Enumeration\ImageResolutionDPI;
 use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
+use Sensiolabs\GotenbergBundle\NodeBuilder\FloatNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\IntegerNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\NativeEnumNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
@@ -400,6 +401,108 @@ trait PagePropertiesTrait
         return $this;
     }
 
+    /**
+     * Set the watermark text to render on every page during PDF export.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
+     *
+     * @example nativeWatermarkText('CONFIDENTIAL')
+     */
+    #[WithConfigurationNode(new ScalarNodeBuilder('native_watermark_text'))]
+    public function nativeWatermarkText(string $text): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkText is not available.');
+
+        $this->getBodyBag()->set('nativeWatermarkText', $text);
+
+        return $this;
+    }
+
+    /**
+     * Set the watermark text color (e.g., '#000000').
+     *
+     * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
+     *
+     * @example nativeWatermarkColor('#FF0000')
+     */
+    #[WithConfigurationNode(new ScalarNodeBuilder('native_watermark_color'))]
+    public function nativeWatermarkColor(string $color): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkColor is not available.');
+
+        $this->getBodyBag()->set('nativeWatermarkColor', $color);
+
+        return $this;
+    }
+
+    /**
+     * Set the watermark font height in points.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
+     *
+     * @example nativeWatermarkFontHeight(50.0)
+     */
+    #[WithConfigurationNode(new FloatNodeBuilder('native_watermark_font_height'))]
+    public function nativeWatermarkFontHeight(float $height): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkFontHeight is not available.');
+
+        $this->getBodyBag()->set('nativeWatermarkFontHeight', $height);
+
+        return $this;
+    }
+
+    /**
+     * Set the watermark rotation angle in degrees.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
+     *
+     * @example nativeWatermarkRotateAngle(-45.0)
+     */
+    #[WithConfigurationNode(new FloatNodeBuilder('native_watermark_rotate_angle'))]
+    public function nativeWatermarkRotateAngle(float $angle): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkRotateAngle is not available.');
+
+        $this->getBodyBag()->set('nativeWatermarkRotateAngle', $angle);
+
+        return $this;
+    }
+
+    /**
+     * Set the watermark font name.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
+     *
+     * @example nativeWatermarkFontName('Liberation Sans')
+     */
+    #[WithConfigurationNode(new ScalarNodeBuilder('native_watermark_font_name'))]
+    public function nativeWatermarkFontName(string $fontName): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option nativeWatermarkFontName is not available.');
+
+        $this->getBodyBag()->set('nativeWatermarkFontName', $fontName);
+
+        return $this;
+    }
+
+    /**
+     * Set a tiled watermark text rendered across every page during PDF export.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf#native-watermarks-libreoffice
+     *
+     * @example nativeTiledWatermarkText('DRAFT')
+     */
+    #[WithConfigurationNode(new ScalarNodeBuilder('native_tiled_watermark_text'))]
+    public function nativeTiledWatermarkText(string $text): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option nativeTiledWatermarkText is not available.');
+
+        $this->getBodyBag()->set('nativeTiledWatermarkText', $text);
+
+        return $this;
+    }
+
     #[NormalizeGotenbergPayload]
     private function normalizePageProperties(): \Generator
     {
@@ -425,5 +528,7 @@ trait PagePropertiesTrait
         yield 'reduceImageResolution' => NormalizerFactory::bool();
         yield 'maxImageResolution' => NormalizerFactory::enum();
         yield 'updateIndexes' => NormalizerFactory::bool();
+        yield 'nativeWatermarkFontHeight' => NormalizerFactory::float();
+        yield 'nativeWatermarkRotateAngle' => NormalizerFactory::float();
     }
 }

--- a/src/Builder/Util/NormalizerFactory.php
+++ b/src/Builder/Util/NormalizerFactory.php
@@ -136,6 +136,14 @@ class NormalizerFactory
     }
 
     /**
+     * @return (\Closure(string, string): list<array<string, string>>)
+     */
+    public static function hexColor(): \Closure
+    {
+        return static fn (string $key, string $value) => yield [$key => (string) hexdec(ltrim($value, '#'))];
+    }
+
+    /**
      * @return (\Closure(string, float): list<array<string, string>>)
      */
     public static function float(): \Closure

--- a/tests/Builder/Behaviors/LibreOffice/PagePropertiesTestCaseTrait.php
+++ b/tests/Builder/Behaviors/LibreOffice/PagePropertiesTestCaseTrait.php
@@ -268,60 +268,60 @@ trait PagePropertiesTestCaseTrait
         $this->assertGotenbergFormData('updateIndexes', 'false');
     }
 
-    public function testNativeWatermarkText(): void
+    public function testWatermarkText(): void
     {
         $this->getDefaultBuilder()
-            ->nativeWatermarkText('CONFIDENTIAL')
+            ->watermarkText('CONFIDENTIAL')
             ->generate()
         ;
 
         $this->assertGotenbergFormData('nativeWatermarkText', 'CONFIDENTIAL');
     }
 
-    public function testNativeWatermarkColor(): void
+    public function testWatermarkColor(): void
     {
         $this->getDefaultBuilder()
-            ->nativeWatermarkColor('#FF0000')
+            ->watermarkColor('#FF0000')
             ->generate()
         ;
 
-        $this->assertGotenbergFormData('nativeWatermarkColor', '#FF0000');
+        $this->assertGotenbergFormData('nativeWatermarkColor', '16711680');
     }
 
-    public function testNativeWatermarkFontHeight(): void
+    public function testWatermarkFontHeight(): void
     {
         $this->getDefaultBuilder()
-            ->nativeWatermarkFontHeight(50.0)
+            ->watermarkFontHeight(50)
             ->generate()
         ;
 
-        $this->assertGotenbergFormData('nativeWatermarkFontHeight', '50.0');
+        $this->assertGotenbergFormData('nativeWatermarkFontHeight', '50');
     }
 
-    public function testNativeWatermarkRotateAngle(): void
+    public function testWatermarkRotateAngle(): void
     {
         $this->getDefaultBuilder()
-            ->nativeWatermarkRotateAngle(-45.0)
+            ->watermarkRotateAngle(-450)
             ->generate()
         ;
 
-        $this->assertGotenbergFormData('nativeWatermarkRotateAngle', '-45.0');
+        $this->assertGotenbergFormData('nativeWatermarkRotateAngle', '-450');
     }
 
-    public function testNativeWatermarkFontName(): void
+    public function testWatermarkFontName(): void
     {
         $this->getDefaultBuilder()
-            ->nativeWatermarkFontName('Liberation Sans')
+            ->watermarkFontName('Liberation Sans')
             ->generate()
         ;
 
         $this->assertGotenbergFormData('nativeWatermarkFontName', 'Liberation Sans');
     }
 
-    public function testNativeTiledWatermarkText(): void
+    public function testTiledWatermarkText(): void
     {
         $this->getDefaultBuilder()
-            ->nativeTiledWatermarkText('DRAFT')
+            ->tiledWatermarkText('DRAFT')
             ->generate()
         ;
 

--- a/tests/Builder/Behaviors/LibreOffice/PagePropertiesTestCaseTrait.php
+++ b/tests/Builder/Behaviors/LibreOffice/PagePropertiesTestCaseTrait.php
@@ -267,4 +267,64 @@ trait PagePropertiesTestCaseTrait
 
         $this->assertGotenbergFormData('updateIndexes', 'false');
     }
+
+    public function testNativeWatermarkText(): void
+    {
+        $this->getDefaultBuilder()
+            ->nativeWatermarkText('CONFIDENTIAL')
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('nativeWatermarkText', 'CONFIDENTIAL');
+    }
+
+    public function testNativeWatermarkColor(): void
+    {
+        $this->getDefaultBuilder()
+            ->nativeWatermarkColor('#FF0000')
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('nativeWatermarkColor', '#FF0000');
+    }
+
+    public function testNativeWatermarkFontHeight(): void
+    {
+        $this->getDefaultBuilder()
+            ->nativeWatermarkFontHeight(50.0)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('nativeWatermarkFontHeight', '50.0');
+    }
+
+    public function testNativeWatermarkRotateAngle(): void
+    {
+        $this->getDefaultBuilder()
+            ->nativeWatermarkRotateAngle(-45.0)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('nativeWatermarkRotateAngle', '-45.0');
+    }
+
+    public function testNativeWatermarkFontName(): void
+    {
+        $this->getDefaultBuilder()
+            ->nativeWatermarkFontName('Liberation Sans')
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('nativeWatermarkFontName', 'Liberation Sans');
+    }
+
+    public function testNativeTiledWatermarkText(): void
+    {
+        $this->getDefaultBuilder()
+            ->nativeTiledWatermarkText('DRAFT')
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('nativeTiledWatermarkText', 'DRAFT');
+    }
 }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.28      |
| Bug fix ?               | no   |
| New feature ?           | yes|
| BC break ?              | no   |

## Description

https://github.com/gotenberg/gotenberg/releases/tag/v8.28.0

> LibreOffice
> Native Watermarks: Added support for LibreOffice's built-in watermark rendering during PDF export via new form fields: nativeWatermarkText, nativeWatermarkColor, nativeWatermarkFontHeight, nativeWatermarkRotateAngle, nativeWatermarkFontName, and nativeTiledWatermarkText.
