### PR TITLE
feat: Add downloadFrom new fields (release 8.28)

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -190,7 +190,7 @@ parameters:
 			path: src/Builder/Screenshot/UrlScreenshotBuilder.php
 
 		-
-			message: '#^Call to function array_key_exists\(\) with ''url'' and array\{url\: string, extraHttpHeaders\?\: array\<string, string\>\} will always evaluate to true\.$#'
+			message: '#^Call to function array_key_exists\(\) with ''url'' and array\{url\: string, extraHttpHeaders\?\: array\<string, string\>, field\?\: string\} will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Builder/Util/ValidatorFactory.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -190,7 +190,7 @@ parameters:
 			path: src/Builder/Screenshot/UrlScreenshotBuilder.php
 
 		-
-			message: '#^Call to function array_key_exists\(\) with ''url'' and array\{url\: string, extraHttpHeaders\?\: array\<string, string\>, field\?\: string\} will always evaluate to true\.$#'
+			message: '#^Call to function array_key_exists\(\) with ''url'' and array\{url\: string, extraHttpHeaders\?\: array\<string, string\>, field\?\: Sensiolabs\\GotenbergBundle\\Enumeration\\DownloadFromField\|string\} will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Builder/Util/ValidatorFactory.php
@@ -198,7 +198,7 @@ parameters:
 		-
 			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 2
+			count: 1
 			path: src/Builder/Util/ValidatorFactory.php
 
 		-

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -196,6 +196,12 @@ parameters:
 			path: src/Builder/Util/ValidatorFactory.php
 
 		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/Builder/Util/ValidatorFactory.php
+
+		-
 			message: '#^Instanceof between SplFileInfo and SplFileInfo will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1

