### PR TITLE
feat: Add `Gotenberg-Webhook-Events-Url` header (release 8.29)

### DIFF
--- a/docs/pdf/ConvertPdfBuilder.md
+++ b/docs/pdf/ConvertPdfBuilder.md
@@ -52,6 +52,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -136,7 +138,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -173,6 +175,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/ConvertPdfBuilder.md
+++ b/docs/pdf/ConvertPdfBuilder.md
@@ -193,7 +193,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/EmbedPdfBuilder.md
+++ b/docs/pdf/EmbedPdfBuilder.md
@@ -44,6 +44,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -101,7 +103,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -138,6 +140,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/EmbedPdfBuilder.md
+++ b/docs/pdf/EmbedPdfBuilder.md
@@ -158,7 +158,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/EncryptPdfBuilder.md
+++ b/docs/pdf/EncryptPdfBuilder.md
@@ -40,6 +40,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -81,7 +83,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -118,6 +120,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/EncryptPdfBuilder.md
+++ b/docs/pdf/EncryptPdfBuilder.md
@@ -138,7 +138,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/FlattenPdfBuilder.md
+++ b/docs/pdf/FlattenPdfBuilder.md
@@ -46,6 +46,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -85,7 +87,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -122,6 +124,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/FlattenPdfBuilder.md
+++ b/docs/pdf/FlattenPdfBuilder.md
@@ -142,7 +142,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -385,7 +385,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -95,6 +95,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -328,7 +330,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -365,6 +367,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -651,7 +651,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/LibreOfficePdfBuilder.md
+++ b/docs/pdf/LibreOfficePdfBuilder.md
@@ -108,6 +108,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -594,7 +596,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -631,6 +633,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -139,6 +139,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -401,7 +403,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -438,6 +440,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -458,7 +458,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -305,7 +305,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -53,6 +53,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -248,7 +250,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -285,6 +287,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/SplitPdfBuilder.md
+++ b/docs/pdf/SplitPdfBuilder.md
@@ -56,6 +56,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -236,7 +238,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -273,6 +275,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/SplitPdfBuilder.md
+++ b/docs/pdf/SplitPdfBuilder.md
@@ -293,7 +293,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -391,7 +391,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -86,6 +86,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -334,7 +336,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -371,6 +373,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -228,7 +228,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -87,6 +87,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -171,7 +173,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -208,6 +210,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -132,6 +132,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -260,7 +262,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -297,6 +299,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -317,7 +317,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -243,7 +243,7 @@ return $gotenberg
 ```
 
 ### webhookEventsUrl(string \$url)
-Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -75,6 +75,8 @@ class YourController
 - [webhookConfiguration](#webhookconfigurationstring-name)
 - [webhookErrorRoute](#webhookerrorroutestring-route-array-parameters-string-method)
 - [webhookErrorUrl](#webhookerrorurlstring-url-string-method)
+- [webhookEventsRoute](#webhookeventsroutestring-route-array-parameters)
+- [webhookEventsUrl](#webhookeventsurlstring-url)
 - [webhookExtraHeaders](#webhookextraheadersarray-extrahttpheaders)
 - [webhookRoute](#webhookroutestring-route-array-parameters-string-method)
 - [webhookUrl](#webhookurlstring-url-string-method)
@@ -186,7 +188,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+    ->webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
     ->generate()
     ->stream()
 ;
@@ -223,6 +225,33 @@ Sets the webhook for cases of success.<br />Optionally sets a custom HTTP method
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->webhookErrorUrl('https://my.webhook.url', 'PUT')
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsRoute(string \$route, array \$parameters)
+Sets the webhook route with params for event callbacks.<br />
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+    ->generate()
+    ->stream()
+;
+```
+
+### webhookEventsUrl(string \$url)
+Sets the URL that will receive structured JSON event callbacks after each webhook operation.<br />When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),<br />`correlationId`, and `timestamp`.<br />
+
+> [!TIP]
+> See: [https://gotenberg.dev/docs/webhook-download#webhooks](https://gotenberg.dev/docs/webhook-download#webhooks)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->webhookEventsUrl('https://my.webhook.url/events')
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -281,7 +281,8 @@ trait WebhookTrait
                 throw new InvalidBuilderConfiguration(\sprintf('Invalid webhook configuration : You must provide "url" or "route" keys for "%s" configuration.', $type));
             }
 
