### PR TITLE
Refactor/deprecate content methods

### DIFF
--- a/UPGRADE-1.2.md
+++ b/UPGRADE-1.2.md
@@ -1,1 +1,13 @@
 # UPGRADE FROM 1.1.0 to 1.2.0
+
+## Deprecations
+
+### `ContentTrait`: header and footer methods moved to `PageMarginalTrait`
+
+The `header()`, `headerRaw()`, `headerFile()`, `footer()`, `footerRaw()` and `footerFile()` methods have been moved out of `ContentTrait` into the new dedicated `PageMarginalTrait`. These methods are still accessible through `ContentTrait` in 1.2 but will be removed in 2.0.
+
+If you use `ContentTrait` directly in your own builders, add `PageMarginalTrait` instead to handle headers and footers.
+
+### `UrlPdfBuilder` and `UrlScreenshotBuilder`: `content*` methods deprecated
+
+The `content()`, `contentRaw()` and `contentFile()` methods are deprecated on `UrlPdfBuilder` and `UrlScreenshotBuilder`. Since the page body is provided by the URL itself, these methods have no effect. Use `url()` or `route()` instead. They will be removed in 2.0.

--- a/UPGRADE-1.2.md
+++ b/UPGRADE-1.2.md
@@ -1,13 +1,1 @@
 # UPGRADE FROM 1.1.0 to 1.2.0
-
-## Deprecations
-
-### `ContentTrait`: header and footer methods moved to `PageMarginalTrait`
-
-The `header()`, `headerRaw()`, `headerFile()`, `footer()`, `footerRaw()` and `footerFile()` methods have been moved out of `ContentTrait` into the new dedicated `PageMarginalTrait`. These methods are still accessible through `ContentTrait` in 1.2 but will be removed in 2.0.
-
-If you use `ContentTrait` directly in your own builders, add `PageMarginalTrait` instead to handle headers and footers.
-
-### `UrlPdfBuilder` and `UrlScreenshotBuilder`: `content*` methods deprecated
-
-The `content()`, `contentRaw()` and `contentFile()` methods are deprecated on `UrlPdfBuilder` and `UrlScreenshotBuilder`. Since the page body is provided by the URL itself, these methods have no effect. Use `url()` or `route()` instead. They will be removed in 2.0.

--- a/UPGRADE-1.4.md
+++ b/UPGRADE-1.4.md
@@ -1,0 +1,13 @@
+# UPGRADE FROM 1.3.0 to 1.4.0
+
+## Deprecations
+
+### `ContentTrait`: header and footer methods moved to `PageMarginalTrait`
+
+The `header()`, `headerRaw()`, `headerFile()`, `footer()`, `footerRaw()` and `footerFile()` methods have been moved out of `ContentTrait` into the new dedicated `PageMarginalTrait`. These methods are still accessible through `ContentTrait` in 1.4 but will be removed in 2.0.
+
+If you use `ContentTrait` directly in your own builders, add `PageMarginalTrait` instead to handle headers and footers.
+
+### `UrlPdfBuilder` and `UrlScreenshotBuilder`: `content*` methods deprecated
+
+The `content()`, `contentRaw()` and `contentFile()` methods are deprecated on `UrlPdfBuilder` and `UrlScreenshotBuilder`. Since the page body is provided by the URL itself, these methods have no effect. Use `url()` or `route()` instead. They will be removed in 2.0.

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -131,6 +131,7 @@ class BuilderParser
 
         $this->prepareBuilderFromClass($class);
         $this->cleanBuilderFromClass($class);
+        $this->filterDeprecatedMethods($class);
 
         foreach ($this->parts['methods']['@'] as $methodName => $parts) {
             $package = $parts['package'] ?? '@';
@@ -341,7 +342,7 @@ class BuilderParser
                 $this->parts['methods']['@'][$method->getShortName()]['package'] = $newPackage;
             }
 
-            if (isset($parsedDocBlock['description']) && [''] !== $parsedDocBlock['description']) {
+            if (isset($parsedDocBlock['description']) && [] !== $parsedDocBlock['description'] && [''] !== $parsedDocBlock['description']) {
                 $this->parts['methods']['@'][$method->getShortName()]['description'] = $parsedDocBlock['description'];
             }
 
@@ -354,6 +355,24 @@ class BuilderParser
                     $this->parts['methods']['@'][$method->getShortName()]['tags']['see'] ?? [],
                     $parsedDocBlock['tags']['see'],
                 )));
