### PR TITLE
feat: Add `bookmarks` and `autoIndexBookmarks` form fields (release 8.28) 

### DIFF
--- a/docs/generate.php
+++ b/docs/generate.php
@@ -262,7 +262,7 @@ class BuilderParser
         $markdown = '';
         $lastKey = array_key_last($exampleList);
         foreach ($exampleList as $key => $example) {
-            $markdown = <<<MARKDOWN
+            $markdown .= <<<MARKDOWN
                 ```php
                 return \$gotenberg
                     // Your builder call as ->html() and the rest of your configuration code
@@ -276,11 +276,11 @@ class BuilderParser
             $isLast = $lastKey === $key;
 
             if (false === $isLast) {
-                $markdown .= '<br />';
+                $markdown .= "\n\n";
             }
         }
 
-        return rtrim($markdown, '<br />');
+        return rtrim($markdown);
     }
 
     /**

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -39,6 +39,8 @@ class YourController
 ### Available methods
 
 - [addMetadata](#addmetadatastring-key-string-value)
+- [autoIndexBookmarks](#autoindexbookmarksbool-bool)
+- [bookmarks](#bookmarksarray-bookmarks)
 - [downloadFrom](#downloadfromarray-downloadfrom)
 - [embedFiles](#embedfilesstringablestring-paths)
 - [files](#filesstringablestring-paths)
@@ -63,6 +65,45 @@ If you want to add metadata from the ones already loaded in the configuration.<b
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->addMetadata('key', 'value')
+    ->generate()
+    ->stream()
+;
+```
+
+### autoIndexBookmarks(bool \$bool)
+Extracts existing bookmarks from input files and offsets their page numbers<br />based on their position in the merged document (default false).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines](https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->autoIndexBookmarks() // is same as `->autoIndexBookmarks(true)`
+    ->generate()
+    ->stream()
+;
+```
+
+### bookmarks(array \$bookmarks)
+Bookmarks to write (JSON). A list applies to the final merged PDF.<br />A map of filename→bookmarks shifts page indexes per file before merging.<br /><br />You can also provide custom bookmarks with the bookmarks form field. When provided as a list, it is applied<br />directly to the final merged PDF. When provided as a map of filename to bookmarks, page indexes are shifted per<br />file before merging.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines](https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->bookmarks([['title' => 'Introduction', 'page' => 1, 'children' => []], ['title' => 'Appendix', 'page' => 5, 'children' => []]])
+    ->generate()
+    ->stream()
+;
+```
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->bookmarks(['1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1, 'children' => []]], '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1, 'children' => []]]])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -38,7 +38,7 @@ class YourController
 
 ### Available methods
 