-            if (\in_array($type, ['success', 'error'], true) && !\in_array($webhook[$type]['method'] ?? '', ['POST', 'PUT', 'PATCH'], true)) {
+            $method = $webhook[$type]['method'] ?? null;
+            if (null !== $method && !\in_array($method, ['POST', 'PUT', 'PATCH'], true) && \in_array($type, ['success', 'error'], true)) {
                 throw new InvalidBuilderConfiguration(\sprintf('Invalid webhook configuration : "POST" "PUT", "PATCH" are the only available methods for "%s" configuration.', $type));
             }
 

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -191,7 +191,8 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params for event callbacks.
      *
-     * @param array<string, mixed> $parameters
+     * @param string                $route #Route
+     * @param array<string, mixed>  $parameters
      *
      * @example webhookEventsRoute('my_route_events', ['foo' => 'bar'])
      */
@@ -217,6 +218,7 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params and method for cases of success.
      *
+     * @param string                    $route #Route
      * @param array<string, mixed>      $parameters
      * @param 'PATCH'|'POST'|'PUT'|null $method
      *
@@ -230,6 +232,7 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params and method for cases of error.
      *
+     * @param string                    $route #Route
      * @param array<string, mixed>      $parameters
      * @param 'PATCH'|'POST'|'PUT'|null $method
      *

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -27,7 +27,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *          route?: string|array{0: string, 1?: array<string, mixed>},
  *          method: 'PUT'|'PATCH'|'POST'|null
  *      },
- *     extra_http_headers?: array<string, string>
+ *     extra_http_headers?: array<string, string>,
+ *     events?: array{
+ *          url?: string,
+ *          route?: string|array{0: string, 1?: array<string, mixed>}
+ *      }
  *  }
  *
  * @package Behavior\\Async
@@ -44,7 +48,7 @@ trait WebhookTrait
      *
      * @see https://gotenberg.dev/docs/webhook-download#webhooks
      *
-     * @example webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST']])
+     * @example webhook(['config_name' => 'my_config', 'success' => ['url' => 'https://my.webhook.url/success', 'method' => 'POST'], 'error' => ['route' => 'my_route_error', 'method' => 'POST'], 'events' => ['url' => 'https://my.webhook.url/events']])
      */
     #[WithConfigurationNode(new WebhookNodeBuilder('webhook', children: [
         new ScalarNodeBuilder('config_name', restrictTo: 'string'),
@@ -59,6 +63,10 @@ trait WebhookTrait
             new EnumNodeBuilder('method', values: ['POST', 'PUT', 'PATCH']),
         ]),
         new ArrayNodeBuilder('extra_http_headers', normalizeKeys: false, useAttributeAsKey: 'name', prototype: 'variable'),
+        new ArrayNodeBuilder('events', children: [
+            new ScalarNodeBuilder('url', restrictTo: 'string'),
+            new VariableNodeBuilder('route'),
+        ]),
     ]))]
     public function webhook(array $webhook): static
     {
@@ -68,6 +76,7 @@ trait WebhookTrait
             $this->getHeadersBag()->unset('Gotenberg-Webhook-Error-Url');
             $this->getHeadersBag()->unset('Gotenberg-Webhook-Error-Method');
             $this->getHeadersBag()->unset('Gotenberg-Webhook-Extra-Http-Headers');
+            $this->getHeadersBag()->unset('Gotenberg-Webhook-Events-Url');
 
             return $this;
         }
@@ -96,12 +105,27 @@ trait WebhookTrait
             }
         }
 
