### PR TITLE
fix: disable "declare_strict_types" php-cs-fixer rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -21,6 +21,7 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'blank_line_between_import_groups' => false,
+        'declare_strict_types' => false,
         'native_function_invocation' => true,
         'no_superfluous_elseif' => true,
         'no_useless_else' => true,


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #... |

## Description

Disable "declare_strict_types" php-cs-fixer rule to make CI green again. Force `strict_type` or not could be decided later.