### PR TITLE
feat: add lazy template rendering to stream HTML at send time

### DIFF
--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -138,13 +138,13 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [content](#contentstring-template-array-context)
+- [content](#contentstring-template-array-context-bool-lazy)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
+- [footer](#footerstring-template-array-context-bool-lazy)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
+- [header](#headerstring-template-array-context-bool-lazy)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
@@ -977,7 +977,7 @@ return $gotenberg
 ```
 
 
-### content(string \$template, array \$context)
+### content(string \$template, array \$context, bool \$lazy)
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
@@ -1011,7 +1011,7 @@ return $gotenberg
 ;
 ```
 
-### footer(string \$template, array \$context)
+### footer(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -1054,7 +1054,7 @@ return $gotenberg
 ;
 ```
 
-### header(string \$template, array \$context)
+### header(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -183,10 +183,10 @@ class YourController
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
+- [footer](#footerstring-template-array-context-bool-lazy)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
+- [header](#headerstring-template-array-context-bool-lazy)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
@@ -1053,7 +1053,7 @@ return $gotenberg
 ;
 ```
 
-### footer(string \$template, array \$context)
+### footer(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -1096,7 +1096,7 @@ return $gotenberg
 ;
 ```
 
-### header(string \$template, array \$context)
+### header(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -129,13 +129,13 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [content](#contentstring-template-array-context)
+- [content](#contentstring-template-array-context-bool-lazy)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
+- [footer](#footerstring-template-array-context-bool-lazy)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
+- [header](#headerstring-template-array-context-bool-lazy)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
@@ -974,7 +974,7 @@ return $gotenberg
 ```
 
 
-### content(string \$template, array \$context)
+### content(string \$template, array \$context, bool \$lazy)
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
@@ -1008,7 +1008,7 @@ return $gotenberg
 ;
 ```
 
-### footer(string \$template, array \$context)
+### footer(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -1051,7 +1051,7 @@ return $gotenberg
 ;
 ```
 
-### header(string \$template, array \$context)
+### header(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -107,13 +107,13 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [content](#contentstring-template-array-context)
+- [content](#contentstring-template-array-context-bool-lazy)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
+- [footer](#footerstring-template-array-context-bool-lazy)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
+- [header](#headerstring-template-array-context-bool-lazy)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
@@ -493,7 +493,7 @@ return $gotenberg
 ```
 
 
-### content(string \$template, array \$context)
+### content(string \$template, array \$context, bool \$lazy)
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
@@ -527,7 +527,7 @@ return $gotenberg
 ;
 ```
 
-### footer(string \$template, array \$context)
+### footer(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -570,7 +570,7 @@ return $gotenberg
 ;
 ```
 
-### header(string \$template, array \$context)
+### header(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -153,10 +153,10 @@ class YourController
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
+- [footer](#footerstring-template-array-context-bool-lazy)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
+- [header](#headerstring-template-array-context-bool-lazy)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
@@ -594,7 +594,7 @@ return $gotenberg
 ;
 ```
 
-### footer(string \$template, array \$context)
+### footer(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -637,7 +637,7 @@ return $gotenberg
 ;
 ```
 
-### header(string \$template, array \$context)
+### header(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -95,13 +95,13 @@ class YourController
 - [waitDelay](#waitdelaystring-delay)
 - [waitForExpression](#waitforexpressionstring-expression)
 - [waitForSelector](#waitforselectorstring-selector)
-- [content](#contentstring-template-array-context)
+- [content](#contentstring-template-array-context-bool-lazy)
 - [contentFile](#contentfilestring-path)
 - [contentRaw](#contentrawstring-html)
-- [footer](#footerstring-template-array-context)
+- [footer](#footerstring-template-array-context-bool-lazy)
 - [footerFile](#footerfilestring-path)
 - [footerRaw](#footerrawstring-html)
-- [header](#headerstring-template-array-context)
+- [header](#headerstring-template-array-context-bool-lazy)
 - [headerFile](#headerfilestring-path)
 - [headerRaw](#headerrawstring-html)
 - [emulatedMediaFeatures](#emulatedmediafeaturesarray-emulatedmediafeatures)
@@ -508,7 +508,7 @@ return $gotenberg
 ```
 
 
-### content(string \$template, array \$context)
+### content(string \$template, array \$context, bool \$lazy)
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
@@ -542,7 +542,7 @@ return $gotenberg
 ;
 ```
 
-### footer(string \$template, array \$context)
+### footer(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 
@@ -585,7 +585,7 @@ return $gotenberg
 ;
 ```
 
-### header(string \$template, array \$context)
+### header(string \$template, array \$context, bool \$lazy)
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#header--footer)
 

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -3,12 +3,12 @@
 namespace Sensiolabs\GotenbergBundle\Builder;
 
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Result\GotenbergAsyncResult;
 use Sensiolabs\GotenbergBundle\Builder\Result\GotenbergFileResult;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Builder\ValueObject\StreamedPart;
 use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
 use Sensiolabs\GotenbergBundle\Exception\InvalidNormalizerException;
 use Sensiolabs\GotenbergBundle\Exception\VersionCompatibilityException;
@@ -85,12 +85,11 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     public function generate(): GotenbergFileResult
     {
         $this->validatePayloadBody();
-        $payloadBody = iterator_to_array($this->normalizePayloadBody(), false);
 
         $response = $this->getClient()->call(
             $this->getEndpoint(),
             new Payload(
-                $payloadBody,
+                $this->createPayloadBodyFactory(),
                 $this->getHeadersBag()->all(),
             ),
         );
@@ -105,12 +104,11 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     public function generateAsync(): GotenbergAsyncResult
     {
         $this->validatePayloadBody();
-        $payloadBody = iterator_to_array($this->normalizePayloadBody(), false);
 
         $response = $this->getClient()->call(
             $this->getEndpoint(),
             new Payload(
-                $payloadBody,
+                $this->createPayloadBodyFactory(),
                 $this->getHeadersBag()->all(),
             ),
         );
@@ -159,11 +157,44 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     }
 
     /**
-     * @return \Generator<int, array<string, string>>
+     * @return \Closure(): \Generator<int, array<string, string>>
      */
-    private function normalizePayloadBody(): \Generator
+    private function createPayloadBodyFactory(): \Closure
     {
-        /** @var array<string, (\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $normalizers */
+        $normalizers = $this->getNormalizers();
+        $version = $this->getVersion();
+        $logger = $this->getLogger();
+
+        $normalize = function (bool $streamed) use ($normalizers, $version, $logger): \Generator {
+            foreach ($this->getBodyBag()->all() as $key => $value) {
+                if (($value instanceof StreamedPart) !== $streamed) {
+                    continue;
+                }
+
+                $normalizer = $normalizers[$key] ?? NormalizerFactory::noop();
+
+                if (!\is_callable($normalizer)) {
+                    throw new InvalidNormalizerException(\sprintf('Normalizer "%s" is not a valid callable function.', $key));
+                }
+
+                yield from $normalizer($key, $value, $version, $logger);
+            }
+        };
+
+        // Streamed parts are sent first. Rendering them may register extra fields - assets referenced from a Twig
+        // template, typically - and the body bag is only read back for the remaining fields once every streamed
+        // part has been written to the wire.
+        return static function () use ($normalize): \Generator {
+            yield from $normalize(true);
+            yield from $normalize(false);
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getNormalizers(): array
+    {
         $normalizers = [];
 
         $reflection = new \ReflectionClass(static::class);
@@ -185,17 +216,6 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
             }
         } while ($reflection = $reflection->getParentClass());
 
-        $version = $this->getVersion();
-        $logger = $this->getLogger();
-
-        foreach ($this->getBodyBag()->all() as $key => $value) {
-            $normalizer = $normalizers[$key] ?? NormalizerFactory::noop();
-
-            if (!\is_callable($normalizer)) {
-                throw new InvalidNormalizerException(\sprintf('Normalizer "%s" is not a valid callable function.', $key));
-            }
-
-            yield from $normalizer($key, $value, $version, $logger);
-        }
+        return $normalizers;
     }
 }

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -13,6 +13,7 @@ use Sensiolabs\GotenbergBundle\Builder\ValueObject\StreamedPart;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
 use Sensiolabs\GotenbergBundle\Exception\PartRenderingException;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ArrayNodeBuilder;
+use Sensiolabs\GotenbergBundle\NodeBuilder\BooleanNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ScalarNodeBuilder;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
 
@@ -24,22 +25,35 @@ trait ContentTrait
     use AssetBaseDirFormatterAwareTrait;
     use TwigAwareTrait;
 
+    private bool $lazy = false;
+
     abstract protected function getBodyBag(): BodyBag;
+
+    /**
+     * Only render templates when the HTTP request is sent, streaming the HTML chunk by chunk to keep memory usage
+     * minimal. Rendering errors are then thrown during the request instead of when calling this method.
+     *
+     * @example lazy()
+     */
+    #[WithConfigurationNode(new BooleanNodeBuilder('lazy'))]
+    public function lazy(bool $lazy = true): static
+    {
+        $this->lazy = $lazy;
+
+        return $this;
+    }
 
     /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
-     * @param bool                 $lazy     When true, the template is only rendered when the HTTP request is sent,
-     *                                       streaming the HTML chunk by chunk to keep memory usage minimal. Rendering
-     *                                       errors are then thrown during the request instead of when calling this method.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
      * @example content('content.html.twig', ['my_var' => 'value'])
      */
-    public function content(string $template, array $context = [], bool $lazy = false): self
+    public function content(string $template, array $context = []): self
     {
-        return $this->withRenderedPart(Part::Body, $template, $context, $lazy);
+        return $this->withRenderedPart(Part::Body, $template, $context);
     }
 
     /**
@@ -77,9 +91,6 @@ trait ContentTrait
     /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
-     * @param bool                 $lazy     When true, the template is only rendered when the HTTP request is sent,
-     *                                       streaming the HTML chunk by chunk to keep memory usage minimal. Rendering
-     *                                       errors are then thrown during the request instead of when calling this method.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
@@ -91,9 +102,9 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
-    public function header(string $template, array $context = [], bool $lazy = false): static
+    public function header(string $template, array $context = []): static
     {
-        return $this->withRenderedPart(Part::Header, $template, $context, $lazy);
+        return $this->withRenderedPart(Part::Header, $template, $context);
     }
 
     /**
@@ -114,9 +125,6 @@ trait ContentTrait
     /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
-     * @param bool                 $lazy     When true, the template is only rendered when the HTTP request is sent,
-     *                                       streaming the HTML chunk by chunk to keep memory usage minimal. Rendering
-     *                                       errors are then thrown during the request instead of when calling this method.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
@@ -128,9 +136,9 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
-    public function footer(string $template, array $context = [], bool $lazy = false): static
+    public function footer(string $template, array $context = []): static
     {
-        return $this->withRenderedPart(Part::Footer, $template, $context, $lazy);
+        return $this->withRenderedPart(Part::Footer, $template, $context);
     }
 
     /**
@@ -196,7 +204,7 @@ trait ContentTrait
      *
      * @throws PartRenderingException if the template could not be rendered
      */
-    protected function withRenderedPart(Part $part, string $template, array $context = [], bool $lazy = false): static
+    protected function withRenderedPart(Part $part, string $template, array $context = []): static
     {
         $twig = $this->getTwig();
         $context['_builder'] = $this;
@@ -207,8 +215,8 @@ trait ContentTrait
             throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
         }
 
-        // Rendering is deferred until the request body is sent so the HTML is streamed chunk
-        // by chunk to Gotenberg instead of being buffered in memory.
+        // Rendering is deferred until the request body is sent, so the HTML is streamed chunk by chunk to Gotenberg
+        // instead of being buffered in memory.
         $renderer = function () use ($twig, $loadedTemplate, $template, $part, $context): \Generator {
             $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
             try {
@@ -220,7 +228,7 @@ trait ContentTrait
             }
         };
 
-        if (!$lazy) {
+        if (false === $this->lazy) {
             $html = '';
             foreach ($renderer() as $chunk) {
                 $html .= $chunk;

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -9,6 +9,7 @@ use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\TwigAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Builder\ValueObject\RenderedPart;
+use Sensiolabs\GotenbergBundle\Builder\ValueObject\StreamedPart;
 use Sensiolabs\GotenbergBundle\Enumeration\Part;
 use Sensiolabs\GotenbergBundle\Exception\PartRenderingException;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ArrayNodeBuilder;
@@ -28,14 +29,17 @@ trait ContentTrait
     /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
+     * @param bool                 $lazy     When true, the template is only rendered when the HTTP request is sent,
+     *                                       streaming the HTML chunk by chunk to keep memory usage minimal. Rendering
+     *                                       errors are then thrown during the request instead of when calling this method.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
      * @example content('content.html.twig', ['my_var' => 'value'])
      */
-    public function content(string $template, array $context = []): self
+    public function content(string $template, array $context = [], bool $lazy = false): self
     {
-        return $this->withRenderedPart(Part::Body, $template, $context);
+        return $this->withRenderedPart(Part::Body, $template, $context, $lazy);
     }
 
     /**
@@ -73,6 +77,9 @@ trait ContentTrait
     /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
+     * @param bool                 $lazy     When true, the template is only rendered when the HTTP request is sent,
+     *                                       streaming the HTML chunk by chunk to keep memory usage minimal. Rendering
+     *                                       errors are then thrown during the request instead of when calling this method.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
@@ -84,9 +91,9 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
-    public function header(string $template, array $context = []): static
+    public function header(string $template, array $context = [], bool $lazy = false): static
     {
-        return $this->withRenderedPart(Part::Header, $template, $context);
+        return $this->withRenderedPart(Part::Header, $template, $context, $lazy);
     }
 
     /**
@@ -107,6 +114,9 @@ trait ContentTrait
     /**
      * @param string               $template #Template
      * @param array<string, mixed> $context
+     * @param bool                 $lazy     When true, the template is only rendered when the HTTP request is sent,
+     *                                       streaming the HTML chunk by chunk to keep memory usage minimal. Rendering
+     *                                       errors are then thrown during the request instead of when calling this method.
      *
      * @throws PartRenderingException if the template could not be rendered
      *
@@ -118,9 +128,9 @@ trait ContentTrait
         new ScalarNodeBuilder('template', required: true, restrictTo: 'string'),
         new ArrayNodeBuilder('context', normalizeKeys: false, prototype: 'variable'),
     ]))]
-    public function footer(string $template, array $context = []): static
+    public function footer(string $template, array $context = [], bool $lazy = false): static
     {
-        return $this->withRenderedPart(Part::Footer, $template, $context);
+        return $this->withRenderedPart(Part::Footer, $template, $context, $lazy);
     }
 
     /**
@@ -186,18 +196,45 @@ trait ContentTrait
      *
      * @throws PartRenderingException if the template could not be rendered
      */
-    protected function withRenderedPart(Part $part, string $template, array $context = []): static
+    protected function withRenderedPart(Part $part, string $template, array $context = [], bool $lazy = false): static
     {
-        $this->getTwig()->getRuntime(GotenbergRuntime::class)->setBuilder($this);
+        $twig = $this->getTwig();
+
         try {
-            $renderedPart = new RenderedPart($part, $this->getTwig()->render($template, array_merge($context, ['_builder' => $this])));
+            $loadedTemplate = $twig->load($template);
         } catch (\Throwable $t) {
             throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
-        } finally {
-            $this->getTwig()->getRuntime(GotenbergRuntime::class)->setBuilder(null);
         }
 
-        $this->getBodyBag()->set($part->value, $renderedPart);
+        if (!$lazy) {
+            $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
+            try {
+                $renderedPart = new RenderedPart($part, $loadedTemplate->render(array_merge($context, ['_builder' => $this])));
+            } catch (\Throwable $t) {
+                throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
+            } finally {
+                $twig->getRuntime(GotenbergRuntime::class)->setBuilder(null);
+            }
+
+            $this->getBodyBag()->set($part->value, $renderedPart);
+
+            return $this;
+        }
+
+        // Rendering is deferred until the request body is sent so the HTML is streamed chunk
+        // by chunk to Gotenberg instead of being buffered in memory.
+        $renderer = function () use ($twig, $loadedTemplate, $template, $part, $context): \Generator {
+            $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
+            try {
+                yield from $loadedTemplate->stream(array_merge($context, ['_builder' => $this]));
+            } catch (\Throwable $t) {
+                throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
+            } finally {
+                $twig->getRuntime(GotenbergRuntime::class)->setBuilder(null);
+            }
+        };
+
+        $this->getBodyBag()->set($part->value, new StreamedPart($part, $renderer));
 
         return $this;
     }

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -218,13 +218,21 @@ trait ContentTrait
         // Rendering is deferred until the request body is sent, so the HTML is streamed chunk by chunk to Gotenberg
         // instead of being buffered in memory.
         $renderer = function () use ($twig, $loadedTemplate, $template, $part, $context): \Generator {
-            $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
+            $runtime = $twig->getRuntime(GotenbergRuntime::class);
+            $runtime->setBuilder($this);
+
             try {
-                yield from $loadedTemplate->stream($context);
+                foreach ($loadedTemplate->stream($context) as $chunk) {
+                    yield $chunk;
+
+                    // The runtime is shared: another streamed part may have rendered - and reset it - while this
+                    // generator was suspended on the yield above.
+                    $runtime->setBuilder($this);
+                }
             } catch (\Throwable $t) {
                 throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
             } finally {
-                $twig->getRuntime(GotenbergRuntime::class)->setBuilder(null);
+                $runtime->setBuilder(null);
             }
         };
 

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -199,6 +199,7 @@ trait ContentTrait
     protected function withRenderedPart(Part $part, string $template, array $context = [], bool $lazy = false): static
     {
         $twig = $this->getTwig();
+        $context['_builder'] = $this;
 
         try {
             $loadedTemplate = $twig->load($template);
@@ -209,7 +210,7 @@ trait ContentTrait
         if (!$lazy) {
             $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
             try {
-                $renderedPart = new RenderedPart($part, $loadedTemplate->render(array_merge($context, ['_builder' => $this])));
+                $renderedPart = new RenderedPart($part, $loadedTemplate->render($context));
             } catch (\Throwable $t) {
                 throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
             } finally {
@@ -226,7 +227,7 @@ trait ContentTrait
         $renderer = function () use ($twig, $loadedTemplate, $template, $part, $context): \Generator {
             $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
             try {
-                yield from $loadedTemplate->stream(array_merge($context, ['_builder' => $this]));
+                yield from $loadedTemplate->stream($context);
             } catch (\Throwable $t) {
                 throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
             } finally {

--- a/src/Builder/Behaviors/Chromium/ContentTrait.php
+++ b/src/Builder/Behaviors/Chromium/ContentTrait.php
@@ -207,21 +207,6 @@ trait ContentTrait
             throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
         }
 
-        if (!$lazy) {
-            $twig->getRuntime(GotenbergRuntime::class)->setBuilder($this);
-            try {
-                $renderedPart = new RenderedPart($part, $loadedTemplate->render($context));
-            } catch (\Throwable $t) {
-                throw new PartRenderingException(\sprintf('Could not render template "%s" into PDF part "%s". %s', $template, $part->value, $t->getMessage()), previous: $t);
-            } finally {
-                $twig->getRuntime(GotenbergRuntime::class)->setBuilder(null);
-            }
-
-            $this->getBodyBag()->set($part->value, $renderedPart);
-
-            return $this;
-        }
-
         // Rendering is deferred until the request body is sent so the HTML is streamed chunk
         // by chunk to Gotenberg instead of being buffered in memory.
         $renderer = function () use ($twig, $loadedTemplate, $template, $part, $context): \Generator {
@@ -234,6 +219,17 @@ trait ContentTrait
                 $twig->getRuntime(GotenbergRuntime::class)->setBuilder(null);
             }
         };
+
+        if (!$lazy) {
+            $html = '';
+            foreach ($renderer() as $chunk) {
+                $html .= $chunk;
+            }
+
+            $this->getBodyBag()->set($part->value, new RenderedPart($part, $html));
+
+            return $this;
+        }
 
         $this->getBodyBag()->set($part->value, new StreamedPart($part, $renderer));
 

--- a/src/Builder/Payload.php
+++ b/src/Builder/Payload.php
@@ -8,25 +8,54 @@ use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 final class Payload
 {
     /**
-     * @param list<array<string, string>> $bodyOptions
-     * @param array<string, mixed>        $headersOptions
+     * @var \Closure(): \Generator<int, array<string, mixed>>
+     */
+    private readonly \Closure $bodyOptions;
+
+    /**
+     * @var list<array<string, mixed>>|null
+     */
+    private array|null $resolvedBodyOptions;
+
+    private string|null $boundary = null;
+
+    /**
+     * Passing a closure defers the resolution of the fields until the body is written to the wire.
+     *
+     * @param list<array<string, mixed>>|\Closure(): \Generator<int, array<string, mixed>> $bodyOptions
+     * @param array<string, mixed>                                                         $headersOptions
      */
     public function __construct(
-        private readonly array $bodyOptions,
+        array|\Closure $bodyOptions,
         private readonly array $headersOptions,
     ) {
+        if ($bodyOptions instanceof \Closure) {
+            $this->bodyOptions = $bodyOptions;
+            $this->resolvedBodyOptions = null;
+
+            return;
+        }
+
+        $this->bodyOptions = static function () use ($bodyOptions): \Generator {
+            yield from $bodyOptions;
+        };
+        $this->resolvedBodyOptions = $bodyOptions;
     }
 
     /**
      * Compiles the values into a FormDataPart to send to the HTTP client.
+     *
+     * Deferred fields are resolved without being rendered. Prefer {@see self::bodyToIterable()} to send the
+     * body, as it is the only way for a streamed part to register extra fields while it is being rendered.
      */
     public function getFormData(): FormDataPart
     {
-        return new FormDataPart($this->bodyOptions);
+        return new FormDataPart($this->getBodyOptions());
     }
 
     /**
-     * Compiles the values into Headers to send to the HTTP client.
+     * Compiles the values into Headers to send to the HTTP client, including the Content-Type describing the
+     * body returned by {@see self::bodyToIterable()}.
      */
     public function getHeaders(): Headers
     {
@@ -38,15 +67,62 @@ final class Payload
             $headers->addHeader($name, $value);
         }
 
+        $headers->addParameterizedHeader('Content-Type', 'multipart/form-data', ['boundary' => $this->getBoundary()]);
+
         return $headers;
     }
 
     /**
-     * @return list<array<string, string>>
+     * Compiles the values into a multipart/form-data body, resolving and streaming each part as it goes.
+     *
+     * Each part body must be fully consumed before the next field is pulled: a streamed part registers extra
+     * fields while it is rendered, and those are only picked up by the deferred fields yielded after it.
+     *
+     * @return \Generator<int, string>
+     */
+    public function bodyToIterable(): \Generator
+    {
+        $boundary = $this->getBoundary();
+        $resolved = [];
+
+        foreach ($this->resolvedBodyOptions ?? ($this->bodyOptions)() as $fields) {
+            $resolved[] = $fields;
+
+            foreach ((new FormDataPart([$fields]))->getParts() as $part) {
+                yield '--'.$boundary."\r\n";
+                yield from $part->toIterable();
+                yield "\r\n";
+            }
+        }
+
+        $this->resolvedBodyOptions = $resolved;
+
+        yield '--'.$boundary."--\r\n";
+    }
+
+    /**
+     * Whether the fields are final, which they only are once the body has been written to the wire.
+     *
+     * @internal introspection hook for the profiler
+     */
+    public function isBodyResolved(): bool
+    {
+        return null !== $this->resolvedBodyOptions;
+    }
+
+    /**
+     * Only reflects what was sent once {@see self::isBodyResolved()} is true. Before that, it returns a
+     * provisional snapshot: resolving the fields does not render the streamed parts, so the extra fields they
+     * would register are missing. That snapshot is deliberately not memoized, so the request itself still
+     * resolves the fields against the state the rendering leaves behind.
+     *
+     * @return list<array<string, mixed>>
+     *
+     * @internal introspection hook for the profiler
      */
     public function getBodyOptions(): array
     {
-        return $this->bodyOptions;
+        return $this->resolvedBodyOptions ?? iterator_to_array(($this->bodyOptions)(), false);
     }
 
     /**
@@ -55,5 +131,10 @@ final class Payload
     public function getHeadersOptions(): array
     {
         return $this->headersOptions;
+    }
+
+    private function getBoundary(): string
+    {
+        return $this->boundary ??= strtr(base64_encode(random_bytes(6)), '+/', '-_');
     }
 }

--- a/src/Builder/Util/NormalizerFactory.php
+++ b/src/Builder/Util/NormalizerFactory.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Builder\Util;
 
 use Psr\Log\LoggerInterface;
 use Sensiolabs\GotenbergBundle\Builder\ValueObject\RenderedPart;
+use Sensiolabs\GotenbergBundle\Builder\ValueObject\StreamedPart;
 use Sensiolabs\GotenbergBundle\Enumeration\DownloadFromField;
 use Sensiolabs\GotenbergBundle\Enumeration\Unit;
 use Sensiolabs\GotenbergBundle\Exception\JsonEncodingException;
@@ -164,13 +165,15 @@ class NormalizerFactory
     }
 
     /**
-     * @return (\Closure(string, RenderedPart|\SplFileInfo): list<array{files: DataPart}>)
+     * @return (\Closure(string, RenderedPart|StreamedPart|\SplFileInfo): list<array{files: DataPart}>)
      */
     public static function content(): \Closure
     {
-        return static function (string $key, RenderedPart|\SplFileInfo $value) {
+        return static function (string $key, RenderedPart|StreamedPart|\SplFileInfo $value) {
             if ($value instanceof RenderedPart) {
                 yield ['files' => new DataPart($value->body, $value->type->value, 'text/html')];
+            } elseif ($value instanceof StreamedPart) {
+                yield ['files' => new StreamedDataPart($value->renderer, $value->type->value, 'text/html')];
             } else {
                 yield ['files' => new DataPart(new File($value, $key))];
             }

--- a/src/Builder/Util/StreamedDataPart.php
+++ b/src/Builder/Util/StreamedDataPart.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Util;
+
+use Symfony\Component\Mime\Part\DataPart;
+
+/**
+ * DataPart whose body is generated lazily, chunk by chunk, while the request is sent.
+ */
+class StreamedDataPart extends DataPart
+{
+    /**
+     * @param \Closure(): \Generator<mixed, scalar|\Stringable|null> $renderer
+     */
+    public function __construct(
+        private readonly \Closure $renderer,
+        string $filename,
+        string $contentType,
+    ) {
+        parent::__construct('', $filename, $contentType);
+    }
+
+    public function getBody(): string
+    {
+        return implode('', iterator_to_array(($this->renderer)(), false));
+    }
+
+    public function bodyToString(): string
+    {
+        return $this->getBody();
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function bodyToIterable(): iterable
+    {
+        foreach (($this->renderer)() as $chunk) {
+            yield (string) $chunk;
+        }
+    }
+}

--- a/src/Builder/Util/StreamedDataPart.php
+++ b/src/Builder/Util/StreamedDataPart.php
@@ -2,10 +2,14 @@
 
 namespace Sensiolabs\GotenbergBundle\Builder\Util;
 
+use Sensiolabs\GotenbergBundle\Exception\LogicException;
 use Symfony\Component\Mime\Part\DataPart;
 
 /**
  * DataPart whose body is generated lazily, chunk by chunk, while the request is sent.
+ *
+ * Only {@see self::bodyToIterable()} may consume it: materializing the whole body in memory
+ * would defeat the purpose of streaming it.
  */
 class StreamedDataPart extends DataPart
 {
@@ -29,16 +33,11 @@ class StreamedDataPart extends DataPart
 
     public function getBody(): string
     {
-        return implode('', iterator_to_array(($this->renderer)(), false));
-    }
-
-    public function bodyToString(): string
-    {
-        return $this->getBody();
+        throw new LogicException(\sprintf('A streamed part cannot be materialized in memory, use "%s::bodyToIterable()" instead.', self::class));
     }
 
     /**
-     * @return iterable<string>
+     * @return \Generator<int, string>
      */
     public function bodyToIterable(): iterable
     {

--- a/src/Builder/Util/StreamedDataPart.php
+++ b/src/Builder/Util/StreamedDataPart.php
@@ -10,6 +10,13 @@ use Symfony\Component\Mime\Part\DataPart;
 class StreamedDataPart extends DataPart
 {
     /**
+     * Twig templates yield lots of tiny chunks (one per text node or expression). Yielding them
+     * as-is makes curl send each one as a separate HTTP chunk, slowing the transfer down to the
+     * point of hitting Gotenberg's API timeout. Chunks are buffered to this size before being yielded.
+     */
+    private const CHUNK_SIZE = 16384;
+
+    /**
      * @param \Closure(): \Generator<mixed, scalar|\Stringable|null> $renderer
      */
     public function __construct(
@@ -35,8 +42,17 @@ class StreamedDataPart extends DataPart
      */
     public function bodyToIterable(): iterable
     {
+        $buffer = '';
         foreach (($this->renderer)() as $chunk) {
-            yield (string) $chunk;
+            $buffer .= $chunk;
+            if (\strlen($buffer) >= self::CHUNK_SIZE) {
+                yield $buffer;
+                $buffer = '';
+            }
+        }
+
+        if ('' !== $buffer) {
+            yield $buffer;
         }
     }
 }

--- a/src/Builder/ValueObject/StreamedPart.php
+++ b/src/Builder/ValueObject/StreamedPart.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\ValueObject;
+
+use Sensiolabs\GotenbergBundle\Enumeration\Part;
+
+class StreamedPart
+{
+    /**
+     * @param \Closure(): \Generator<mixed, scalar|\Stringable|null, mixed, void> $renderer
+     */
+    public function __construct(
+        public readonly Part $type,
+        public readonly \Closure $renderer,
+    ) {
+    }
+}

--- a/src/Client/GotenbergClient.php
+++ b/src/Client/GotenbergClient.php
@@ -19,10 +19,6 @@ final class GotenbergClient implements GotenbergClientInterface
     public function call(string $endpoint, Payload $payload): ResponseInterface
     {
         $headers = $payload->getHeaders();
-        $formDataPart = $payload->getFormData();
-        foreach ($formDataPart->getPreparedHeaders()->all() as $header) {
-            $headers->add($header);
-        }
 
         // Unfold header values not accepted by HttpClient
         // @see https://www.rfc-editor.org/rfc/rfc2822.html#section-2.2.3
@@ -34,7 +30,9 @@ final class GotenbergClient implements GotenbergClientInterface
                 $endpoint,
                 [
                     'headers' => array_map($unfold, $headers->toArray()),
-                    'body' => $formDataPart->bodyToIterable(),
+                    // A generator closure, and not the generator itself, so that the HTTP client can restart
+                    // the body from scratch when it retries the request.
+                    'body' => $payload->bodyToIterable(...),
                 ],
             );
         } catch (ExceptionInterface $e) {

--- a/src/Debug/Client/TraceableGotenbergClient.php
+++ b/src/Debug/Client/TraceableGotenbergClient.php
@@ -10,9 +10,9 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 final class TraceableGotenbergClient implements GotenbergClientInterface
 {
     /**
-     * @var list<array{'headers': array<string, mixed>, 'body': list<array<string, string>>}>
+     * @var list<Payload>
      */
-    private array $payload = [];
+    private array $payloads = [];
 
     public function __construct(private readonly GotenbergClientInterface $inner)
     {
@@ -22,10 +22,7 @@ final class TraceableGotenbergClient implements GotenbergClientInterface
     {
         $response = $this->inner->call($endpoint, $payload);
 
-        $this->payload[] = [
-            'headers' => $payload->getHeadersOptions(),
-            'body' => $payload->getBodyOptions(),
-        ];
+        $this->payloads[] = $payload;
 
         return $response;
     }
@@ -36,10 +33,14 @@ final class TraceableGotenbergClient implements GotenbergClientInterface
     }
 
     /**
-     * @return list<array{'headers': array<string, mixed>, 'body': list<array<string, string>>}>
+     * @return list<array{'headers': array<string, mixed>, 'body': list<array<string, mixed>>|null}>
      */
     public function getPayload(): array
     {
-        return $this->payload;
+        // Read as late as possible.
+        return array_map(static fn (Payload $payload): array => [
+            'headers' => $payload->getHeadersOptions(),
+            'body' => $payload->isBodyResolved() ? $payload->getBodyOptions() : null,
+        ], $this->payloads);
     }
 }

--- a/src/Test/Builder/GotenbergBuilderTestCase.php
+++ b/src/Test/Builder/GotenbergBuilderTestCase.php
@@ -157,4 +157,22 @@ abstract class GotenbergBuilderTestCase extends TestCase
 
         $this->fail(\sprintf('No matching content file found with name "%s" and content type "%s".', $filename, $contentType));
     }
+
+    protected function assertContentFileContains(string $filename, string $contentType = 'text/html', string|null $expectedContent = null): void
+    {
+        foreach ($this->client->getBody() as $part) {
+            if (!$part instanceof DataPart || $part->getFilename() !== $filename) {
+                continue;
+            }
+
+            self::assertSame($contentType, $part->getContentType());
+            if (null !== $expectedContent) {
+                self::assertStringContainsString($expectedContent, $part->getBody());
+            }
+
+            return;
+        }
+
+        $this->fail(\sprintf('No matching content file found with name "%s" and content type "%s".', $filename, $contentType));
+    }
 }

--- a/src/Test/Builder/GotenbergBuilderTestCase.php
+++ b/src/Test/Builder/GotenbergBuilderTestCase.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Test\Builder;
 
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
+use Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart;
 use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Version\StaticVersionFetcher;
 use Symfony\Component\DependencyInjection\Container;
@@ -88,7 +89,7 @@ abstract class GotenbergBuilderTestCase extends TestCase
             }
             $found = true;
 
-            $expected = trim($part->getBody());
+            $expected = trim(self::getPartBody($part));
             if (trim($value) === $expected) {
                 $this->addToAssertionCount(1);
 
@@ -149,7 +150,7 @@ abstract class GotenbergBuilderTestCase extends TestCase
 
             self::assertSame($contentType, $part->getContentType());
             if (null !== $expectedContent) {
-                self::assertSame($expectedContent, $part->getBody());
+                self::assertSame($expectedContent, self::getPartBody($part));
             }
 
             return;
@@ -167,12 +168,32 @@ abstract class GotenbergBuilderTestCase extends TestCase
 
             self::assertSame($contentType, $part->getContentType());
             if (null !== $expectedContent) {
-                self::assertStringContainsString($expectedContent, $part->getBody());
+                self::assertStringContainsString($expectedContent, self::getPartBody($part));
             }
 
             return;
         }
 
         $this->fail(\sprintf('No matching content file found with name "%s" and content type "%s".', $filename, $contentType));
+    }
+
+    protected function assertContentFileIsStreamed(string $filename): void
+    {
+        foreach ($this->client->getBody() as $part) {
+            if ($part instanceof StreamedDataPart && $part->getFilename() === $filename) {
+                return;
+            }
+        }
+
+        $this->fail(\sprintf('No streamed content file found with name "%s".', $filename));
+    }
+
+    private static function getPartBody(TextPart|DataPart $part): string
+    {
+        if ($part instanceof StreamedDataPart) {
+            return implode('', iterator_to_array($part->bodyToIterable(), false));
+        }
+
+        return $part->getBody();
     }
 }

--- a/src/Test/Builder/GotenbergClientAsserter.php
+++ b/src/Test/Builder/GotenbergClientAsserter.php
@@ -30,6 +30,10 @@ class GotenbergClientAsserter implements GotenbergClientInterface
         try {
             $this->endpoint = $endpoint;
             $this->payload = $payload;
+
+            // Force DataPart resolution.
+            iterator_to_array($payload->bodyToIterable(), false);
+
             $this->body = $payload->getFormData()->getParts();
         } catch (\Throwable $t) {
             $this->throwable = $t;

--- a/tests/Builder/PayloadTest.php
+++ b/tests/Builder/PayloadTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\Builder\Payload;
+use Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart;
+
+#[CoversClass(Payload::class)]
+final class PayloadTest extends TestCase
+{
+    /**
+     * A streamed part registers extra fields while it is rendered, so the deferred fields must be resolved
+     * against the state left behind by the parts already written to the wire.
+     */
+    public function testBodyToIterableSendsFieldsRegisteredWhileRendering(): void
+    {
+        $payload = new Payload(self::createBodyFactory(), []);
+
+        self::assertSame(['index.html', 'late.txt'], self::filenamesOf($payload));
+    }
+
+    /**
+     * Reading the fields before the body is sent cannot trigger the rendering, so the snapshot it returns is
+     * incomplete. Memoizing it would make the request itself miss those fields.
+     */
+    public function testReadingBodyOptionsEarlyDoesNotTruncateTheBody(): void
+    {
+        $payload = new Payload(self::createBodyFactory(), []);
+
+        self::assertCount(1, $payload->getBodyOptions());
+        self::assertSame(['index.html', 'late.txt'], self::filenamesOf($payload));
+    }
+
+    public function testBodyIsNotResolvedUntilItHasBeenSent(): void
+    {
+        $payload = new Payload(self::createBodyFactory(), []);
+
+        self::assertFalse($payload->isBodyResolved());
+
+        self::filenamesOf($payload);
+
+        self::assertTrue($payload->isBodyResolved());
+    }
+
+    public function testFieldsGivenUpfrontAreResolvedFromTheStart(): void
+    {
+        $payload = new Payload([['url' => 'https://example.com']], []);
+
+        self::assertTrue($payload->isBodyResolved());
+    }
+
+    public function testBodyIsRestartedFromScratchOnEveryIteration(): void
+    {
+        $payload = new Payload(self::createBodyFactory(), []);
+
+        foreach ($payload->bodyToIterable() as $chunk) {
+            break; // breaks before full resolution
+        }
+
+        self::assertSame(['index.html', 'late.txt'], self::filenamesOf($payload));
+    }
+
+    /**
+     * @return \Closure(): \Generator<int, array<string, mixed>>
+     */
+    private static function createBodyFactory(): \Closure
+    {
+        $registered = [];
+
+        return static function () use (&$registered): \Generator {
+            $registered = [];
+
+            yield ['files' => new StreamedDataPart(static function () use (&$registered): \Generator {
+                yield '<html>';
+                $registered[] = 'late.txt';
+                yield '</html>';
+            }, 'index.html', 'text/html')];
+
+            foreach ($registered as $name) {
+                yield ['files' => new StreamedDataPart(static fn (): \Generator => yield 'late', $name, 'text/plain')];
+            }
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function filenamesOf(Payload $payload): array
+    {
+        $body = implode('', iterator_to_array($payload->bodyToIterable(), false));
+
+        preg_match_all('/filename="([^"]+)"/', $body, $matches);
+
+        return $matches[1];
+    }
+}

--- a/tests/Builder/Pdf/HtmlPdfBuilderTest.php
+++ b/tests/Builder/Pdf/HtmlPdfBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Builder\Pdf;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
 use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
 use Sensiolabs\GotenbergBundle\Exception\MissingRequiredFieldException;
@@ -10,6 +11,7 @@ use Sensiolabs\GotenbergBundle\Formatter\AssetBaseDirFormatter;
 use Sensiolabs\GotenbergBundle\Test\Builder\GotenbergBuilderTestCase;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\ChromiumPdfTestCaseTrait;
 use Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors\EmbedTestCaseTrait;
+use Sensiolabs\GotenbergBundle\Twig\GotenbergExtension;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
 use Symfony\Component\DependencyInjection\Container;
 use Twig\Environment;
@@ -157,6 +159,34 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
         $this->assertContentFileContains('header.html', 'text/html', 'My Header');
         $this->assertContentFileContains('index.html', 'text/html', 'My PDF');
         $this->assertContentFileContains('footer.html', 'text/html', 'My Footer');
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testTwigContentRegistersAssetsFromTheTemplate(bool $lazy): void
+    {
+        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
+
+        $twig = new Environment(new FilesystemLoader(self::FIXTURE_DIR), [
+            'strict_variables' => true,
+        ]);
+        $twig->addExtension(new GotenbergExtension());
+        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
+            public function load(string $class): object|null
+            {
+                return GotenbergRuntime::class === $class ? new GotenbergRuntime() : null;
+            }
+        });
+
+        $this->container->set('twig', $twig);
+
+        $this->getBuilder()
+            ->lazy($lazy)
+            ->content('templates/header_with_asset.html.twig', ['name' => 'world'])
+            ->generate()
+        ;
+
+        $this->assertGotenbergFormDataFile('files', 'image/png', self::FIXTURE_DIR.'/assets/logo.png');
     }
 
     public function testWithRawHtmlWithHeaderAndFooterParts(): void

--- a/tests/Builder/Pdf/HtmlPdfBuilderTest.php
+++ b/tests/Builder/Pdf/HtmlPdfBuilderTest.php
@@ -125,6 +125,46 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
         $this->assertContentFile('index.html', 'text/html', $expected);
     }
 
+    public function testWithLazyTwigContentFile(): void
+    {
+        $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
+
+        $twig = new Environment(new FilesystemLoader(self::FIXTURE_DIR), [
+            'strict_variables' => true,
+        ]);
+
+        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
+            public function load(string $class): object|null
+            {
+                return GotenbergRuntime::class === $class ? new GotenbergRuntime() : null;
+            }
+        });
+
+        $this->container->set('twig', $twig);
+
+        $this->getBuilder()
+            ->content('templates/content.html.twig', ['name' => 'world'], lazy: true)
+            ->generate()
+        ;
+
+        $expected = <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <title>My PDF</title>
+            </head>
+            <body>
+                <h1>Hello world!</h1>
+                <img src="logo.png" />
+            </body>
+        </html>
+
+        HTML;
+
+        $this->assertContentFile('index.html', 'text/html', $expected);
+    }
+
     public function testWithRawHtmlWithHeaderAndFooterParts(): void
     {
         $this->getBuilder()

--- a/tests/Builder/Pdf/HtmlPdfBuilderTest.php
+++ b/tests/Builder/Pdf/HtmlPdfBuilderTest.php
@@ -143,26 +143,15 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
         $this->container->set('twig', $twig);
 
         $this->getBuilder()
-            ->content('templates/content.html.twig', ['name' => 'world'], lazy: true)
+            ->header('templates/header.html.twig', ['name' => 'world'], true)
+            ->content('templates/content.html.twig', ['name' => 'world'], true)
+            ->footer('templates/footer.html.twig', ['name' => 'world'], true)
             ->generate()
         ;
 
-        $expected = <<<HTML
-        <!DOCTYPE html>
-        <html lang="en">
-            <head>
-                <meta charset="utf-8" />
-                <title>My PDF</title>
-            </head>
-            <body>
-                <h1>Hello world!</h1>
-                <img src="logo.png" />
-            </body>
-        </html>
-
-        HTML;
-
-        $this->assertContentFile('index.html', 'text/html', $expected);
+        $this->assertContentFileContains('header.html', 'text/html', 'My Header');
+        $this->assertContentFileContains('index.html', 'text/html', 'My PDF');
+        $this->assertContentFileContains('footer.html', 'text/html', 'My Footer');
     }
 
     public function testWithRawHtmlWithHeaderAndFooterParts(): void

--- a/tests/Builder/Pdf/HtmlPdfBuilderTest.php
+++ b/tests/Builder/Pdf/HtmlPdfBuilderTest.php
@@ -125,7 +125,7 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
         $this->assertContentFile('index.html', 'text/html', $expected);
     }
 
-    public function testWithLazyTwigContentFile(): void
+    public function testWithLazyTwigContent(): void
     {
         $this->container->set('asset_base_dir_formatter', new AssetBaseDirFormatter(self::FIXTURE_DIR, [self::FIXTURE_DIR]));
 
@@ -143,11 +143,16 @@ final class HtmlPdfBuilderTest extends GotenbergBuilderTestCase
         $this->container->set('twig', $twig);
 
         $this->getBuilder()
-            ->header('templates/header.html.twig', ['name' => 'world'], true)
-            ->content('templates/content.html.twig', ['name' => 'world'], true)
-            ->footer('templates/footer.html.twig', ['name' => 'world'], true)
+            ->lazy()
+            ->header('templates/header.html.twig', ['name' => 'world'])
+            ->content('templates/content.html.twig', ['name' => 'world'])
+            ->footer('templates/footer.html.twig', ['name' => 'world'])
             ->generate()
         ;
+
+        $this->assertContentFileIsStreamed('header.html');
+        $this->assertContentFileIsStreamed('index.html');
+        $this->assertContentFileIsStreamed('footer.html');
 
         $this->assertContentFileContains('header.html', 'text/html', 'My Header');
         $this->assertContentFileContains('index.html', 'text/html', 'My PDF');

--- a/tests/Builder/Util/StreamedDataPartTest.php
+++ b/tests/Builder/Util/StreamedDataPartTest.php
@@ -5,11 +5,12 @@ namespace Sensiolabs\GotenbergBundle\Tests\Builder\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart;
+use Sensiolabs\GotenbergBundle\Exception\LogicException;
 
 #[CoversClass(StreamedDataPart::class)]
 final class StreamedDataPartTest extends TestCase
 {
-    public function testGetBodyMaterializesTheRenderedContent(): void
+    public function testBodyToIterableYieldsTheRenderedContent(): void
     {
         $part = new StreamedDataPart(
             static function (): \Generator {
@@ -24,8 +25,27 @@ final class StreamedDataPartTest extends TestCase
             'text/html',
         );
 
-        self::assertSame('Hello <strong>Jean-Beru</strong>!', $part->getBody());
-        self::assertSame('Hello <strong>Jean-Beru</strong>!', $part->bodyToString());
+        self::assertSame('Hello <strong>Jean-Beru</strong>!', implode('', iterator_to_array($part->bodyToIterable(), false)));
+    }
+
+    public function testGetBodyThrows(): void
+    {
+        $part = new StreamedDataPart(static fn (): \Generator => yield 'Hello', 'index.html', 'text/html');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A streamed part cannot be materialized in memory, use "Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart::bodyToIterable()" instead.');
+
+        $part->getBody();
+    }
+
+    public function testBodyToStringThrows(): void
+    {
+        $part = new StreamedDataPart(static fn (): \Generator => yield 'Hello', 'index.html', 'text/html');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A streamed part cannot be materialized in memory, use "Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart::bodyToIterable()" instead.');
+
+        $part->bodyToString();
     }
 
     public function testBodyToIterableBuffersSmallChunks(): void

--- a/tests/Builder/Util/StreamedDataPartTest.php
+++ b/tests/Builder/Util/StreamedDataPartTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Builder\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart;
+
+#[CoversClass(StreamedDataPart::class)]
+final class StreamedDataPartTest extends TestCase
+{
+    public function testGetBodyMaterializesTheRenderedContent(): void
+    {
+        $part = new StreamedDataPart(
+            static function (): \Generator {
+                yield 'Hello';
+                yield ' ';
+                yield '<strong>';
+                yield 'Jean-Beru';
+                yield '</strong>';
+                yield '!';
+            },
+            'index.html',
+            'text/html',
+        );
+
+        self::assertSame('Hello <strong>Jean-Beru</strong>!', $part->getBody());
+        self::assertSame('Hello <strong>Jean-Beru</strong>!', $part->bodyToString());
+    }
+
+    public function testBodyToIterableBuffersSmallChunks(): void
+    {
+        $part = new StreamedDataPart(
+            static function (): \Generator {
+                $stream = array_fill(0, 10_000, 'text'); // 40,000 chars
+                foreach ($stream as $chunk) {
+                    yield $chunk;
+                }
+            },
+            'index.html',
+            'text/html',
+        );
+
+        $chunks = [];
+        foreach ($part->bodyToIterable() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        self::assertCount(3, $chunks); // 16384 x 3 = 49152 chars max
+    }
+}

--- a/tests/Debug/Client/TraceableGotenbergClientTest.php
+++ b/tests/Debug/Client/TraceableGotenbergClientTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Tests\Debug\Client;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\GotenbergBundle\Builder\Payload;
+use Sensiolabs\GotenbergBundle\Builder\Util\StreamedDataPart;
+use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
+use Sensiolabs\GotenbergBundle\Debug\Client\TraceableGotenbergClient;
+
+#[CoversClass(TraceableGotenbergClient::class)]
+final class TraceableGotenbergClientTest extends TestCase
+{
+    public function testCollectedBodyHoldsTheFieldsRegisteredWhileRendering(): void
+    {
+        $client = $this->createTraceableClient();
+        $payload = self::createPayload();
+
+        $client->call('/some/url', $payload);
+        iterator_to_array($payload->bodyToIterable(), false);
+
+        self::assertSame(['index.html', 'late.txt'], self::filenamesOf($client->getPayload()[0]['body']));
+    }
+
+    public function testCollectedBodyIsNotReportedBeforeItIsSent(): void
+    {
+        $client = $this->createTraceableClient();
+
+        $client->call('/some/url', self::createPayload());
+
+        self::assertNull($client->getPayload()[0]['body']);
+    }
+
+    public function testCollectedHeadersAreTheOnesSetOnTheBuilder(): void
+    {
+        $client = $this->createTraceableClient();
+
+        $client->call('/some/url', new Payload([], ['Gotenberg-Output-Filename' => 'invoice']));
+
+        self::assertSame(['Gotenberg-Output-Filename' => 'invoice'], $client->getPayload()[0]['headers']);
+    }
+
+    private function createTraceableClient(): TraceableGotenbergClient
+    {
+        return new TraceableGotenbergClient($this->createStub(GotenbergClientInterface::class));
+    }
+
+    private static function createPayload(): Payload
+    {
+        $registered = [];
+
+        return new Payload(static function () use (&$registered): \Generator {
+            $registered = [];
+
+            yield ['files' => new StreamedDataPart(static function () use (&$registered): \Generator {
+                yield '<html>';
+                $registered[] = 'late.txt';
+                yield '</html>';
+            }, 'index.html', 'text/html')];
+
+            foreach ($registered as $name) {
+                yield ['files' => new StreamedDataPart(static fn (): \Generator => yield 'late', $name, 'text/plain')];
+            }
+        }, []);
+    }
+
+    /**
+     * @param list<array<string, mixed>>|null $body
+     *
+     * @return list<string>
+     */
+    private static function filenamesOf(array|null $body): array
+    {
+        self::assertIsArray($body);
+
+        return array_map(static function (array $fields): string {
+            $part = reset($fields);
+            self::assertInstanceOf(StreamedDataPart::class, $part);
+
+            return (string) $part->getFilename();
+        }, $body);
+    }
+}


### PR DESCRIPTION
 | Q                       | A        |
  |-------------------------|----------|
  | Gotenberg API version ? | 8.x      |
  | Bug fix ?               | no       |
  | New feature ?           | yes      |
  | BC break ?              | no       |

## Description

When calling `content($template, $context)` (or `header()` / `footer()`), the Twig template is rendered immediately and the resulting HTML is kept in memory until the request is sent to Gotenberg.
  
This PR adds a `$lazy` argument to `content()`, `header()` and `footer()`. When set to `true`, the template is only rendered while the HTTP request body is sent. Peak memory usage is then a single Twig output chunk instead of the full document.

Lazy rendering is disabled by default to keep BC promise.

## Example

```php
public function __invoke(GotenbergPdfInterface $gotenberg): Response
{
    return $gotenberg->html()
        ->content('invoice.html.twig', ['invoice' => $invoice], lazy: true)
        ->generate()
        ->stream();
}
```

## Screenshots

Example: 5000 lines containing an inlined svg + a paragraph.

### Before

<img width="971" height="693" alt="image" src="https://github.com/user-attachments/assets/51b7064c-73cd-4961-af41-27b7d99cd4d2" />

### After

<img width="971" height="693" alt="image" src="https://github.com/user-attachments/assets/7d220862-3c38-4ccd-ada9-3c23ef63f4c6" />