--- a/src/Builder/Behaviors/DownloadFromTrait.php
+++ b/src/Builder/Behaviors/DownloadFromTrait.php
@@ -8,6 +8,7 @@ use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
+use Sensiolabs\GotenbergBundle\Enumeration\DownloadFromField;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ArrayNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\EnumNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
@@ -21,7 +22,7 @@ trait DownloadFromTrait
     /**
      * Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).
      *
-     * @param list<array{url: string, extraHttpHeaders?: array<string, string>, field?: ''|'watermark'|'stamp'|'embedded'}> $downloadFrom
+     * @param list<array{url: string, extraHttpHeaders?: array<string, string>, field?: DownloadFromField|string}> $downloadFrom
      *
      * @see https://gotenberg.dev/docs/webhook-download#download-from
      *
@@ -33,7 +34,7 @@ trait DownloadFromTrait
             new ScalarNodeBuilder('name', required: true),
             new ScalarNodeBuilder('value', required: true),
         ]),
-        new EnumNodeBuilder('field', values: ['', 'watermark', 'stamp', 'embedded']),
+        new EnumNodeBuilder('field', callback: DownloadFromField::class),
     ]))]
     public function downloadFrom(array $downloadFrom): static
     {
@@ -67,6 +68,6 @@ trait DownloadFromTrait
     #[NormalizeGotenbergPayload]
     private function normalizeDownloadFrom(): \Generator
     {
-        yield 'downloadFrom' => NormalizerFactory::json(false);
+        yield 'downloadFrom' => NormalizerFactory::downloadFrom();
     }
 }

--- a/src/Builder/Behaviors/DownloadFromTrait.php
+++ b/src/Builder/Behaviors/DownloadFromTrait.php
@@ -9,6 +9,7 @@ use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ArrayNodeBuilder;
+use Sensiolabs\GotenbergBundle\NodeBuilder\EnumNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
 
 trait DownloadFromTrait
@@ -20,7 +21,7 @@ trait DownloadFromTrait
     /**
      * Sets download from to download each entry (file) in parallel (URLs MUST return a Content-Disposition header with a filename parameter.).
      *
-     * @param list<array{url: string, extraHttpHeaders?: array<string, string>}> $downloadFrom
+     * @param list<array{url: string, extraHttpHeaders?: array<string, string>, field?: ''|'watermark'|'stamp'|'embedded'}> $downloadFrom
      *
      * @see https://gotenberg.dev/docs/webhook-download#download-from
      *
@@ -32,6 +33,7 @@ trait DownloadFromTrait
             new ScalarNodeBuilder('name', required: true),
             new ScalarNodeBuilder('value', required: true),
         ]),
+        new EnumNodeBuilder('field', values: ['', 'watermark', 'stamp', 'embedded']),
     ]))]
     public function downloadFrom(array $downloadFrom): static
     {
@@ -43,6 +45,13 @@ trait DownloadFromTrait
         }
 
         $this->logWarningIfVersionIs('<', '8.10', 'The option downloadFrom is not available.');
+
+        foreach ($downloadFrom as $file) {
+            if (\array_key_exists('field', $file)) {
+                $this->logWarningIfVersionIs('<', '8.28', 'The option "field" in downloadFrom is not available.');
+                break;
+            }
+        }
 
         $value = $this->getBodyBag()->get('downloadFrom', []);
 

--- a/src/Builder/Util/NormalizerFactory.php
+++ b/src/Builder/Util/NormalizerFactory.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Util;
 
 use Psr\Log\LoggerInterface;
 use Sensiolabs\GotenbergBundle\Builder\ValueObject\RenderedPart;
+use Sensiolabs\GotenbergBundle\Enumeration\DownloadFromField;
 use Sensiolabs\GotenbergBundle\Enumeration\Unit;
 use Sensiolabs\GotenbergBundle\Exception\JsonEncodingException;
 use Sensiolabs\GotenbergBundle\Version\Version;
@@ -46,6 +47,28 @@ class NormalizerFactory
             }
 
             yield [$key => $value.$unit->value];
+        };
+    }
+
+    /**
+     * @return (\Closure(string, array<string, array{url: string, extraHttpHeaders?: array<string, string>, field?: DownloadFromField|string}>): list<array<string, string>>)
+     */
+    public static function downloadFrom(): \Closure
+    {
+        return static function (string $key, array $value) {
+            $entries = [];
+            foreach ($value as $entry) {
+                if (isset($entry['field']) && $entry['field'] instanceof DownloadFromField) {
+                    $entry['field'] = $entry['field']->value;
+                }
+                $entries[] = $entry;
+            }
+
+            try {
+                yield [$key => json_encode($entries, \JSON_THROW_ON_ERROR)];
+            } catch (\JsonException $exception) {
+                throw new JsonEncodingException(previous: $exception);
+            }
         };
     }
 

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -66,9 +66,9 @@ class ValidatorFactory
      */
     public static function download(array $downloadFrom): void
     {
-        $validFields = ['watermark', 'stamp', 'embedded', ''];
+        $allowedValues = ['watermark', 'stamp', 'embedded', ''];
 
-        foreach ($downloadFrom as $file) {
+        foreach ($downloadFrom as $i => $file) {
             if (!\array_key_exists('url', $file)) {
                 throw new InvalidBuilderConfiguration('"url" is mandatory into "downloadFrom" array field.');
             }
@@ -79,11 +79,11 @@ class ValidatorFactory
 
             if (\array_key_exists('field', $file)) {
                 if (!\is_string($file['field'])) {
-                    throw new InvalidBuilderConfiguration('"field" in "downloadFrom" must be a string.');
+                    throw new InvalidBuilderConfiguration(sprintf('Unsupported "downloadFrom[%d].field", expected one of "%s".', $i, implode('", "', $allowedValues)));
                 }
 
-                if (!\in_array($file['field'], $validFields, true)) {
-                    throw new InvalidBuilderConfiguration(\sprintf('Invalid "field" value "%s" in "downloadFrom". Allowed values are: "watermark", "stamp", "embedded", "".', $file['field']));
+                if (!\in_array($file['field'], $allowedValues, true)) {
+                    throw new InvalidBuilderConfiguration(sprintf('Unsupported "downloadFrom[%d].field", expected one of "%s".', $i, implode('", "', $allowedValues)));
                 }
             }
         }

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Builder\Util;
 
+use Sensiolabs\GotenbergBundle\Enumeration\DownloadFromField;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -62,11 +63,11 @@ class ValidatorFactory
     }
 
     /**
-     * @param list<array{url: string, extraHttpHeaders?: array<string, string>, field?: string}> $downloadFrom
+     * @param list<array{url: string, extraHttpHeaders?: array<string, string>, field?: DownloadFromField|string}> $downloadFrom
      */
     public static function download(array $downloadFrom): void
     {
-        $allowedValues = ['watermark', 'stamp', 'embedded', ''];
+        $allowedValues = array_column(DownloadFromField::cases(), 'value');
 
         foreach ($downloadFrom as $i => $file) {
             if (!\array_key_exists('url', $file)) {
@@ -77,13 +78,9 @@ class ValidatorFactory
                 throw new InvalidBuilderConfiguration('"url" in "downloadFrom" must be a string.');
             }
 
-            if (\array_key_exists('field', $file)) {
-                if (!\is_string($file['field'])) {
-                    throw new InvalidBuilderConfiguration(sprintf('Unsupported "downloadFrom[%d].field", expected one of "%s".', $i, implode('", "', $allowedValues)));
-                }
-
+            if (\array_key_exists('field', $file) && !$file['field'] instanceof DownloadFromField) {
                 if (!\in_array($file['field'], $allowedValues, true)) {
-                    throw new InvalidBuilderConfiguration(sprintf('Unsupported "downloadFrom[%d].field", expected one of "%s".', $i, implode('", "', $allowedValues)));
+                    throw new InvalidBuilderConfiguration(\sprintf('Unsupported "downloadFrom[%d].field" "%s", expected one of "%s".', $i, $file['field'], implode('", "', $allowedValues)));
                 }
             }
         }

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -67,8 +67,6 @@ class ValidatorFactory
      */
     public static function download(array $downloadFrom): void
     {
-        $allowedValues = array_column(DownloadFromField::cases(), 'value');
-
         foreach ($downloadFrom as $i => $file) {
             if (!\array_key_exists('url', $file)) {
                 throw new InvalidBuilderConfiguration('"url" is mandatory into "downloadFrom" array field.');
@@ -79,8 +77,8 @@ class ValidatorFactory
             }
 
             if (\array_key_exists('field', $file) && !$file['field'] instanceof DownloadFromField) {
-                if (!\in_array($file['field'], $allowedValues, true)) {
-                    throw new InvalidBuilderConfiguration(\sprintf('Unsupported "downloadFrom[%d].field" "%s", expected one of "%s".', $i, $file['field'], implode('", "', $allowedValues)));
+                if (DownloadFromField::tryFrom($file['field']) === null) {
+                    throw new InvalidBuilderConfiguration(\sprintf('Unsupported "downloadFrom[%d].field" "%s", expected one of "%s".', $i, $file['field'], implode('", "', array_column(DownloadFromField::cases(), 'value'))));
                 }
             }
         }

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -73,8 +73,18 @@ class ValidatorFactory
                 throw new InvalidBuilderConfiguration('"url" is mandatory into "downloadFrom" array field.');
             }
 
-            if (\array_key_exists('field', $file) && !\in_array($file['field'], $validFields, true)) {
-                throw new InvalidBuilderConfiguration(\sprintf('Invalid "field" value "%s" in "downloadFrom". Allowed values are: "watermark", "stamp", "embedded", "".', $file['field']));
+            if (!\is_string($file['url'])) {
+                throw new InvalidBuilderConfiguration('"url" in "downloadFrom" must be a string.');
+            }
+
+            if (\array_key_exists('field', $file)) {
+                if (!\is_string($file['field'])) {
+                    throw new InvalidBuilderConfiguration('"field" in "downloadFrom" must be a string.');
+                }
+
+                if (!\in_array($file['field'], $validFields, true)) {
+                    throw new InvalidBuilderConfiguration(\sprintf('Invalid "field" value "%s" in "downloadFrom". Allowed values are: "watermark", "stamp", "embedded", "".', $file['field']));
+                }
             }
         }
     }

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -62,13 +62,19 @@ class ValidatorFactory
     }
 
     /**
-     * @param list<array{url: string, extraHttpHeaders?: array<string, string>}> $downloadFrom
+     * @param list<array{url: string, extraHttpHeaders?: array<string, string>, field?: string}> $downloadFrom
      */
     public static function download(array $downloadFrom): void
     {
+        $validFields = ['watermark', 'stamp', 'embedded', ''];
+
         foreach ($downloadFrom as $file) {
             if (!\array_key_exists('url', $file)) {
                 throw new InvalidBuilderConfiguration('"url" is mandatory into "downloadFrom" array field.');
+            }
+
+            if (\array_key_exists('field', $file) && !\in_array($file['field'], $validFields, true)) {
+                throw new InvalidBuilderConfiguration(\sprintf('Invalid "field" value "%s" in "downloadFrom". Allowed values are: "watermark", "stamp", "embedded", "".', $file['field']));
             }
         }
     }

--- a/src/Enumeration/DownloadFromField.php
+++ b/src/Enumeration/DownloadFromField.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Enumeration;
+
+enum DownloadFromField: string
+{
+    case RegularFile = '';
+    case Watermark = 'watermark';
+    case Stamp = 'stamp';
+    case Embedded = 'embedded';
+}

--- a/tests/Builder/Behaviors/DownloadFromTestCaseTrait.php
+++ b/tests/Builder/Behaviors/DownloadFromTestCaseTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors;
 
 use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
+use Sensiolabs\GotenbergBundle\Enumeration\DownloadFromField;
 
 /**
  * @template T of BuilderInterface
@@ -38,6 +39,21 @@ trait DownloadFromTestCaseTrait
                 [
                     'url' => 'http://url/to/file.com',
                     'field' => 'watermark',
+                ],
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('downloadFrom', '[{"url":"http:\/\/url\/to\/file.com","field":"watermark"}]');
+    }
+
+    public function testAddAnExternalResourceWithFieldEnum(): void
+    {
+        $this->getDefaultBuilder()
+            ->downloadFrom([
+                [
+                    'url' => 'http://url/to/file.com',
+                    'field' => DownloadFromField::Watermark,
                 ],
             ])
             ->generate()

--- a/tests/Builder/Behaviors/DownloadFromTestCaseTrait.php
+++ b/tests/Builder/Behaviors/DownloadFromTestCaseTrait.php
@@ -31,6 +31,21 @@ trait DownloadFromTestCaseTrait
         $this->assertGotenbergFormData('downloadFrom', '[{"url":"http:\/\/url\/to\/file.com","extraHttpHeaders":{"MyHeader":"MyValue","User-Agent":"MyValue"}}]');
     }
 
+    public function testAddAnExternalResourceWithField(): void
+    {
+        $this->getDefaultBuilder()
+            ->downloadFrom([
+                [
+                    'url' => 'http://url/to/file.com',
+                    'field' => 'watermark',
+                ],
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('downloadFrom', '[{"url":"http:\/\/url\/to\/file.com","field":"watermark"}]');
+    }
+
     public function testUnsetDownloadResource(): void
     {
         $builder = $this->getDefaultBuilder()


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.28      |
| Bug fix ?               | no   |
| New feature ?           | yes |
| BC break ?              | no   |
| Issues                  | Fix #... |

## Description

https://github.com/gotenberg/gotenberg/releases/tag/v8.28.0

> Download From: Extended the downloadFrom JSON schema with a field property ("watermark", "stamp", "embedded", > or "") to route downloaded files to the appropriate form field bucket. The existing embedded boolean is preserved for 
> backward compatibility.