-- [addBookmark](#addbookmarkarray-bookmark)
+- [addBookmark](#addbookmarkstring-title-int-page-array-children)
 - [addMetadata](#addmetadatastring-key-string-value)
 - [autoIndexBookmarks](#autoindexbookmarksbool-bool)
 - [bookmarks](#bookmarksarray-bookmarks)
@@ -59,7 +59,7 @@ class YourController
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
 
-### addBookmark(array \$bookmark)
+### addBookmark(string \$title, int \$page, array \$children)
 Adds a single bookmark entry to the existing list.<br />The `children` property allows nesting bookmarks to create a hierarchical table of contents.<br />
 
 > [!TIP]
@@ -68,7 +68,7 @@ Adds a single bookmark entry to the existing list.<br />The `children` property 
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->addBookmark(['title' => 'Introduction', 'page' => 1])
+    ->addBookmark('Introduction', 1)
     ->generate()
     ->stream()
 ;
@@ -77,7 +77,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->addBookmark(['title' => 'Chapter 1', 'page' => 1, 'children' => [['title' => 'Overview', 'page' => 1]]])
+    ->addBookmark('Chapter 1', 1, [['title' => 'Overview', 'page' => 1]])
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -38,6 +38,7 @@ class YourController
 
 ### Available methods
 
+- [addBookmark](#addbookmarkarray-bookmark)
 - [addMetadata](#addmetadatastring-key-string-value)
 - [autoIndexBookmarks](#autoindexbookmarksbool-bool)
 - [bookmarks](#bookmarksarray-bookmarks)
@@ -57,6 +58,30 @@ class YourController
 - [webhookUrl](#webhookurlstring-url-string-method)
 - [ownerPassword](#ownerpasswordstring-ownerpassword)
 - [userPassword](#userpasswordstring-userpassword)
+
+### addBookmark(array \$bookmark)
+Adds a single bookmark entry to the existing list.<br />The `children` property allows nesting bookmarks to create a hierarchical table of contents.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines](https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addBookmark(['title' => 'Introduction', 'page' => 1])
+    ->generate()
+    ->stream()
+;
+```
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addBookmark(['title' => 'Chapter 1', 'page' => 1, 'children' => [['title' => 'Overview', 'page' => 1]]])
+    ->generate()
+    ->stream()
+;
+```
 
 ### addMetadata(string \$key, string \$value)
 If you want to add metadata from the ones already loaded in the configuration.<br />
@@ -86,7 +111,7 @@ return $gotenberg
 ```
 
 ### bookmarks(array \$bookmarks)
-Bookmarks to write (JSON). A list applies to the final merged PDF.<br />A map of filename→bookmarks shifts page indexes per file before merging.<br /><br />You can also provide custom bookmarks with the bookmarks form field. When provided as a list, it is applied<br />directly to the final merged PDF. When provided as a map of filename to bookmarks, page indexes are shifted per<br />file before merging.<br />
+Bookmarks to write. When provided as a list, it is applied directly to the final merged PDF.<br />When provided as a map of filename to bookmarks, page indexes are shifted per file before merging.<br />The `children` property allows nesting bookmarks to create a hierarchical table of contents.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines](https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines)
@@ -94,7 +119,7 @@ Bookmarks to write (JSON). A list applies to the final merged PDF.<br />A map of
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->bookmarks([['title' => 'Introduction', 'page' => 1, 'children' => []], ['title' => 'Appendix', 'page' => 5, 'children' => []]])
+    ->bookmarks([['title' => 'Introduction', 'page' => 1, 'children' => [['title' => 'Overview', 'page' => 1]]], ['title' => 'Appendix', 'page' => 5]])
     ->generate()
     ->stream()
 ;
@@ -103,7 +128,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->bookmarks(['1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1, 'children' => []]], '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1, 'children' => []]]])
+    ->bookmarks(['1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1]], '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1]]])
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/BookmarksTrait.php
+++ b/src/Builder/Behaviors/BookmarksTrait.php
@@ -7,6 +7,7 @@ use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Builder\Util\ValidatorFactory;
 use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
 
 /**
@@ -43,19 +44,26 @@ trait BookmarksTrait
      * Adds a single bookmark entry to the existing list.
      * The `children` property allows nesting bookmarks to create a hierarchical table of contents.
      *
-     * @param Bookmark $bookmark
+     * @param list<Bookmark> $children
      *
      * @see https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines
      *
-     * @example addBookmark(['title' => 'Introduction', 'page' => 1])
-     * @example addBookmark(['title' => 'Chapter 1', 'page' => 1, 'children' => [['title' => 'Overview', 'page' => 1]]])
+     * @example addBookmark('Introduction', 1)
+     * @example addBookmark('Chapter 1', 1, [['title' => 'Overview', 'page' => 1]])
      */
-    public function addBookmark(array $bookmark): static
+    public function addBookmark(string $title, int $page, array $children = []): static
     {
+        ValidatorFactory::pageNumber($page);
+
         $this->logWarningIfVersionIs('<', '8.28', 'The option bookmarks is not available.');
 
         /** @var list<Bookmark> $current */
         $current = $this->getBodyBag()->get('bookmarks', []);
+
+        $bookmark = ['title' => $title, 'page' => $page];
+        if ([] !== $children) {
+            $bookmark['children'] = $children;
+        }
 
         $this->getBodyBag()->set('bookmarks', [...$current, $bookmark]);
 

--- a/src/Builder/Behaviors/BookmarksTrait.php
+++ b/src/Builder/Behaviors/BookmarksTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
+
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
+use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
+
+trait BookmarksTrait
+{
+    use LoggerAwareTrait;
+
+    abstract protected function getBodyBag(): BodyBag;
+
+    /**
+     * Bookmarks to write (JSON). A list applies to the final merged PDF.
+     * A map of filename→bookmarks shifts page indexes per file before merging.
+     *
+     * You can also provide custom bookmarks with the bookmarks form field. When provided as a list, it is applied
+     * directly to the final merged PDF. When provided as a map of filename to bookmarks, page indexes are shifted per
+     * file before merging.
+     *
+     * @param list<array{title: string, page: int, children?: list<mixed>}>|array<string, list<array{title: string, page: int, children?: list<mixed>}>> $bookmarks
+     *
+     * @see https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines
+     *
+     * @example bookmarks([['title' => 'Introduction', 'page' => 1, 'children' => []], ['title' => 'Appendix', 'page' => 5, 'children' => []]])
+     * @example bookmarks(['1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1, 'children' => []]], '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1, 'children' => []]]])
+     */
+    public function bookmarks(array $bookmarks): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option bookmarks is not available.');
+
+        $this->getBodyBag()->set('bookmarks', $bookmarks);
+
+        return $this;
+    }
+
+    /**
+     * Extracts existing bookmarks from input files and offsets their page numbers
+     * based on their position in the merged document (default false).
+     *
+     * @see https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines
+     *
+     * @example autoIndexBookmarks() // is same as `->autoIndexBookmarks(true)`
+     */
+    #[WithConfigurationNode(new BooleanNodeBuilder('auto_index_bookmarks'))]
+    public function autoIndexBookmarks(bool $bool = true): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option autoIndexBookmarks is not available.');
+
+        $this->getBodyBag()->set('autoIndexBookmarks', $bool);
+
+        return $this;
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizeBookmarks(): \Generator
+    {
+        yield 'bookmarks' => NormalizerFactory::json();
+        yield 'autoIndexBookmarks' => NormalizerFactory::bool();
+    }
+}

--- a/src/Builder/Behaviors/BookmarksTrait.php
+++ b/src/Builder/Behaviors/BookmarksTrait.php
@@ -9,6 +9,9 @@ use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
 
+/**
+ * @phpstan-type Bookmark array{title: string, page: int, children?: list<array{title: string, page: int, children?: list<mixed>}>}
+ */
 trait BookmarksTrait
 {
     use LoggerAwareTrait;
@@ -16,25 +19,45 @@ trait BookmarksTrait
     abstract protected function getBodyBag(): BodyBag;
 
     /**
-     * Bookmarks to write (JSON). A list applies to the final merged PDF.
-     * A map of filename→bookmarks shifts page indexes per file before merging.
+     * Bookmarks to write. When provided as a list, it is applied directly to the final merged PDF.
+     * When provided as a map of filename to bookmarks, page indexes are shifted per file before merging.
+     * The `children` property allows nesting bookmarks to create a hierarchical table of contents.
      *
-     * You can also provide custom bookmarks with the bookmarks form field. When provided as a list, it is applied
-     * directly to the final merged PDF. When provided as a map of filename to bookmarks, page indexes are shifted per
-     * file before merging.
-     *
-     * @param list<array{title: string, page: int, children?: list<mixed>}>|array<string, list<array{title: string, page: int, children?: list<mixed>}>> $bookmarks
+     * @param list<Bookmark>|array<string, list<Bookmark>> $bookmarks
      *
      * @see https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines
      *
-     * @example bookmarks([['title' => 'Introduction', 'page' => 1, 'children' => []], ['title' => 'Appendix', 'page' => 5, 'children' => []]])
-     * @example bookmarks(['1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1, 'children' => []]], '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1, 'children' => []]]])
+     * @example bookmarks([['title' => 'Introduction', 'page' => 1, 'children' => [['title' => 'Overview', 'page' => 1]]], ['title' => 'Appendix', 'page' => 5]])
+     * @example bookmarks(['1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1]], '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1]]])
      */
     public function bookmarks(array $bookmarks): static
     {
         $this->logWarningIfVersionIs('<', '8.28', 'The option bookmarks is not available.');
 
         $this->getBodyBag()->set('bookmarks', $bookmarks);
+
+        return $this;
+    }
+
+    /**
+     * Adds a single bookmark entry to the existing list.
+     * The `children` property allows nesting bookmarks to create a hierarchical table of contents.
+     *
+     * @param Bookmark $bookmark
+     *
+     * @see https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs#bookmarks-pdf-engines
+     *
+     * @example addBookmark(['title' => 'Introduction', 'page' => 1])
+     * @example addBookmark(['title' => 'Chapter 1', 'page' => 1, 'children' => [['title' => 'Overview', 'page' => 1]]])
+     */
+    public function addBookmark(array $bookmark): static
+    {
+        $this->logWarningIfVersionIs('<', '8.28', 'The option bookmarks is not available.');
+
+        /** @var list<Bookmark> $current */
+        $current = $this->getBodyBag()->get('bookmarks', []);
+
+        $this->getBodyBag()->set('bookmarks', [...$current, $bookmark]);
 
         return $this;
     }

--- a/src/Builder/Behaviors/BookmarksTrait.php
+++ b/src/Builder/Behaviors/BookmarksTrait.php
@@ -53,7 +53,7 @@ trait BookmarksTrait
      */
     public function addBookmark(string $title, int $page, array $children = []): static
     {
-        ValidatorFactory::pageNumber($page);
+        ValidatorFactory::page($page);
 
         $this->logWarningIfVersionIs('<', '8.28', 'The option bookmarks is not available.');
 

--- a/src/Builder/Pdf/MergePdfBuilder.php
+++ b/src/Builder/Pdf/MergePdfBuilder.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\BookmarksTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormatterAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EmbedTrait;
@@ -33,6 +34,7 @@ use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 final class MergePdfBuilder extends AbstractBuilder
 {
     use AssetBaseDirFormatterAwareTrait;
+    use BookmarksTrait;
     use DownloadFromTrait;
     use EmbedTrait;
     use EncryptTrait;

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -87,7 +87,7 @@ class ValidatorFactory
         }
     }
 
-    public static function pageNumber(int $value): void
+    public static function page(int $value): void
     {
         if ($value < 1) {
             throw new InvalidBuilderConfiguration(\sprintf('Page number must be greater than or equal to 1, %d given.', $value));

--- a/src/Builder/Util/ValidatorFactory.php
+++ b/src/Builder/Util/ValidatorFactory.php
@@ -86,4 +86,11 @@ class ValidatorFactory
             throw new InvalidBuilderConfiguration(\sprintf('The value "%s" must be between 0 and 100.', $value));
         }
     }
+
+    public static function pageNumber(int $value): void
+    {
+        if ($value < 1) {
+            throw new InvalidBuilderConfiguration(\sprintf('Page number must be greater than or equal to 1, %d given.', $value));
+        }
+    }
 }

--- a/src/DependencyInjection/SensiolabsGotenbergExtension.php
+++ b/src/DependencyInjection/SensiolabsGotenbergExtension.php
@@ -79,7 +79,7 @@ class SensiolabsGotenbergExtension extends Extension
     }
 
     /**
-     * @param array<array-key, mixed> $config
+     * @param array<mixed> $config
      */
     public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {

--- a/tests/Builder/Behaviors/BookmarksTestCaseTrait.php
+++ b/tests/Builder/Behaviors/BookmarksTestCaseTrait.php
@@ -29,6 +29,22 @@ trait BookmarksTestCaseTrait
         $this->assertGotenbergFormData('bookmarks', '[{"title":"Introduction","page":1,"children":[]},{"title":"Appendix","page":5,"children":[]}]');
     }
 
+    public function testBookmarksWithChildren(): void
+    {
+        $this->getDefaultBuilder()
+            ->bookmarks([
+                ['title' => 'Introduction', 'page' => 1, 'children' => [
+                    ['title' => 'Overview', 'page' => 1, 'children' => []],
+                    ['title' => 'Getting Started', 'page' => 2, 'children' => []],
+                ]],
+                ['title' => 'Appendix', 'page' => 5, 'children' => []],
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('bookmarks', '[{"title":"Introduction","page":1,"children":[{"title":"Overview","page":1,"children":[]},{"title":"Getting Started","page":2,"children":[]}]},{"title":"Appendix","page":5,"children":[]}]');
+    }
+
     public function testBookmarksAsMap(): void
     {
         $this->getDefaultBuilder()
@@ -40,6 +56,17 @@ trait BookmarksTestCaseTrait
         ;
 
         $this->assertGotenbergFormData('bookmarks', '{"1_pdf.pdf":[{"title":"Introduction","page":1,"children":[]}],"2_pdf.pdf":[{"title":"Appendix","page":1,"children":[]}]}');
+    }
+
+    public function testAddBookmark(): void
+    {
+        $this->getDefaultBuilder()
+            ->addBookmark(['title' => 'Introduction', 'page' => 1, 'children' => []])
+            ->addBookmark(['title' => 'Appendix', 'page' => 5, 'children' => [['title' => 'Sub-section', 'page' => 5, 'children' => []]]])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('bookmarks', '[{"title":"Introduction","page":1,"children":[]},{"title":"Appendix","page":5,"children":[{"title":"Sub-section","page":5,"children":[]}]}]');
     }
 
     public function testAutoIndexBookmarks(): void

--- a/tests/Builder/Behaviors/BookmarksTestCaseTrait.php
+++ b/tests/Builder/Behaviors/BookmarksTestCaseTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors;
+
+use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
+
+/**
+ * @template T of BuilderInterface
+ */
+trait BookmarksTestCaseTrait
+{
+    /** @use BehaviorTrait<T> */
+    use BehaviorTrait;
+
+    abstract protected function assertGotenbergFormData(string $field, string $expectedValue): void;
+
+    public function testBookmarksAsList(): void
+    {
+        $this->getDefaultBuilder()
+            ->bookmarks([
+                ['title' => 'Introduction', 'page' => 1, 'children' => []],
+                ['title' => 'Appendix', 'page' => 5, 'children' => []],
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('bookmarks', '[{"title":"Introduction","page":1,"children":[]},{"title":"Appendix","page":5,"children":[]}]');
+    }
+
+    public function testBookmarksAsMap(): void
+    {
+        $this->getDefaultBuilder()
+            ->bookmarks([
+                '1_pdf.pdf' => [['title' => 'Introduction', 'page' => 1, 'children' => []]],
+                '2_pdf.pdf' => [['title' => 'Appendix', 'page' => 1, 'children' => []]],
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('bookmarks', '{"1_pdf.pdf":[{"title":"Introduction","page":1,"children":[]}],"2_pdf.pdf":[{"title":"Appendix","page":1,"children":[]}]}');
+    }
+
+    public function testAutoIndexBookmarks(): void
+    {
+        $this->getDefaultBuilder()
+            ->autoIndexBookmarks()
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('autoIndexBookmarks', 'true');
+    }
+
+    public function testAutoIndexBookmarksFalse(): void
+    {
+        $this->getDefaultBuilder()
+            ->autoIndexBookmarks(false)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('autoIndexBookmarks', 'false');
+    }
+}

--- a/tests/Builder/Behaviors/BookmarksTestCaseTrait.php
+++ b/tests/Builder/Behaviors/BookmarksTestCaseTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors;
 
 use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
+use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 
 /**
  * @template T of BuilderInterface
@@ -61,12 +62,20 @@ trait BookmarksTestCaseTrait
     public function testAddBookmark(): void
     {
         $this->getDefaultBuilder()
-            ->addBookmark(['title' => 'Introduction', 'page' => 1, 'children' => []])
-            ->addBookmark(['title' => 'Appendix', 'page' => 5, 'children' => [['title' => 'Sub-section', 'page' => 5, 'children' => []]]])
+            ->addBookmark('Introduction', 1)
+            ->addBookmark('Appendix', 5, [['title' => 'Sub-section', 'page' => 5]])
             ->generate()
         ;
 
-        $this->assertGotenbergFormData('bookmarks', '[{"title":"Introduction","page":1,"children":[]},{"title":"Appendix","page":5,"children":[{"title":"Sub-section","page":5,"children":[]}]}]');
+        $this->assertGotenbergFormData('bookmarks', '[{"title":"Introduction","page":1},{"title":"Appendix","page":5,"children":[{"title":"Sub-section","page":5}]}]');
+    }
+
+    public function testAddBookmarkThrowsOnInvalidPage(): void
+    {
+        $this->expectException(InvalidBuilderConfiguration::class);
+        $this->expectExceptionMessage('Page number must be greater than or equal to 1, 0 given.');
+
+        $this->getDefaultBuilder()->addBookmark('Introduction', 0);
     }
 
     public function testAutoIndexBookmarks(): void

--- a/tests/Builder/Pdf/MergePdfBuilderTest.php
+++ b/tests/Builder/Pdf/MergePdfBuilderTest.php
@@ -7,6 +7,7 @@ use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 use Sensiolabs\GotenbergBundle\Test\Builder\GotenbergBuilderTestCase;
+use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\BookmarksTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\DownloadFromTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\EmbedTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\EncryptTestCaseTrait;
@@ -21,6 +22,9 @@ use Symfony\Component\DependencyInjection\Container;
  */
 final class MergePdfBuilderTest extends GotenbergBuilderTestCase
 {
+    /** @use BookmarksTestCaseTrait<MergePdfBuilder> */
+    use BookmarksTestCaseTrait;
+
     /** @use DownloadFromTestCaseTrait<MergePdfBuilder> */
     use DownloadFromTestCaseTrait;
 


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.28      |
| Bug fix ?               | no   |
| New feature ?           | yes|
| BC break ?              | no   |
| Issues                  | Fix #... |

## Description

Merge Bookmark Management: The merge route now supports a `bookmarks` form field for custom bookmarks with automatic page-offset shifting, and an `autoIndexBookmarks `option to extract and reindex existing bookmarks from input files.
