### PR TITLE
feat: Allow to render Twig templates with a specific locale

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -29,6 +29,9 @@ $config = $config
     ->ignoreErrorsOnPackage('symfony/routing', [
         ErrorType::DEV_DEPENDENCY_IN_PROD,
     ])
+    ->ignoreErrorsOnPackage('symfony/translation', [
+        ErrorType::DEV_DEPENDENCY_IN_PROD,
+    ])
     ->ignoreErrorsOnPackage('twig/twig', [
         ErrorType::DEV_DEPENDENCY_IN_PROD,
     ])

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,8 @@
         "symfony/monolog-bundle": "^3.10 || ^4.0",
         "symfony/routing": "^6.4 || ^7.0 || ^8.0",
         "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
+        "symfony/translation": "^6.4 || ^7.0 || ^8.0",
+        "symfony/twig-bridge": "^6.4 || ^7.0 || ^8.0",
         "symfony/twig-bundle": "^6.4 || ^7.0 || ^8.0",
         "symfony/var-dumper": "^6.4 || ^7.0 || ^8.0",
         "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
@@ -70,6 +72,7 @@
     "suggest": {
         "symfony/monolog-bundle": "Enables logging througout the generating process.",
         "symfony/routing": "Allows you to use webhook to generate URL or route.",
+        "symfony/translation": "Allows you to render Twig templates with a specific locale via the locale() builder method.",
         "symfony/twig-bundle": "Allows you to use Twig to render templates into PDF.",
         "monolog/monolog": "Enables logging througout the generating process.",
         "async-aws/s3": "Upload any file to aws s3 compatible endpoints supporting multi part upload without memory overhead.",

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -860,7 +860,7 @@ Render Twig templates (content, header, footer) using the given locale.<br /><br
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->locale('fr')
+    ->locale('fr')->content('content.html.twig')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -132,6 +132,7 @@ class YourController
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
+- [locale](#localestring-locale)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
@@ -848,6 +849,18 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerRaw('<html><body><h1>The header</h1></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
+### locale(string \$locale)
+Render Twig templates (content, header, footer) using the given locale.<br /><br />Requires symfony/translation. The current application locale is restored<br />after each rendered template.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->locale('fr')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -911,7 +911,7 @@ Render Twig templates (content, header, footer) using the given locale.<br /><br
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->locale('fr')
+    ->locale('fr')->content('content.html.twig')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -174,6 +174,7 @@ class YourController
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
+- [locale](#localestring-locale)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
@@ -899,6 +900,18 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerRaw('<html><body><h1>The header</h1></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
+### locale(string \$locale)
+Render Twig templates (content, header, footer) using the given locale.<br /><br />Requires symfony/translation. The current application locale is restored<br />after each rendered template.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->locale('fr')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -123,6 +123,7 @@ class YourController
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
+- [locale](#localestring-locale)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
@@ -854,6 +855,18 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerRaw('<html><body><h1>The header</h1></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
+### locale(string \$locale)
+Render Twig templates (content, header, footer) using the given locale.<br /><br />Requires symfony/translation. The current application locale is restored<br />after each rendered template.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->locale('fr')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -866,7 +866,7 @@ Render Twig templates (content, header, footer) using the given locale.<br /><br
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->locale('fr')
+    ->locale('fr')->content('content.html.twig')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -113,6 +113,7 @@ class YourController
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
+- [locale](#localestring-locale)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -565,6 +566,18 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerRaw('<html><body><h1>The header</h1></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
+### locale(string \$locale)
+Render Twig templates (content, header, footer) using the given locale.<br /><br />Requires symfony/translation. The current application locale is restored<br />after each rendered template.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->locale('fr')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -577,7 +577,7 @@ Render Twig templates (content, header, footer) using the given locale.<br /><br
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->locale('fr')
+    ->locale('fr')->content('content.html.twig')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -156,6 +156,7 @@ class YourController
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
+- [locale](#localestring-locale)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -632,6 +633,18 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerRaw('<html><body><h1>The header</h1></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
+### locale(string \$locale)
+Render Twig templates (content, header, footer) using the given locale.<br /><br />Requires symfony/translation. The current application locale is restored<br />after each rendered template.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->locale('fr')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -644,7 +644,7 @@ Render Twig templates (content, header, footer) using the given locale.<br /><br
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->locale('fr')
+    ->locale('fr')->content('content.html.twig')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -592,7 +592,7 @@ Render Twig templates (content, header, footer) using the given locale.<br /><br
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->locale('fr')
+    ->locale('fr')->content('content.html.twig')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -101,6 +101,7 @@ class YourController
 - [header](#headerstring-template-array-context)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
+- [locale](#localestring-locale)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -580,6 +581,18 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->headerRaw('<html><body><h1>The header</h1></body></html>')
+    ->generate()
+    ->stream()
+;
+```
+
+### locale(string \$locale)
+Render Twig templates (content, header, footer) using the given locale.<br /><br />Requires symfony/translation. The current application locale is restored<br />after each rendered template.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->locale('fr')
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -5,6 +5,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LocaleSwitcherAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\TwigAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
@@ -21,9 +22,28 @@ use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
 trait ContentTrait
 {
     use AssetBaseDirFormatterAwareTrait;
+    use LocaleSwitcherAwareTrait;
     use TwigAwareTrait;
 
+    private string|null $locale = null;
+
     abstract protected function getBodyBag(): BodyBag;
+
+    /**
+     * Render Twig templates (content, header, footer) using the given locale.
+     *
+     * Requires symfony/translation. The current application locale is restored
+     * after each rendered template.
+     *
+     * @example locale('fr')
+     */
+    #[WithConfigurationNode(new ScalarNodeBuilder('locale', restrictTo: 'string'))]
+    public function locale(string $locale): static
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
 
     /**
      * @param string               $template #Template
@@ -187,6 +207,23 @@ trait ContentTrait
      * @throws PartRenderingException if the template could not be rendered
      */
     protected function withRenderedPart(Part $part, string $template, array $context = []): static
+    {
+        if (null !== $this->locale && $this->getLocaleSwitcher()->getLocale() !== $this->locale) {
+            return $this->getLocaleSwitcher()->runWithLocale(
+                $this->locale,
+                fn () => $this->doRenderPart($part, $template, $context),
+            );
+        }
+
+        return $this->doRenderPart($part, $template, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @throws PartRenderingException if the template could not be rendered
+     */
+    private function doRenderPart(Part $part, string $template, array $context): static
     {
         $this->getTwig()->getRuntime(GotenbergRuntime::class)->setBuilder($this);
         try {

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -35,7 +35,7 @@ trait ContentTrait
      * Requires symfony/translation. The current application locale is restored
      * after each rendered template.
      *
-     * @example locale('fr')
+     * @example locale('fr')->content('content.html.twig')
      */
     #[WithConfigurationNode(new ScalarNodeBuilder('locale', restrictTo: 'string'))]
     public function locale(string $locale): static

--- a/src/Builder/Behaviors/Dependencies/LocaleSwitcherAwareTrait.php
+++ b/src/Builder/Behaviors/Dependencies/LocaleSwitcherAwareTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies;
+
+use Symfony\Component\Translation\LocaleSwitcher;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceMethodsSubscriberTrait;
+
+trait LocaleSwitcherAwareTrait
+{
+    use ServiceMethodsSubscriberTrait;
+
+    #[SubscribedService('translation.locale_switcher', nullable: true)]
+    protected function getLocaleSwitcher(): LocaleSwitcher
+    {
+        if (
+            !$this->container->has('translation.locale_switcher')
+            || !($localeSwitcher = $this->container->get('translation.locale_switcher')) instanceof LocaleSwitcher
+        ) {
+            throw new \LogicException(\sprintf('Symfony Translation is required to use "%s" method. Try to run "composer require symfony/translation".', __METHOD__));
+        }
+
+        return $localeSwitcher;
+    }
+}

--- a/tests/Builder/Pdf/HtmlPdfBuilderTest.php
+++ b/tests/Builder/Pdf/HtmlPdfBuilderTest.php
@@ -6,12 +6,15 @@ use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Exception\PartRenderingException;
-use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Test\Builder\GotenbergBuilderTestCase;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\ChromiumPdfTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\EmbedTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\LocaleSwitcher;
+use Symfony\Component\Translation\Translator;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
@@ -54,8 +57,6 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
 
     public function testOutputFilename(): void
     {
-        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
-
         $this->getBuilder()
             ->contentFile('files/content.html')
             ->filename('test')
@@ -68,8 +69,6 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
 
     public function testWidth(): void
     {
-        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
-
         $this->getBuilder()
             ->contentFile('files/content.html')
             ->filename('test')
@@ -87,20 +86,7 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
 
     public function testWithTwigContentFile(): void
     {
-        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
-
-        $twig = new Environment(new FilesystemLoader(self::FIXTURE_DIR), [
-            'strict_variables' => true,
-        ]);
-
-        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
-            public function load(string $class): object|null
-            {
-                return GotenbergRuntime::class === $class ? new GotenbergRuntime() : null;
-            }
-        });
-
-        $this->container->set('twig', $twig);
+        $this->container->set('twig', $this->createTwig());
 
         $this->getBuilder()
             ->content('templates/content.html.twig', ['name' => 'world'])
@@ -215,20 +201,7 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
 
     public function testWithTwigAndHeaderFooterParts(): void
     {
-        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
-
-        $twig = new Environment(new FilesystemLoader(self::FIXTURE_DIR), [
-            'strict_variables' => true,
-        ]);
-
-        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
-            public function load(string $class): object|null
-            {
-                return GotenbergRuntime::class === $class ? new GotenbergRuntime() : null;
-            }
-        });
-
-        $this->container->set('twig', $twig);
+        $this->container->set('twig', $this->createTwig());
 
         $this->getBuilder()
             ->header('templates/header.html.twig', ['name' => 'header'])
@@ -287,8 +260,6 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
 
     public function testFilesAsHeaderAndFooter(): void
     {
-        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
-
         $this->getBuilder()
             ->headerFile('files/header.html')
             ->contentFile('files/content.html')
@@ -309,20 +280,7 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
     {
         $this->expectException(PartRenderingException::class);
 
-        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
-
-        $twig = new Environment(new FilesystemLoader(self::FIXTURE_DIR), [
-            'strict_variables' => true,
-        ]);
-
-        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
-            public function load(string $class): object|null
-            {
-                return GotenbergRuntime::class === $class ? new GotenbergRuntime() : null;
-            }
-        });
-
-        $this->container->set('twig', $twig);
+        $this->container->set('twig', $this->createTwig());
 
         $this->getBuilder()
             ->content('templates/invalid.html.twig', ['name' => 'world'])
@@ -339,5 +297,89 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
             ->content('templates/content.html.twig', ['name' => 'world'])
             ->generate()
         ;
+    }
+
+    public function testTranslationDependencyRequirementWhenLocaleIsSet(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Symfony Translation is required to use "Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LocaleSwitcherAwareTrait::getLocaleSwitcher" method. Try to run "composer require symfony/translation".');
+
+        $this->container->set('twig', $this->createTwig());
+
+        $this->getBuilder()
+            ->locale('fr')
+            ->content('templates/content.html.twig', ['name' => 'world'])
+            ->generate()
+        ;
+    }
+
+    public function testWithLocaleSwitchesLocaleForRendering(): void
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['hello' => 'Hello'], 'en');
+        $translator->addResource('array', ['hello' => 'Bonjour'], 'fr');
+
+        $localeSwitcher = new LocaleSwitcher('en', [$translator]);
+        $this->container->set('translation.locale_switcher', $localeSwitcher);
+
+        $twig = $this->createTwig();
+        $twig->addExtension(new TranslationExtension($translator));
+        $this->container->set('twig', $twig);
+
+        $this->getBuilder()
+            ->locale('fr')
+            ->content('templates/content_translated.html.twig', ['name' => 'world'])
+            ->generate()
+        ;
+
+        $expected = <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <title>My PDF</title>
+            </head>
+            <body>
+                <h1>Bonjour world!</h1>
+            </body>
+        </html>
+
+        HTML;
+
+        $this->assertContentFile('index.html', 'text/html', $expected);
+        $this->assertSame('en', $localeSwitcher->getLocale(), 'Locale should be restored after rendering');
+    }
+
+    public function testWithSameLocaleDoesNotInvokeRunWithLocale(): void
+    {
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->method('getLocale')->willReturn('en');
+        $localeSwitcher->expects($this->never())->method('runWithLocale');
+        $this->container->set('translation.locale_switcher', $localeSwitcher);
+
+        $this->container->set('twig', $this->createTwig());
+
+        $this->getBuilder()
+            ->locale('en')
+            ->content('templates/content.html.twig', ['name' => 'world'])
+            ->generate()
+        ;
+    }
+
+    private function createTwig(): Environment
+    {
+        $twig = new Environment(new FilesystemLoader(self::FIXTURE_DIR), [
+            'strict_variables' => true,
+        ]);
+
+        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
+            public function load(string $class): object|null
+            {
+                return GotenbergRuntime::class === $class ? new GotenbergRuntime() : null;
+            }
+        });
+
+        return $twig;
     }
 }

--- a/tests/Fixtures/templates/content_translated.html.twig
+++ b/tests/Fixtures/templates/content_translated.html.twig
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>My PDF</title>
+    </head>
+    <body>
+        <h1>{{ 'hello'|trans }} {{ name }}!</h1>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a `locale(string)` method on builders using Twig templates (`HtmlPdfBuilder`, `MarkdownPdfBuilder`, `UrlPdfBuilder` and their Screenshot counterparts) to render content, header and footer templates with the given locale via Symfony's `LocaleSwitcher`.
- Behavior is unchanged when `locale()` is not called: `symfony/translation` remains an optional dependency. A clear `LogicException` is thrown if `locale()` is called without it installed.
- Exposed as a YAML configuration node via `WithConfigurationNode` so it can be set globally per builder.

## Credits
Original idea by @StevenRenaux.