### PR TITLE
feat: add files order control for merge endpoint

### DIFF
--- a/docs/pdf/MergePdfBuilder.md
+++ b/docs/pdf/MergePdfBuilder.md
@@ -49,6 +49,8 @@ class YourController
 - [metadata](#metadataarray-metadata)
 - [pdfFormat](#pdfformatsensiolabsgotenbergbundleenumerationpdfformat-format)
 - [pdfUniversalAccess](#pdfuniversalaccessbool-bool)
+- [sortFilesByCall](#sortfilesbycall)
+- [sortFilesByName](#sortfilesbyname)
 - [stampExpression](#stampexpressionstring-stampexpression)
 - [stampFile](#stampfilestringablestring-path)
 - [stampOptions](#stampoptionsarray-stampoptions)
@@ -261,6 +263,12 @@ return $gotenberg
     ->stream()
 ;
 ```
+
+### sortFilesByCall()
+Preserves the order in which files were added to the builder.<br />Each file's multipart filename is prefixed with a zero-padded counter<br />(e.g. `000001-document.pdf`) so that Gotenberg's alphanumeric sort<br />yields the original call order. The file on disk is not renamed.
+
+### sortFilesByName()
+Lets Gotenberg sort the files alphanumerically by their multipart filename.<br />This is the default behavior.
 
 ### stampExpression(string \$stampExpression)
 The stamp content. For 'text', the string to render.<br />For 'image' or 'pdf', the filename of the uploaded stamp file.<br />

--- a/src/Builder/Behaviors/FilesOrderTrait.php
+++ b/src/Builder/Behaviors/FilesOrderTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
+
+use Psr\Log\LoggerInterface;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Version\Version;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\File;
+
+trait FilesOrderTrait
+{
+    use FilesTrait {
+        normalizeFiles as private normalizeFilesOriginal;
+    }
+
+    /**
+     * @var 'name'|'call'
+     */
+    private string $filesSortMode = 'name';
+
+    /**
+     * Lets Gotenberg sort the files alphanumerically by their multipart filename.
+     * This is the default behavior.
+     */
+    public function sortFilesByName(): self
+    {
+        $this->filesSortMode = 'name';
+
+        return $this;
+    }
+
+    /**
+     * Preserves the order in which files were added to the builder.
+     * Each file's multipart filename is prefixed with a zero-padded counter
+     * (e.g. `000001-document.pdf`) so that Gotenberg's alphanumeric sort
+     * yields the original call order. The file on disk is not renamed.
+     */
+    public function sortFilesByCall(): self
+    {
+        $this->filesSortMode = 'call';
+
+        return $this;
+    }
+
+    #[NormalizeGotenbergPayload]
+    private function normalizeFiles(): \Generator
+    {
+        $mode = $this->filesSortMode;
+        $delegate = NormalizerFactory::asset();
+
+        yield 'files' => static function (string $key, array $assets, Version $version, LoggerInterface|null $logger) use ($mode, $delegate): \Generator {
+            if ('call' !== $mode || [] === $assets) {
+                yield from $delegate($key, $assets);
+
+                return;
+            }
+
+            $index = 1;
+            foreach ($assets as $entryKey => $info) {
+                yield ['files' => new DataPart(
+                    new File($info),
+                    \sprintf('%06d-%s', $index++, basename($entryKey)),
+                )];
+            }
+        };
+    }
+}

--- a/src/Builder/Pdf/MergePdfBuilder.php
+++ b/src/Builder/Pdf/MergePdfBuilder.php
@@ -9,7 +9,7 @@ use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\AssetBaseDirFormat
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\DownloadFromTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EmbedTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\EncryptTrait;
-use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesTrait;
+use Sensiolabs\GotenbergBundle\Builder\Behaviors\FilesOrderTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\FlattenTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\MetadataTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\PdfFormatTrait;
@@ -40,7 +40,7 @@ final class MergePdfBuilder extends AbstractBuilder
     use DownloadFromTrait;
     use EmbedTrait;
     use EncryptTrait;
-    use FilesTrait;
+    use FilesOrderTrait;
     use FlattenTrait;
     use MetadataTrait;
     use PdfFormatTrait;
@@ -54,6 +54,9 @@ final class MergePdfBuilder extends AbstractBuilder
         'pdf',
     ];
 
+    /**
+     * @return list<string>
+     */
     protected function getAllowedFilesExtensions(): array
     {
         return self::AVAILABLE_EXTENSIONS;

--- a/tests/Builder/Pdf/MergePdfBuilderTest.php
+++ b/tests/Builder/Pdf/MergePdfBuilderTest.php
@@ -18,6 +18,7 @@ use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\StampTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\WatermarkTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\WebhookTestCaseTrait;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Mime\Part\DataPart;
 
 /**
  * @extends GotenbergBuilderTestCase<MergePdfBuilder>
@@ -119,5 +120,75 @@ final class MergePdfBuilderTest extends GotenbergBuilderTestCase
         $this->getBuilder()
             ->generate()
         ;
+    }
+
+    public function testDefaultModeDoesNotPrefixFilenames(): void
+    {
+        $this->getBuilder()
+            ->files('pdf/simple_pdf.pdf', 'pdf/simple_pdf_1.pdf')
+            ->generate()
+        ;
+
+        $this->assertFilesFilenames(['simple_pdf.pdf', 'simple_pdf_1.pdf']);
+    }
+
+    public function testSortFilesByNameIsExplicitDefault(): void
+    {
+        $this->getBuilder()
+            ->sortFilesByName()
+            ->files('pdf/simple_pdf.pdf', 'pdf/simple_pdf_1.pdf')
+            ->generate()
+        ;
+
+        $this->assertFilesFilenames(['simple_pdf.pdf', 'simple_pdf_1.pdf']);
+    }
+
+    public function testSortFilesByCallPrefixesFilenames(): void
+    {
+        $this->getBuilder()
+            ->files('pdf/simple_pdf_1.pdf', 'pdf/simple_pdf.pdf')
+            ->sortFilesByCall()
+            ->generate()
+        ;
+
+        $this->assertFilesFilenames(['000001-simple_pdf_1.pdf', '000002-simple_pdf.pdf']);
+    }
+
+    public function testSortFilesByCallThenByNameRevertsToDefault(): void
+    {
+        $this->getBuilder()
+            ->sortFilesByCall()
+            ->files('pdf/simple_pdf.pdf', 'pdf/simple_pdf_1.pdf')
+            ->sortFilesByName()
+            ->generate()
+        ;
+
+        $this->assertFilesFilenames(['simple_pdf.pdf', 'simple_pdf_1.pdf']);
+    }
+
+    public function testSortFilesByCallWithAbsolutePathOnlyPrefixesBasename(): void
+    {
+        $this->getBuilder()
+            ->sortFilesByCall()
+            ->files(self::FIXTURE_DIR.'/pdf/simple_pdf.pdf')
+            ->generate()
+        ;
+
+        $this->assertFilesFilenames(['000001-simple_pdf.pdf']);
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    private function assertFilesFilenames(array $expected): void
+    {
+        $actual = [];
+        foreach ($this->client->getBody() as $part) {
+            if ($part instanceof DataPart && 'files' === $part->getName()) {
+                $actual[] = $part->getFilename();
+            }
+        }
+
+        self::assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
Introduce sortFilesByName() and sortFilesByCall() on MergePdfBuilder to control how Gotenberg orders files in the merged PDF.

The merge endpoint sorts files alphanumerically by their multipart filename. sortFilesByCall() prefixes each multipart filename with a zero-padded counter (e.g. 000001-document.pdf) so the merge follows the order in which files() was called. sortFilesByName() restores the default behavior. Files on disk are never renamed.

Closes #264

| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | no       |
| New feature ?           | yes      |
| BC break ?              | no       |
| Issues                  | Fix #264 |
