### PR TITLE
feat: Add `skipNetworkAlmostIdleEvent` new field (release 8.29)

### DIFF
--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -144,6 +144,7 @@ class YourController
 - [extraHttpHeaders](#extrahttpheadersarray-headers)
 - [userAgent](#useragentstring-useragent)
 - [emulatedMediaType](#emulatedmediatypesensiolabsgotenbergbundleenumerationemulatedmediatype-mediatype)
+- [skipNetworkAlmostIdleEvent](#skipnetworkalmostidleeventbool-bool)
 - [skipNetworkIdleEvent](#skipnetworkidleeventbool-bool)
 
 ### addMetadata(string \$key, string \$value)
@@ -1026,6 +1027,21 @@ return $gotenberg
 ;
 ```
 
+
+### skipNetworkAlmostIdleEvent(bool \$bool)
+Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.<br />Useful for pages with long-polling or analytics connections. (default true).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+    ->generate()
+    ->stream()
+;
+```
 
 ### skipNetworkIdleEvent(bool \$bool)
 Gotenberg, by default, waits for the network idle event to ensure that the majority of the page is rendered during<br />conversion. However, this often significantly slows down the conversion process. Setting this form field to true<br />can greatly enhance the conversion speed.<br />

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -186,6 +186,7 @@ class YourController
 - [extraHttpHeaders](#extrahttpheadersarray-headers)
 - [userAgent](#useragentstring-useragent)
 - [emulatedMediaType](#emulatedmediatypesensiolabsgotenbergbundleenumerationemulatedmediatype-mediatype)
+- [skipNetworkAlmostIdleEvent](#skipnetworkalmostidleeventbool-bool)
 - [skipNetworkIdleEvent](#skipnetworkidleeventbool-bool)
 
 ### addMetadata(string \$key, string \$value)
@@ -1077,6 +1078,21 @@ return $gotenberg
 ;
 ```
 
+
+### skipNetworkAlmostIdleEvent(bool \$bool)
+Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.<br />Useful for pages with long-polling or analytics connections. (default true).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+    ->generate()
+    ->stream()
+;
+```
 
 ### skipNetworkIdleEvent(bool \$bool)
 Gotenberg, by default, waits for the network idle event to ensure that the majority of the page is rendered during<br />conversion. However, this often significantly slows down the conversion process. Setting this form field to true<br />can greatly enhance the conversion speed.<br />

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -135,6 +135,7 @@ class YourController
 - [extraHttpHeaders](#extrahttpheadersarray-headers)
 - [userAgent](#useragentstring-useragent)
 - [emulatedMediaType](#emulatedmediatypesensiolabsgotenbergbundleenumerationemulatedmediatype-mediatype)
+- [skipNetworkAlmostIdleEvent](#skipnetworkalmostidleeventbool-bool)
 - [skipNetworkIdleEvent](#skipnetworkidleeventbool-bool)
 
 ### addMetadata(string \$key, string \$value)
@@ -1032,6 +1033,21 @@ return $gotenberg
 ;
 ```
 
+
+### skipNetworkAlmostIdleEvent(bool \$bool)
+Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.<br />Useful for pages with long-polling or analytics connections. (default true).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+    ->generate()
+    ->stream()
+;
+```
 
 ### skipNetworkIdleEvent(bool \$bool)
 Gotenberg, by default, waits for the network idle event to ensure that the majority of the page is rendered during<br />conversion. However, this often significantly slows down the conversion process. Setting this form field to true<br />can greatly enhance the conversion speed.<br />

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -123,6 +123,7 @@ class YourController
 - [extraHttpHeaders](#extrahttpheadersarray-headers)
 - [userAgent](#useragentstring-useragent)
 - [emulatedMediaType](#emulatedmediatypesensiolabsgotenbergbundleenumerationemulatedmediatype-mediatype)
+- [skipNetworkAlmostIdleEvent](#skipnetworkalmostidleeventbool-bool)
 - [skipNetworkIdleEvent](#skipnetworkidleeventbool-bool)
 
 ### downloadFrom(array \$downloadFrom)
@@ -718,6 +719,21 @@ return $gotenberg
 ;
 ```
 
+
+### skipNetworkAlmostIdleEvent(bool \$bool)
+Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.<br />Useful for pages with long-polling or analytics connections. (default true).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+    ->generate()
+    ->stream()
+;
+```
 
 ### skipNetworkIdleEvent(bool \$bool)
 Gotenberg, by default, waits for the network idle event to ensure that the majority of the page is rendered during<br />conversion. However, this often significantly slows down the conversion process. Setting this form field to true<br />can greatly enhance the conversion speed.<br />

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -166,6 +166,7 @@ class YourController
 - [extraHttpHeaders](#extrahttpheadersarray-headers)
 - [userAgent](#useragentstring-useragent)
 - [emulatedMediaType](#emulatedmediatypesensiolabsgotenbergbundleenumerationemulatedmediatype-mediatype)
+- [skipNetworkAlmostIdleEvent](#skipnetworkalmostidleeventbool-bool)
 - [skipNetworkIdleEvent](#skipnetworkidleeventbool-bool)
 
 ### downloadFrom(array \$downloadFrom)
@@ -785,6 +786,21 @@ return $gotenberg
 ;
 ```
 
+
+### skipNetworkAlmostIdleEvent(bool \$bool)
+Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.<br />Useful for pages with long-polling or analytics connections. (default true).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+    ->generate()
+    ->stream()
+;
+```
 
 ### skipNetworkIdleEvent(bool \$bool)
 Gotenberg, by default, waits for the network idle event to ensure that the majority of the page is rendered during<br />conversion. However, this often significantly slows down the conversion process. Setting this form field to true<br />can greatly enhance the conversion speed.<br />

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -111,6 +111,7 @@ class YourController
 - [extraHttpHeaders](#extrahttpheadersarray-headers)
 - [userAgent](#useragentstring-useragent)
 - [emulatedMediaType](#emulatedmediatypesensiolabsgotenbergbundleenumerationemulatedmediatype-mediatype)
+- [skipNetworkAlmostIdleEvent](#skipnetworkalmostidleeventbool-bool)
 - [skipNetworkIdleEvent](#skipnetworkidleeventbool-bool)
 
 ### downloadFrom(array \$downloadFrom)
@@ -733,6 +734,21 @@ return $gotenberg
 ;
 ```
 
+
+### skipNetworkAlmostIdleEvent(bool \$bool)
+Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.<br />Useful for pages with long-polling or analytics connections. (default true).<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+    ->generate()
+    ->stream()
+;
+```
 
 ### skipNetworkIdleEvent(bool \$bool)
 Gotenberg, by default, waits for the network idle event to ensure that the majority of the page is rendered during<br />conversion. However, this often significantly slows down the conversion process. Setting this form field to true<br />can greatly enhance the conversion speed.<br />

--- a/src/Builder/Behaviors/Chromium/PerformanceModeTrait.php
+++ b/src/Builder/Behaviors/Chromium/PerformanceModeTrait.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium;
 
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
@@ -13,6 +14,8 @@ use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
  */
 trait PerformanceModeTrait
 {
+    use LoggerAwareTrait;
+
     abstract protected function getBodyBag(): BodyBag;
 
     /**
@@ -32,9 +35,28 @@ trait PerformanceModeTrait
         return $this;
     }
 
+    /**
+     * Does not wait for Chromium network to be almost idle (at most 2 open connections for 500ms) before conversion.
+     * Useful for pages with long-polling or analytics connections. (default true).
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#http--networking
+     *
+     * @example skipNetworkAlmostIdleEvent() // is same as `->skipNetworkAlmostIdleEvent(true)`
+     */
+    #[WithConfigurationNode(new BooleanNodeBuilder('skip_network_almost_idle_event'))]
+    public function skipNetworkAlmostIdleEvent(bool $bool = true): static
+    {
+        $this->logWarningIfVersionIs('<', '8.29', 'The option skipNetworkAlmostIdleEvent is not available.');
+
+        $this->getBodyBag()->set('skipNetworkAlmostIdleEvent', $bool);
+
+        return $this;
+    }
+
     #[NormalizeGotenbergPayload]
     private function normalizePerformanceMode(): \Generator
     {
         yield 'skipNetworkIdleEvent' => NormalizerFactory::bool();
+        yield 'skipNetworkAlmostIdleEvent' => NormalizerFactory::bool();
     }
 }

--- a/tests/Builder/Behaviors/Chromium/PerformanceModeTestCaseTrait.php
+++ b/tests/Builder/Behaviors/Chromium/PerformanceModeTestCaseTrait.php
@@ -24,4 +24,14 @@ trait PerformanceModeTestCaseTrait
 
         $this->assertGotenbergFormData('skipNetworkIdleEvent', 'true');
     }
+
+    public function testSkipNetworkAlmostIdleEvent(): void
+    {
+        $this->getDefaultBuilder()
+            ->skipNetworkAlmostIdleEvent(false)
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormData('skipNetworkAlmostIdleEvent', 'false');
+    }
 }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.29      |
| Bug fix ?               | no   |
| New feature ?           | yes|
| BC break ?              | no   |
| Issues                  | Fix #... |

## Description

Related to https://github.com/gotenberg/gotenberg/releases/tag/v8.29.0