+            }
+
+            if (isset($parsedDocBlock['tags']['example']) && [] !== $parsedDocBlock['tags']['example']) {
+                $this->parts['methods']['@'][$method->getShortName()]['tags']['example'] = $parsedDocBlock['tags']['example'];
+            }
+        }
+    }
+
+    /**
+     * @param ReflectionClass<object> $class
+     */
+    private function filterDeprecatedMethods(ReflectionClass $class): void
+    {
+        foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if (str_contains($method->getDocComment() ?: '', '@deprecated')) {
+                unset($this->methodsSignature[$method->getName()]);
+                unset($this->methodsLink[$method->getName()]);
+                unset($this->parts['methods']['@'][$method->getShortName()]);
             }
         }
     }

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -304,6 +304,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -774,7 +783,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->footer('header.html.twig', ['my_var' => 'value'])
+    ->footer('footer.html.twig', ['my_var' => 'value'])
     ->generate()
     ->stream()
 ;
@@ -796,7 +805,7 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+The raw html string to use as the page footer.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -839,7 +848,7 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+The raw html string to use as the page header.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -377,6 +377,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -825,7 +834,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->footer('header.html.twig', ['my_var' => 'value'])
+    ->footer('footer.html.twig', ['my_var' => 'value'])
     ->generate()
     ->stream()
 ;