+        if (isset($webhook['events']['route'])) {
+            if (\is_string($webhook['events']['route'])) {
+                $this->webhookEventsRoute($webhook['events']['route']);
+            }
+
+            if (\is_array($webhook['events']['route'])) {
+                $route = $webhook['events']['route'];
+                $this->webhookEventsRoute($route[0], $route[1] ?? []);
+            }
+        }
+
         if (isset($webhook['success']['url'])) {
             $this->webhookUrl($webhook['success']['url'], $webhook['success']['method'] ?? null);
         }
 
         if (isset($webhook['error']['url'])) {
             $this->webhookErrorUrl($webhook['error']['url'], $webhook['error']['method'] ?? null);
+        }
+
+        if (isset($webhook['events']['url'])) {
+            $this->webhookEventsUrl($webhook['events']['url']);
         }
 
         if (isset($webhook['extra_http_headers'])) {
@@ -145,6 +169,36 @@ trait WebhookTrait
         }
 
         return $this;
+    }
+
+    /**
+     * Sets the URL that will receive structured JSON event callbacks after each webhook operation.
+     * When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),
+     * `correlationId`, and `timestamp`.
+     *
+     * @see https://gotenberg.dev/docs/webhook-download#webhooks
+     *
+     * @example webhookEventsUrl('https://my.webhook.url/events')
+     */
+    public function webhookEventsUrl(string $url): static
+    {
+        $this->logWarningIfVersionIs('<', '8.29', 'The option Gotenberg-Webhook-Events-Url is not available.');
+
+        $this->getHeadersBag()->set('Gotenberg-Webhook-Events-Url', $url);
+
+        return $this;
+    }
+
+    /**
+     * Sets the webhook route with params for event callbacks.
+     *
+     * @param array<string, mixed> $parameters
+     *
+     * @example webhookEventsRoute('my_route_events', ['foo' => 'bar'])
+     */
+    public function webhookEventsRoute(string $route, array $parameters = []): static
+    {
+        return $this->webhookEventsUrl($this->getUrlGenerator()->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     /**
@@ -223,12 +277,12 @@ trait WebhookTrait
             throw new InvalidBuilderConfiguration('Invalid webhook configuration : At least a "success" key is required.');
         }
 
-        foreach (['success', 'error'] as $type) {
+        foreach (['success', 'error', 'events'] as $type) {
             if (isset($webhook[$type]['url'], $webhook[$type]['route'])) {
                 throw new InvalidBuilderConfiguration(\sprintf('Invalid webhook configuration : You must provide "url" or "route" keys for "%s" configuration.', $type));
             }
 
-            if (isset($webhook[$type]['method']) && !\in_array($webhook[$type]['method'], ['POST', 'PUT', 'PATCH'], true)) {
+            if (\in_array($type, ['success', 'error'], true) && isset($webhook[$type]['method']) && !\in_array($webhook[$type]['method'], ['POST', 'PUT', 'PATCH'], true)) {
                 throw new InvalidBuilderConfiguration(\sprintf('Invalid webhook configuration : "POST" "PUT", "PATCH" are the only available methods for "%s" configuration.', $type));
             }
 

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -191,7 +191,7 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params for event callbacks.
      *
-     * @param string                $route #Route
+     * @param string                $route      #Route
      * @param array<string, mixed>  $parameters
      *
      * @example webhookEventsRoute('my_route_events', ['foo' => 'bar'])
@@ -218,7 +218,7 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params and method for cases of success.
      *
-     * @param string                    $route #Route
+     * @param string                    $route      #Route
      * @param array<string, mixed>      $parameters
      * @param 'PATCH'|'POST'|'PUT'|null $method
      *
@@ -232,7 +232,7 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params and method for cases of error.
      *
-     * @param string                    $route #Route
+     * @param string                    $route      #Route
      * @param array<string, mixed>      $parameters
      * @param 'PATCH'|'POST'|'PUT'|null $method
      *

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -191,8 +191,8 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params for event callbacks.
      *
-     * @param string                $route     #Route
-     * @param array<string, mixed> $parameters
+     * @param string                $route      #Route
+     * @param array<string, mixed>  $parameters
      *
      * @example webhookEventsRoute('my_route_events', ['foo' => 'bar'])
      */

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -191,8 +191,8 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params for event callbacks.
      *
-     * @param string                $route      #Route
-     * @param array<string, mixed>  $parameters
+     * @param string                $route     #Route
+     * @param array<string, mixed> $parameters
      *
      * @example webhookEventsRoute('my_route_events', ['foo' => 'bar'])
      */

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -191,8 +191,8 @@ trait WebhookTrait
     /**
      * Sets the webhook route with params for event callbacks.
      *
-     * @param string                $route      #Route
-     * @param array<string, mixed>  $parameters
+     * @param string               $route      #Route
+     * @param array<string, mixed> $parameters
      *
      * @example webhookEventsRoute('my_route_events', ['foo' => 'bar'])
      */

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -173,8 +173,7 @@ trait WebhookTrait
 
     /**
      * Sets the URL that will receive structured JSON event callbacks after each webhook operation.
-     * When set, POST requests are sent with event type (`webhook.success` or `webhook.error`),
-     * `correlationId`, and `timestamp`.
+     * When set, POST requests are sent with event type (`webhook.success` or `webhook.error`), `correlationId`, and `timestamp`.
      *
      * @see https://gotenberg.dev/docs/webhook-download#webhooks
      *
@@ -282,7 +281,7 @@ trait WebhookTrait
                 throw new InvalidBuilderConfiguration(\sprintf('Invalid webhook configuration : You must provide "url" or "route" keys for "%s" configuration.', $type));
             }
 
-            if (\in_array($type, ['success', 'error'], true) && isset($webhook[$type]['method']) && !\in_array($webhook[$type]['method'], ['POST', 'PUT', 'PATCH'], true)) {
+            if (\in_array($type, ['success', 'error'], true) && !\in_array($webhook[$type]['method'] ?? '', ['POST', 'PUT', 'PATCH'], true)) {
                 throw new InvalidBuilderConfiguration(\sprintf('Invalid webhook configuration : "POST" "PUT", "PATCH" are the only available methods for "%s" configuration.', $type));
             }
 

--- a/tests/Builder/Behaviors/WebhookTestCaseTrait.php
+++ b/tests/Builder/Behaviors/WebhookTestCaseTrait.php
@@ -39,6 +39,9 @@ trait WebhookTestCaseTrait
                 'extra_http_headers' => [
                     'my_header' => 'value',
                 ],
+                'events' => [
+                    'url' => 'https://my.webhook.url/events',
+                ],
             ])
             ->generate()
         ;
@@ -48,6 +51,7 @@ trait WebhookTestCaseTrait
         $this->assertGotenbergHeader('Gotenberg-Webhook-Error-Url', 'http://example.com/error');
         $this->assertGotenbergHeader('Gotenberg-Webhook-Error-Method', 'POST');
         $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Events-Url', 'https://my.webhook.url/events');
     }
 
     public function testFullWebhookConfigurationWithRoute(): void
@@ -126,6 +130,38 @@ trait WebhookTestCaseTrait
         $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
     }
 
+    public function testFullWebhookConfigurationWithEventsRoute(): void
+    {
+        $router = $this->createMock(Router::class);
+        $router->expects($this->exactly(3))
+            ->method('generate')
+            ->willReturnOnConsecutiveCalls('http://example.com/success', 'http://example.com/error', 'http://example.com/events')
+        ;
+
+        $this->container->set('router', $router);
+
+        $this->getDefaultBuilder()
+            ->webhook([
+                'success' => [
+                    'route' => 'my_route',
+                    'method' => 'PUT',
+                ],
+                'error' => [
+                    'route' => 'my_error_route',
+                    'method' => 'POST',
+                ],
+                'events' => [
+                    'route' => 'my_events_route',
+                ],
+            ])
+            ->generate()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Url', 'http://example.com/success');
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Error-Url', 'http://example.com/error');
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Events-Url', 'http://example.com/events');
+    }
+
     public function testAddWebhookUrlToCallOnSuccessResult(): void
     {
         $this->getDefaultBuilder()
@@ -156,6 +192,16 @@ trait WebhookTestCaseTrait
         ;
 
         $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
+    }
+
+    public function testWebhookEventsUrl(): void
+    {
+        $this->getDefaultBuilder()
+            ->webhookEventsUrl('https://my.webhook.url/events')
+            ->generate()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Webhook-Events-Url', 'https://my.webhook.url/events');
     }
 
     /**
@@ -215,6 +261,49 @@ trait WebhookTestCaseTrait
             ],
             'Invalid webhook configuration : You must provide "url" or "route" keys for "success" configuration.',
         ];
+        yield 'with events route and url configuration' => [
+            [
+                'success' => [
+                    'url' => 'http://example.com/success',
+                    'method' => 'PUT',
+                ],
+                'events' => [
+                    'url' => 'http://example.com/events',
+                    'route' => 'my_events_route',
+                ],
+            ],
+            'Invalid webhook configuration : You must provide "url" or "route" keys for "events" configuration.',
+        ];
+        yield 'with invalid events route configuration' => [
+            [
+                'success' => [
+                    'url' => 'http://example.com/success',
+                    'method' => 'PUT',
+                ],
+                'events' => [
+                    'route' => [
+                        ['my_events_route'],
+                        ['var' => 'foo'],
+                    ],
+                ],
+            ],
+            'Invalid webhook configuration : You must provide a valid route name for "events" configuration.',
+        ];
+        yield 'with invalid events route params configuration' => [
+            [
+                'success' => [
+                    'url' => 'http://example.com/success',
+                    'method' => 'PUT',
+                ],
+                'events' => [
+                    'route' => [
+                        'my_events_route',
+                        'foo',
+                    ],
+                ],
+            ],
+            'Invalid webhook configuration : You must provide valid route parameters for "events" configuration.',
+        ];
     }
 
     /**
@@ -249,6 +338,7 @@ trait WebhookTestCaseTrait
                     'my_header' => 'value',
                 ],
             ])
+            ->webhookEventsUrl('https://my.webhook.url/events')
         ;
 
         self::assertArrayHasKey('Gotenberg-Webhook-Url', $builder->getHeadersBag()->all());
@@ -266,6 +356,9 @@ trait WebhookTestCaseTrait
         self::assertArrayHasKey('Gotenberg-Webhook-Extra-Http-Headers', $builder->getHeadersBag()->all());
         self::assertSame('{"my_header":"value"}', $builder->getHeadersBag()->get('Gotenberg-Webhook-Extra-Http-Headers'));
 
+        self::assertArrayHasKey('Gotenberg-Webhook-Events-Url', $builder->getHeadersBag()->all());
+        self::assertSame('https://my.webhook.url/events', $builder->getHeadersBag()->get('Gotenberg-Webhook-Events-Url'));
+
         $builder->webhook([]);
 
         self::assertArrayNotHasKey('Gotenberg-Webhook-Url', $builder->getHeadersBag()->all());
@@ -273,6 +366,7 @@ trait WebhookTestCaseTrait
         self::assertArrayNotHasKey('Gotenberg-Webhook-Error-Url', $builder->getHeadersBag()->all());
         self::assertArrayNotHasKey('Gotenberg-Webhook-Error-Method', $builder->getHeadersBag()->all());
         self::assertArrayNotHasKey('Gotenberg-Webhook-Extra-Http-Headers', $builder->getHeadersBag()->all());
+        self::assertArrayNotHasKey('Gotenberg-Webhook-Events-Url', $builder->getHeadersBag()->all());
     }
 
     public function testWebhookUrlsCanBeSetUsingTheRegistry(): void

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -283,6 +283,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'metadata' => [
                         ],
@@ -307,6 +308,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'metadata' => [
                         ],
@@ -331,6 +333,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'metadata' => [
                         ],
@@ -351,6 +354,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'metadata' => [
                         ],
@@ -363,6 +367,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'metadata' => [
                         ],
@@ -375,6 +380,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                     ],
                     'split' => [
@@ -385,6 +391,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'metadata' => [
                         ],
@@ -397,6 +404,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                     ],
                 ],
@@ -413,6 +421,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'footer' => [
                             'context' => [],
@@ -435,6 +444,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'footer' => [
                             'context' => [],
@@ -457,6 +467,7 @@ final class ConfigurationTest extends TestCase
                             'error' => [
                             ],
                             'extra_http_headers' => [],
+                            'events' => [],
                         ],
                         'footer' => [
                             'context' => [],


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.29      |
| Bug fix ?               | no   |
| New feature ?           | yes|
| BC break ?              | no   |
| Issues                  | Fix #... |

## Description

Related to https://github.com/gotenberg/gotenberg/releases/tag/v8.29.0
