### PR TITLE
fix: remove query string from packages assets

### DIFF
--- a/src/Twig/GotenbergRuntime.php
+++ b/src/Twig/GotenbergRuntime.php
@@ -87,7 +87,11 @@ final class GotenbergRuntime
 
         $packages = $this->packages;
         if (null !== $packages) {
+            // Remove leading slash since the path from a package is relative
             $path = ltrim($packages->getUrl($path), '/');
+
+            // Remove the query string or fragment added by some version strategy (e.g. "?v=abc123")
+            $path = substr($path, 0, strcspn($path, '?#'));
         }
 
         return $path;

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Twig;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\GotenbergBundle\Builder\BuilderAssetInterface;
 use Sensiolabs\GotenbergBundle\Twig\GotenbergRuntime;
@@ -109,7 +110,9 @@ class GotenbergRuntimeTest extends TestCase
         $this->assertSame('result.png', $path);
     }
 
-    public function testGetAssetUrlWhenPackagesWithQueryString(): void
+    #[TestWith(['/build/front/my_file.css?v=abc123'])]
+    #[TestWith(['/build/front/my_file.css#abc123'])]
+    public function testGetAssetUrlWhenPackagesWithUrlSpecificCharactersString(string $assetPathUrl): void
     {
         $builder = $this->createMock(BuilderAssetInterface::class);
         $builder->expects($this->once())
@@ -121,7 +124,7 @@ class GotenbergRuntimeTest extends TestCase
         $packages->expects($this->once())
             ->method('getUrl')
             ->with('/build/front/my_file.css')
-            ->willReturn('/build/front/my_file.css?v=abc123')
+            ->willReturn($assetPathUrl)
         ;
 
         $runtime = new GotenbergRuntime($packages, null);

--- a/tests/Twig/GotenbergRuntimeTest.php
+++ b/tests/Twig/GotenbergRuntimeTest.php
@@ -109,6 +109,29 @@ class GotenbergRuntimeTest extends TestCase
         $this->assertSame('result.png', $path);
     }
 
+    public function testGetAssetUrlWhenPackagesWithQueryString(): void
+    {
+        $builder = $this->createMock(BuilderAssetInterface::class);
+        $builder->expects($this->once())
+            ->method('addAsset')
+            ->with('build/front/my_file.css')
+        ;
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->with('/build/front/my_file.css')
+            ->willReturn('/build/front/my_file.css?v=abc123')
+        ;
+
+        $runtime = new GotenbergRuntime($packages, null);
+        $runtime->setBuilder($builder);
+
+        $path = $runtime->getAssetUrl('/build/front/my_file.css');
+
+        $this->assertSame('my_file.css', $path);
+    }
+
     public function testGetAssetUrlWhenAssetMapperRepositoryAndPackages(): void
     {
         $builder = $this->createMock(BuilderAssetInterface::class);


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | Fix #281  |

## Description

Some version strategies add a query string or a fragment in the asset path. Ex: `my_file?v=3`. 

This PR fixes errors occurring when attempting to retrieve the file from the filesystem (ex: using `gotenberg_assert`).