@@ -847,7 +856,7 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+The raw html string to use as the page footer.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -890,7 +899,7 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+The raw html string to use as the page header.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -114,9 +114,6 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [content](#contentstring-template-array-context)
-- [contentFile](#contentfilestring-path)
-- [contentRaw](#contentrawstring-html)
 - [footer](#footerstring-template-array-context)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
@@ -309,6 +306,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->generate()
+    ->stream()
+;
+```
 
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
@@ -739,40 +745,6 @@ return $gotenberg
 ```
 
 
-### content(string \$template, array \$context)
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->content('content.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### contentFile(string \$path)
-The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->contentFile('../public/content.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### contentRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->contentRaw('<html><body><h2>The content</h2></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
 ### footer(string \$template, array \$context)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -780,7 +752,7 @@ return $gotenberg
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->footer('header.html.twig', ['my_var' => 'value'])
+    ->footer('footer.html.twig', ['my_var' => 'value'])
     ->generate()
     ->stream()
 ;
@@ -802,7 +774,7 @@ return $gotenberg
 ```
 
 ### footerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+The raw html string to use as the page footer.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
@@ -845,7 +817,7 @@ return $gotenberg
 ```
 
 ### headerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
+The raw html string to use as the page header.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -107,12 +107,6 @@ class YourController
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
-- [footerFile](#footerfilestring-path)
-- [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
-- [headerFile](#headerfilestring-path)
-- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -492,30 +486,6 @@ return $gotenberg
     ->stream()
 ;
 ```
-
-### footer(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### footerFile(string \$path)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### footerRaw(string \$html)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### header(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### headerFile(string \$path)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### headerRaw(string \$html)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
 
 ### emulatedMediaFeatures(array \$emulatedMediaFeatures)

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -107,6 +107,12 @@ class YourController
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
+- [footer](#footerstring-template-array-context)
+- [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
+- [header](#headerstring-template-array-context)
+- [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -486,6 +492,30 @@ return $gotenberg
     ->stream()
 ;
 ```
+
+### footer(string \$template, array \$context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### footerFile(string \$path)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### header(string \$template, array \$context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### headerFile(string \$path)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
 
 ### emulatedMediaFeatures(array \$emulatedMediaFeatures)

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -107,12 +107,6 @@ class YourController
 - [content](#contentstring-template-array-context)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
-- [footerFile](#footerfilestring-path)
-- [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
-- [headerFile](#headerfilestring-path)
-- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -146,6 +140,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->generate()
+    ->stream()
+;
+```
 
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
@@ -479,92 +482,6 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->contentRaw('<html><body><h2>The content</h2></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
-### footer(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footer('header.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footerFile('../templates/html/footer.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### footerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
-### header(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->header('header.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->headerFile('../templates/html/header.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### headerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -150,12 +150,6 @@ class YourController
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
-- [footerFile](#footerfilestring-path)
-- [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
-- [headerFile](#headerfilestring-path)
-- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -235,6 +229,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->generate()
+    ->stream()
+;
+```
 
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
@@ -546,92 +549,6 @@ The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->contentRaw('<html><body><h2>The content</h2></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
-### footer(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footer('header.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footerFile('../templates/html/footer.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### footerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
-### header(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->header('header.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->headerFile('../templates/html/header.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### headerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -150,12 +150,6 @@ class YourController
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
-- [footerFile](#footerfilestring-path)
-- [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
-- [headerFile](#headerfilestring-path)
-- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -559,30 +553,6 @@ return $gotenberg
     ->stream()
 ;
 ```
-
-### footer(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### footerFile(string \$path)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### footerRaw(string \$html)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### header(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### headerFile(string \$path)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### headerRaw(string \$html)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
 
 ### emulatedMediaFeatures(array \$emulatedMediaFeatures)

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -150,6 +150,12 @@ class YourController
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
 - [contentRaw](#contentrawstring-html)
+- [footer](#footerstring-template-array-context)
+- [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
+- [header](#headerstring-template-array-context)
+- [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -553,6 +559,30 @@ return $gotenberg
     ->stream()
 ;
 ```
+
+### footer(string \$template, array \$context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### footerFile(string \$path)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### header(string \$template, array \$context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### headerFile(string \$path)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
 
 ### emulatedMediaFeatures(array \$emulatedMediaFeatures)

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -92,6 +92,12 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
+- [footer](#footerstring-template-array-context)
+- [footerFile](#footerfilestring-path)
+- [footerRaw](#footerrawstring-html)
+- [header](#headerstring-template-array-context)
+- [headerFile](#headerfilestring-path)
+- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -463,6 +469,31 @@ return $gotenberg
     ->stream()
 ;
 ```
+
+
+### footer(string \$template, array \$context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### footerFile(string \$path)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### footerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### header(string \$template, array \$context)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### headerFile(string \$path)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
+
+### headerRaw(string \$html)
+> [!TIP]
+> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
 
 ### emulatedMediaFeatures(array \$emulatedMediaFeatures)

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -92,12 +92,6 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [footer](#footerstring-template-array-context)
-- [footerFile](#footerfilestring-path)
-- [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
-- [headerFile](#headerfilestring-path)
-- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -469,31 +463,6 @@ return $gotenberg
     ->stream()
 ;
 ```
-
-
-### footer(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### footerFile(string \$path)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### footerRaw(string \$html)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### header(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### headerFile(string \$path)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-### headerRaw(string \$html)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
 
 ### emulatedMediaFeatures(array \$emulatedMediaFeatures)

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -92,15 +92,6 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [content](#contentstring-template-array-context)
-- [contentFile](#contentfilestring-path)
-- [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
-- [footerFile](#footerfilestring-path)
-- [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
-- [headerFile](#headerfilestring-path)
-- [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
 - [failOnConsoleExceptions](#failonconsoleexceptionsbool-bool)
 - [failOnHttpStatusCodes](#failonhttpstatuscodesarray-statuscodes)
@@ -161,6 +152,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
+
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->generate()
+    ->stream()
+;
+```
 
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
@@ -459,127 +459,6 @@ Selector (e.g. '#id') to query before converting an HTML document into PDF until
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
     ->waitForSelector('#special-id')
-    ->generate()
-    ->stream()
-;
-```
-
-
-### content(string \$template, array \$context)
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->content('content.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### contentFile(string \$path)
-The HTML file to convert into PDF.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->contentFile('../public/content.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### contentRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->contentRaw('<html><body><h2>The content</h2></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
-### footer(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footer('header.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### footerFile(string \$path)
-HTML file containing the footer.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footerFile('../templates/html/footer.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### footerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->footerRaw('<html><body><h6>The footer</h6></body></html>')
-    ->generate()
-    ->stream()
-;
-```
-
-### header(string \$template, array \$context)
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->header('header.html.twig', ['my_var' => 'value'])
-    ->generate()
-    ->stream()
-;
-```
-
-### headerFile(string \$path)
-HTML file containing the header.<br /><br />As assets files, by default the HTML files are fetch in the assets folder of your application.<br />If your HTML files are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->headerFile('../templates/html/header.html')
-    ->generate()
-    ->stream()
-;
-```
-
-### headerRaw(string \$html)
-The raw html string to convert into PDF.<br /><br />Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.<br />Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.<br />
-
-> [!TIP]
-> See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
-
-```php
-return $gotenberg
-    // Your builder call as ->html() and the rest of your configuration code
-    ->headerRaw('<html><body><h1>The header</h1></body></html>')
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -71,8 +71,6 @@ trait ContentTrait
     }
 
     /**
-     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
-     *
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
@@ -84,40 +82,33 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
+    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function header(string $template, array $context = []): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
-
-        return $this;
+        return $this->withRenderedPart(Part::Header, $template, $context);
     }
 
     /**
-     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      */
+    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function headerRaw(string $html): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
-
-        return $this;
+        return $this->withRawPart(Part::Header, $html);
     }
 
     /**
-     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @throws PartRenderingException if the file could not be loaded
      */
+    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function headerFile(string $path): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
-
-        return $this;
+        return $this->withFilePart(Part::Header, $path);
     }
 
     /**
-     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
-     *
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
@@ -129,35 +120,30 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
+    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function footer(string $template, array $context = []): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
-
-        return $this;
+        return $this->withRenderedPart(Part::Footer, $template, $context);
     }
 
     /**
-     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      */
+    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function footerRaw(string $html): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
-
-        return $this;
+        return $this->withRawPart(Part::Footer, $html);
     }
 
     /**
-     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @throws PartRenderingException if the file could not be loaded
      */
+    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function footerFile(string $path): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
-
-        return $this;
+        return $this->withFilePart(Part::Footer, $path);
     }
 
     /**

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -93,7 +93,6 @@ trait ContentTrait
 
     /**
      * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
-     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      */
     public function headerRaw(string $html): static
@@ -105,7 +104,6 @@ trait ContentTrait
 
     /**
      * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
-     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @throws PartRenderingException if the file could not be loaded
@@ -140,7 +138,6 @@ trait ContentTrait
 
     /**
      * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
-     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      */
     public function footerRaw(string $html): static
@@ -152,7 +149,6 @@ trait ContentTrait
 
     /**
      * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
-     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @throws PartRenderingException if the file could not be loaded

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -71,6 +71,8 @@ trait ContentTrait
     }
 
     /**
+     * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
+     *
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
@@ -82,33 +84,42 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
-    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function header(string $template, array $context = []): static
     {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. Use "%s" instead.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
         return $this->withRenderedPart(Part::Header, $template, $context);
     }
 
     /**
+     * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
+     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      */
-    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function headerRaw(string $html): static
     {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. Use "%s" instead.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
         return $this->withRawPart(Part::Header, $html);
     }
 
     /**
+     * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
+     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @throws PartRenderingException if the file could not be loaded
      */
-    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function headerFile(string $path): static
     {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. Use "%s" instead.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
         return $this->withFilePart(Part::Header, $path);
     }
 
     /**
+     * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
+     *
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
@@ -120,29 +131,36 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
-    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function footer(string $template, array $context = []): static
     {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. Use "%s" instead.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
         return $this->withRenderedPart(Part::Footer, $template, $context);
     }
 
     /**
+     * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
+     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      */
-    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function footerRaw(string $html): static
     {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. Use "%s" instead.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
         return $this->withRawPart(Part::Footer, $html);
     }
 
     /**
+     * @deprecated since 1.4, will be removed in 2.0. Use PageMarginalTrait instead.
+     *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
      * @throws PartRenderingException if the file could not be loaded
      */
-    #[\Deprecated(message: 'Will be removed in 2.0. Use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\PageMarginalTrait instead', since: 'sensiolabs/GotenbergBundle:1.4')]
     public function footerFile(string $path): static
     {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. Use "%s" instead.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
         return $this->withFilePart(Part::Footer, $path);
     }
 

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -71,14 +71,14 @@ trait ContentTrait
     }
 
     /**
+     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
+     *
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
      * @throws PartRenderingException if the template could not be rendered
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
-     *
-     * @example header('header.html.twig', ['my_var' => 'value'])
      */
     #[WithConfigurationNode(new ArrayNodeBuilder('header', children: [
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
@@ -86,33 +86,44 @@ trait ContentTrait
     ]))]
     public function header(string $template, array $context = []): static
     {
-        return $this->withRenderedPart(Part::Header, $template, $context);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
-     * The raw html string to convert into PDF.
-     *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
-     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
-     *
+     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
-     *
-     * @example headerRaw('<html><body><h1>The header</h1></body></html>')
      */
     public function headerRaw(string $html): static
     {
-        return $this->withRawPart(Part::Header, $html);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
+     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @throws PartRenderingException if the file could not be loaded
+     */
+    public function headerFile(string $path): static
+    {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
+     *
      * @param string               $template #Template
      * @param array<string, mixed> $context
      *
      * @throws PartRenderingException if the template could not be rendered
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
-     *
-     * @example footer('header.html.twig', ['my_var' => 'value'])
      */
     #[WithConfigurationNode(new ArrayNodeBuilder('footer', children: [
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
@@ -120,64 +131,33 @@ trait ContentTrait
     ]))]
     public function footer(string $template, array $context = []): static
     {
-        return $this->withRenderedPart(Part::Footer, $template, $context);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
-     * The raw html string to convert into PDF.
-     *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
-     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
-     *
+     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
-     *
-     * @example footerRaw('<html><body><h6>The footer</h6></body></html>')
      */
     public function footerRaw(string $html): static
     {
-        return $this->withRawPart(Part::Footer, $html);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
-     * HTML file containing the header.
-     *
-     * As assets files, by default the HTML files are fetch in the assets folder of your application.
-     * If your HTML files are in another folder, you can override the default value of assets_directory in your
-     * configuration file config/sensiolabs_gotenberg.yml.
-     *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
-     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
-     *
+     * @deprecated since 1.2, header/footer support has been moved to PageMarginalTrait. Will be removed in 2.0.
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
      *
-     * @throws PartRenderingException if the template could not be rendered
-     *
-     * @example headerFile('../templates/html/header.html')
-     */
-    public function headerFile(string $path): static
-    {
-        return $this->withFilePart(Part::Header, $path);
-    }
-
-    /**
-     * HTML file containing the footer.
-     *
-     * As assets files, by default the HTML files are fetch in the assets folder of your application.
-     * If your HTML files are in another folder, you can override the default value of assets_directory in your
-     * configuration file config/sensiolabs_gotenberg.yml.
-     *
-     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
-     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
-     *
-     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
-     *
-     * @throws PartRenderingException if the template could not be rendered
-     *
-     * @example footerFile('../templates/html/footer.html')
+     * @throws PartRenderingException if the file could not be loaded
      */
     public function footerFile(string $path): static
     {
-        return $this->withFilePart(Part::Footer, $path);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. Header/footer support has been moved to "%s"; this builder does not support it.', __METHOD__, PageMarginalTrait::class), \E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
@@ -227,8 +207,6 @@ trait ContentTrait
     #[NormalizeGotenbergPayload]
     private function normalizeContent(): \Generator
     {
-        yield 'header.html' => NormalizerFactory::content();
         yield 'index.html' => NormalizerFactory::content();
-        yield 'footer.html' => NormalizerFactory::content();
     }
 }

--- a/src/Builder/Behaviors/Chromium/DeprecatedBodyContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/DeprecatedBodyContentTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium;
+
+/**
+ * @package Behavior\\Content
+ */
+trait DeprecatedBodyContentTrait
+{
+    /**
+     * @deprecated since 1.2, will be removed in 2.0. The page body is provided by the URL.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function content(string $template, array $context = []): static
+    {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 1.2, will be removed in 2.0. The page body is provided by the URL.
+     */
+    public function contentRaw(string $html): static
+    {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 1.2, will be removed in 2.0. The page body is provided by the URL.
+     */
+    public function contentFile(string $path): static
+    {
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
+
+        return $this;
+    }
+}

--- a/src/Builder/Behaviors/Chromium/DeprecatedBodyContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/DeprecatedBodyContentTrait.php
@@ -4,37 +4,39 @@ namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium;
 
 /**
  * @package Behavior\\Content
+ *
+ * @internal
  */
 trait DeprecatedBodyContentTrait
 {
     /**
-     * @deprecated since 1.2, will be removed in 2.0. The page body is provided by the URL.
+     * @deprecated since 1.4, will be removed in 2.0. The page body is provided by the URL.
      *
      * @param array<string, mixed> $context
      */
     public function content(string $template, array $context = []): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this;
     }
 
     /**
-     * @deprecated since 1.2, will be removed in 2.0. The page body is provided by the URL.
+     * @deprecated since 1.4, will be removed in 2.0. The page body is provided by the URL.
      */
     public function contentRaw(string $html): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this;
     }
 
     /**
-     * @deprecated since 1.2, will be removed in 2.0. The page body is provided by the URL.
+     * @deprecated since 1.4, will be removed in 2.0. The page body is provided by the URL.
      */
     public function contentFile(string $path): static
     {
-        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.2: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Since sensiolabs/gotenberg-bundle 1.4: "%s" is deprecated and will be removed in 2.0. The page body is provided by the URL.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this;
     }

--- a/src/Builder/Behaviors/Chromium/PageMarginalTrait.php
+++ b/src/Builder/Behaviors/Chromium/PageMarginalTrait.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium;
+
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
+use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Enumeration\Part;
+use Sensiolabs\GotenbergBundle\Exception\PartRenderingException;
+use Sensiolabs\GotenbergBundle\NodeBuilder\ArrayNodeBuilder;
+use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
+
+/**
+ * @package Behavior\\Content
+ */
+trait PageMarginalTrait
+{
+    abstract protected function getBodyBag(): BodyBag;
+
+    /** @param array<string, mixed> $context */
+    abstract protected function withRenderedPart(Part $part, string $template, array $context = []): static;
+
+    abstract protected function withRawPart(Part $part, string $html): static;
+
+    /** @throws PartRenderingException */
+    abstract protected function withFilePart(Part $part, string $path): static;
+
+    /**
+     * @param string               $template #Template
+     * @param array<string, mixed> $context
+     *
+     * @throws PartRenderingException if the template could not be rendered
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @example header('header.html.twig', ['my_var' => 'value'])
+     */
+    #[WithConfigurationNode(new ArrayNodeBuilder('header', children: [
+        new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
+        new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
+    ]))]
+    public function header(string $template, array $context = []): static
+    {
+        return $this->withRenderedPart(Part::Header, $template, $context);
+    }
+
+    /**
+     * The raw html string to use as the page header.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @example headerRaw('<html><body><h1>The header</h1></body></html>')
+     */
+    public function headerRaw(string $html): static
+    {
+        return $this->withRawPart(Part::Header, $html);
+    }
+
+    /**
+     * HTML file containing the header.
+     *
+     * As assets files, by default the HTML files are fetch in the assets folder of your application.
+     * If your HTML files are in another folder, you can override the default value of assets_directory in your
+     * configuration file config/sensiolabs_gotenberg.yml.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @throws PartRenderingException if the file could not be loaded
+     *
+     * @example headerFile('../templates/html/header.html')
+     */
+    public function headerFile(string $path): static
+    {
+        return $this->withFilePart(Part::Header, $path);
+    }
+
+    /**
+     * @param string               $template #Template
+     * @param array<string, mixed> $context
+     *
+     * @throws PartRenderingException if the template could not be rendered
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @example footer('footer.html.twig', ['my_var' => 'value'])
+     */
+    #[WithConfigurationNode(new ArrayNodeBuilder('footer', children: [
+        new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
+        new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
+    ]))]
+    public function footer(string $template, array $context = []): static
+    {
+        return $this->withRenderedPart(Part::Footer, $template, $context);
+    }
+
+    /**
+     * The raw html string to use as the page footer.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @example footerRaw('<html><body><h6>The footer</h6></body></html>')
+     */
+    public function footerRaw(string $html): static
+    {
+        return $this->withRawPart(Part::Footer, $html);
+    }
+
+    /**
+     * HTML file containing the footer.
+     *
+     * As assets files, by default the HTML files are fetch in the assets folder of your application.
+     * If your HTML files are in another folder, you can override the default value of assets_directory in your
+     * configuration file config/sensiolabs_gotenberg.yml.
+     *
+     * Warning: Assets (css, images, etc...) cannot be parsed and loaded dynamically.
+     * Assets can still be loaded using https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets.
+     *
+     * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer
+     *
+     * @throws PartRenderingException if the file could not be loaded
+     *
+     * @example footerFile('../templates/html/footer.html')
+     */
+    public function footerFile(string $path): static
+    {
+        return $this->withFilePart(Part::Footer, $path);
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizePageMarginal(): \Generator
+    {
+        yield 'header.html' => NormalizerFactory::content();
+        yield 'footer.html' => NormalizerFactory::content();
+    }
+}

--- a/src/Builder/Behaviors/ChromiumPdfTrait.php
+++ b/src/Builder/Behaviors/ChromiumPdfTrait.php
@@ -5,7 +5,14 @@ namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
 trait ChromiumPdfTrait
 {
     use Chromium\AssetTrait;
-    use Chromium\ContentTrait;
+    use Chromium\ContentTrait, Chromium\PageMarginalTrait {
+        Chromium\PageMarginalTrait::header insteadof Chromium\ContentTrait;
+        Chromium\PageMarginalTrait::headerRaw insteadof Chromium\ContentTrait;
+        Chromium\PageMarginalTrait::headerFile insteadof Chromium\ContentTrait;
+        Chromium\PageMarginalTrait::footer insteadof Chromium\ContentTrait;
+        Chromium\PageMarginalTrait::footerRaw insteadof Chromium\ContentTrait;
+        Chromium\PageMarginalTrait::footerFile insteadof Chromium\ContentTrait;
+    }
     use Chromium\CookieTrait;
     use Chromium\CustomHttpHeadersTrait;
     use Chromium\EmulatedMediaFeaturesTrait;

--- a/src/Builder/Pdf/UrlPdfBuilder.php
+++ b/src/Builder/Pdf/UrlPdfBuilder.php
@@ -5,6 +5,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Pdf;
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\DeprecatedBodyContentTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumPdfTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\RequestContextAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
@@ -19,7 +20,12 @@ use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 #[WithBuilderConfiguration(type: 'pdf', name: 'url')]
 final class UrlPdfBuilder extends AbstractBuilder implements BuilderAssetInterface
 {
-    use ChromiumPdfTrait;
+    use ChromiumPdfTrait, DeprecatedBodyContentTrait {
+        DeprecatedBodyContentTrait::content insteadof ChromiumPdfTrait;
+        DeprecatedBodyContentTrait::contentRaw insteadof ChromiumPdfTrait;
+        DeprecatedBodyContentTrait::contentFile insteadof ChromiumPdfTrait;
+    }
+
     use RequestContextAwareTrait;
 
     public const ENDPOINT = '/forms/chromium/convert/url';

--- a/src/Builder/Screenshot/UrlScreenshotBuilder.php
+++ b/src/Builder/Screenshot/UrlScreenshotBuilder.php
@@ -5,6 +5,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Screenshot;
 use Sensiolabs\GotenbergBundle\Builder\AbstractBuilder;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithBuilderConfiguration;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\Chromium\DeprecatedBodyContentTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\ChromiumScreenshotTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\RequestContextAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
@@ -19,7 +20,12 @@ use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
 #[WithBuilderConfiguration(type: 'screenshot', name: 'url')]
 final class UrlScreenshotBuilder extends AbstractBuilder implements BuilderAssetInterface
 {
-    use ChromiumScreenshotTrait;
+    use ChromiumScreenshotTrait, DeprecatedBodyContentTrait {
+        DeprecatedBodyContentTrait::content insteadof ChromiumScreenshotTrait;
+        DeprecatedBodyContentTrait::contentRaw insteadof ChromiumScreenshotTrait;
+        DeprecatedBodyContentTrait::contentFile insteadof ChromiumScreenshotTrait;
+    }
+
     use RequestContextAwareTrait;
 
     public const ENDPOINT = '/forms/chromium/screenshot/url';


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes  + Refactor|
| New feature ?           | no   |
| BC break ?              | no  |
| Issues                  | Fix #257 |

## Description

  Summary
  
  - Extract header/footer methods from ContentTrait into a new dedicated PageMarginalTrait; ChromiumPdfTrait resolves the conflict via insteadof so PDF builders transparently use the real implementation
  - Deprecate content(), contentRaw() and contentFile() on UrlPdfBuilder and UrlScreenshotBuilder via a new DeprecatedBodyContentTrait (these builders receive their body from the URL, not from injected HTML)
  - Fix three bugs in docs/generate.php: @example tags were silently dropped when a method was seen via multiple traits, an empty description from a @deprecated-only docblock could overwrite a non-empty one, and deprecated
   no-op stubs appeared in the generated docs without any content

  See UPGRADE-1.2.md for migration instructions.

Replaces #266 

  Test plan

  - ./vendor/bin/phpunit — all tests pass
  - ./vendor/bin/phpstan analyse — no new errors
  - ./vendor/bin/php-cs-fixer fix --diff — no changes
  - dagger call generate-docs export --path . — docs regenerated cleanly, deprecated methods absent from output
  - Confirm HtmlPdfBuilder::header() uses PageMarginalTrait (not the deprecated stub)
  - Confirm UrlPdfBuilder::content() fires E_USER_DEPRECATED
  
