### PR TITLE
feat: add addWebhookExtraHeaders to merge with existing webhook headers

### DIFF
--- a/docs/pdf/ConvertPdfBuilder.md
+++ b/docs/pdf/ConvertPdfBuilder.md
@@ -48,6 +48,7 @@ class YourController
 - [flatten](#flattenbool-bool)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -130,6 +131,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/EmbedPdfBuilder.md
+++ b/docs/pdf/EmbedPdfBuilder.md
@@ -40,6 +40,7 @@ class YourController
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [embedFiles](#embedfilesstringablesensiolabsgotenbergbundlebuildervalueobjectembeddedfilestring-paths)
 - [files](#filesstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -104,6 +105,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/EncryptPdfBuilder.md
+++ b/docs/pdf/EncryptPdfBuilder.md
@@ -36,6 +36,7 @@ class YourController
 
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [files](#filesstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -75,6 +76,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/FlattenPdfBuilder.md
+++ b/docs/pdf/FlattenPdfBuilder.md
@@ -42,6 +42,7 @@ class YourController
 
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [files](#filesstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -79,6 +80,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -91,6 +91,7 @@ class YourController
 - [splitUnify](#splitunifybool-bool)
 - [addAsset](#addassetstringablestring-path)
 - [assets](#assetsstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -331,6 +332,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -110,6 +110,7 @@ class YourController
 - [watermarkFontName](#watermarkfontnamestring-fontname)
 - [watermarkRotateAngle](#watermarkrotateangleint-angle)
 - [watermarkText](#watermarktextstring-text)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -693,6 +694,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -135,6 +135,7 @@ class YourController
 - [wrapperFile](#wrapperfilestring-path)
 - [addAsset](#addassetstringablestring-path)
 - [assets](#assetsstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -395,6 +396,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -49,6 +49,7 @@ class YourController
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -251,6 +252,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/SplitPdfBuilder.md
+++ b/docs/pdf/SplitPdfBuilder.md
@@ -52,6 +52,7 @@ class YourController
 - [splitMode](#splitmodesensiolabsgotenbergbundleenumerationsplitmode-splitmode)
 - [splitSpan](#splitspanstring-splitspan)
 - [splitUnify](#splitunifybool-bool)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -239,6 +240,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -82,6 +82,7 @@ class YourController
 - [url](#urlstring-url)
 - [addAsset](#addassetstringablestring-path)
 - [assets](#assetsstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -328,6 +329,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -83,6 +83,7 @@ class YourController
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [addAsset](#addassetstringablestring-path)
 - [assets](#assetsstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -165,6 +166,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -128,6 +128,7 @@ class YourController
 - [wrapperFile](#wrapperfilestring-path)
 - [addAsset](#addassetstringablestring-path)
 - [assets](#assetsstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -254,6 +255,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -71,6 +71,7 @@ class YourController
 - [url](#urlstring-url)
 - [addAsset](#addassetstringablestring-path)
 - [assets](#assetsstringablestring-paths)
+- [addWebhookExtraHeaders](#addwebhookextraheadersarray-extrahttpheaders)
 - [webhook](#webhookarray-webhook)
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
@@ -180,6 +181,18 @@ return $gotenberg
 ;
 ```
 
+
+### addWebhookExtraHeaders(array \$extraHttpHeaders)
+Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+    ->generate()
+    ->stream()
+;
+```
 
 ### webhook(array \$webhook)
 > [!TIP]

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -216,6 +216,25 @@ trait WebhookTrait
     }
 
     /**
+     * Adds extra headers to the ones already provided to the webhook endpoint, preserving previously set values.
+     *
+     * @param array<string, string> $extraHttpHeaders
+     *
+     * @example addWebhookExtraHeaders(['X-Custom-Header' => 'CustomValue'])
+     */
+    public function addWebhookExtraHeaders(array $extraHttpHeaders): static
+    {
+        if ([] === $extraHttpHeaders) {
+            return $this;
+        }
+
+        $current = $this->getHeadersBag()->get('Gotenberg-Webhook-Extra-Http-Headers');
+        $current = null !== $current ? json_decode($current, true) : [];
+
+        return $this->webhookExtraHeaders(array_merge($current, $extraHttpHeaders));
+    }
+
+    /**
      * Sets the webhook route with params and method for cases of success.
      *
      * @param string                    $route      #Route

--- a/tests/Builder/Behaviors/WebhookTestCaseTrait.php
+++ b/tests/Builder/Behaviors/WebhookTestCaseTrait.php
@@ -194,6 +194,38 @@ trait WebhookTestCaseTrait
         $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
     }
 
+    public function testAddWebhookExtraHeadersToExistingHeaders(): void
+    {
+        $this->getDefaultBuilder()
+            ->webhookExtraHeaders(['my_header' => 'value'])
+            ->addWebhookExtraHeaders(['additional_header' => 'additional_value'])
+            ->generate()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value","additional_header":"additional_value"}');
+    }
+
+    public function testDoNotAddEmptyWebhookExtraHeadersToExistingHeaders(): void
+    {
+        $this->getDefaultBuilder()
+            ->webhookExtraHeaders(['my_header' => 'value'])
+            ->addWebhookExtraHeaders([])
+            ->generate()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
+    }
+
+    public function testAddWebhookExtraHeadersWithoutPriorHeaders(): void
+    {
+        $this->getDefaultBuilder()
+            ->addWebhookExtraHeaders(['my_header' => 'value'])
+            ->generate()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
+    }
+
     public function testWebhookEventsUrl(): void
     {
         $this->getDefaultBuilder()


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no       |
| New feature ?           | yes      |
| BC break ?              | no       |
| Issues                  | Fix #248 |

## Description

Adds `addWebhookExtraHeaders(array $extraHttpHeaders): static` to `WebhookTrait`, mirroring the existing `extraHttpHeaders()` / `addExtraHttpHeaders()` pair (overwrite vs. merge).

Use case: when webhook headers are already defined in bundle config (e.g. a static `Authorization`), callers can now append per-request headers (e.g. a correlation id) without replacing the whole set. Today, `webhookExtraHeaders()` always overwrites, so any caller-provided values wipe the configured ones.

The implementation reads the current `Gotenberg-Webhook-Extra-Http-Headers` header (stored as a JSON string in the headers bag), `array_merge`s the new headers on top, and re-encodes by delegating to `webhookExtraHeaders()`. An empty array short-circuits as a no-op, matching `addExtraHttpHeaders()`.

All 13 builders that compose `WebhookTrait` (10 PDF + 3 Screenshot) inherit the method via trait composition. Three test cases in `WebhookTestCaseTrait` (merge, empty no-op, no prior headers) are therefore exercised against every builder.

Note on naming: the issue suggests `webhookAddExtraHeaders`; this PR uses `addWebhookExtraHeaders` instead, to stay consistent with the existing `extraHttpHeaders` / `addExtraHttpHeaders` convention. Happy to rename if you'd prefer the original spelling.