### PR TITLE
Normalize request headers before dispatch

### DIFF
--- a/UPGRADE-1.4.md
+++ b/UPGRADE-1.4.md
@@ -1,0 +1,5 @@
+# UPGRADE FROM 1.3.0 to 1.4.0
+
+## Breaking changes
+
+* `AbstractBuilder::getHeadersBag()` now retains `Gotenberg-Webhook-Extra-Http-Headers` as an array until the payload is built. Code reading this value directly must expect an array instead of a JSON string.

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -155,7 +155,7 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     {
         /** @var array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $bodyNormalizers */
         $bodyNormalizers = [];
-        /** @var array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, mixed>>)> $headerNormalizers */
+        /** @var array<string, false|(\Closure(string, mixed, Version, LoggerInterface|null): list<array<string, mixed>>)> $headerNormalizers */
         $headerNormalizers = [];
 
         $reflection = new \ReflectionClass(static::class);

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -174,7 +174,7 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
                 }
 
                 if (true === $hasBodyAttributes && true === $hasHeaderAttributes) {
-                    throw new LogicException(\sprintf('Only one of [%s] is allowed on a single method.', \implode(', ', [
+                    throw new LogicException(\sprintf('Only one of [%s] is allowed on a single method.', implode(', ', [
                         NormalizeGotenbergPayload::class,
                         NormalizeGotenbergHeaders::class,
                     ])));

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -12,6 +12,7 @@ use Sensiolabs\GotenbergBundle\Builder\Result\GotenbergFileResult;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Client\GotenbergClientInterface;
 use Sensiolabs\GotenbergBundle\Exception\InvalidNormalizerException;
+use Sensiolabs\GotenbergBundle\Exception\LogicException;
 use Sensiolabs\GotenbergBundle\Exception\VersionCompatibilityException;
 use Sensiolabs\GotenbergBundle\Processor\NullProcessor;
 use Sensiolabs\GotenbergBundle\Processor\ProcessorInterface;
@@ -165,19 +166,26 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
                     continue;
                 }
 
-                $bodyAttributes = $method->getAttributes(NormalizeGotenbergPayload::class);
-                $headerAttributes = $method->getAttributes(NormalizeGotenbergHeaders::class);
+                $hasBodyAttributes = \count($method->getAttributes(NormalizeGotenbergPayload::class)) > 0;
+                $hasHeaderAttributes = \count($method->getAttributes(NormalizeGotenbergHeaders::class)) > 0;
 
-                if (\count($bodyAttributes) === 0 && \count($headerAttributes) === 0) {
+                if (false === $hasBodyAttributes && false === $hasHeaderAttributes) {
                     continue;
                 }
 
+                if (true === $hasBodyAttributes && true === $hasHeaderAttributes) {
+                    throw new LogicException(\sprintf('Only one of [%s] is allowed on a single method.', \implode(', ', [
+                        NormalizeGotenbergPayload::class,
+                        NormalizeGotenbergHeaders::class,
+                    ])));
+                }
+
                 foreach ($method->invoke($this) as $key => $value) {
-                    if (\count($bodyAttributes) > 0) {
+                    if (true === $hasBodyAttributes) {
                         $bodyNormalizers[$key] = $value;
                     }
 
-                    if (\count($headerAttributes) > 0) {
+                    if (true === $hasHeaderAttributes) {
                         $headerNormalizers[$key] = $value;
                     }
                 }

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -194,7 +194,7 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     }
 
     /**
-     * @param array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $normalizers
+     * @param array<string, false|(\Closure(string, mixed, Version, LoggerInterface|null): list<array<string, string>>)> $normalizers
      *
      * @return \Generator<int, array<string, string>>
      */
@@ -212,7 +212,7 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     }
 
     /**
-     * @param array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, mixed>>)> $normalizers
+     * @param array<string, false|(\Closure(string, mixed, Version, LoggerInterface|null): list<array<string, mixed>>)> $normalizers
      *
      * @return \Generator<int, array<string, mixed>>
      */

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -4,6 +4,7 @@ namespace Sensiolabs\GotenbergBundle\Builder;
 
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergHeaders;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\LoggerAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Result\GotenbergAsyncResult;
@@ -85,14 +86,10 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     public function generate(): GotenbergFileResult
     {
         $this->validatePayloadBody();
-        $payloadBody = iterator_to_array($this->normalizePayloadBody(), false);
 
         $response = $this->getClient()->call(
             $this->getEndpoint(),
-            new Payload(
-                $payloadBody,
-                $this->getHeadersBag()->all(),
-            ),
+            $this->buildPayload(),
         );
 
         return new GotenbergFileResult(
@@ -105,14 +102,10 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
     public function generateAsync(): GotenbergAsyncResult
     {
         $this->validatePayloadBody();
-        $payloadBody = iterator_to_array($this->normalizePayloadBody(), false);
 
         $response = $this->getClient()->call(
             $this->getEndpoint(),
-            new Payload(
-                $payloadBody,
-                $this->getHeadersBag()->all(),
-            ),
+            $this->buildPayload(),
         );
 
         return new GotenbergAsyncResult(
@@ -158,13 +151,12 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
         }
     }
 
-    /**
-     * @return \Generator<int, array<string, string>>
-     */
-    private function normalizePayloadBody(): \Generator
+    private function buildPayload(): Payload
     {
-        /** @var array<string, (\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $normalizers */
-        $normalizers = [];
+        /** @var array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $bodyNormalizers */
+        $bodyNormalizers = [];
+        /** @var array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, mixed>>)> $headerNormalizers */
+        $headerNormalizers = [];
 
         $reflection = new \ReflectionClass(static::class);
         do {
@@ -173,14 +165,21 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
                     continue;
                 }
 
-                $attributes = $method->getAttributes(NormalizeGotenbergPayload::class);
+                $bodyAttributes = $method->getAttributes(NormalizeGotenbergPayload::class);
+                $headerAttributes = $method->getAttributes(NormalizeGotenbergHeaders::class);
 
-                if (\count($attributes) === 0) {
+                if (\count($bodyAttributes) === 0 && \count($headerAttributes) === 0) {
                     continue;
                 }
 
                 foreach ($method->invoke($this) as $key => $value) {
-                    $normalizers[$key] = $value;
+                    if (\count($bodyAttributes) > 0) {
+                        $bodyNormalizers[$key] = $value;
+                    }
+
+                    if (\count($headerAttributes) > 0) {
+                        $headerNormalizers[$key] = $value;
+                    }
                 }
             }
         } while ($reflection = $reflection->getParentClass());
@@ -188,7 +187,38 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
         $version = $this->getVersion();
         $logger = $this->getLogger();
 
+        return new Payload(
+            iterator_to_array($this->normalizePayloadBody($bodyNormalizers, $version, $logger), false),
+            array_merge(...iterator_to_array($this->normalizePayloadHeaders($headerNormalizers, $version, $logger), false)),
+        );
+    }
+
+    /**
+     * @param array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $normalizers
+     *
+     * @return \Generator<int, array<string, string>>
+     */
+    private function normalizePayloadBody(array $normalizers, Version $version, LoggerInterface|null $logger): \Generator
+    {
         foreach ($this->getBodyBag()->all() as $key => $value) {
+            $normalizer = $normalizers[$key] ?? NormalizerFactory::noop();
+
+            if (!\is_callable($normalizer)) {
+                throw new InvalidNormalizerException(\sprintf('Normalizer "%s" is not a valid callable function.', $key));
+            }
+
+            yield from $normalizer($key, $value, $version, $logger);
+        }
+    }
+
+    /**
+     * @param array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, mixed>>)> $normalizers
+     *
+     * @return \Generator<int, array<string, mixed>>
+     */
+    private function normalizePayloadHeaders(array $normalizers, Version $version, LoggerInterface|null $logger): \Generator
+    {
+        foreach ($this->getHeadersBag()->all() as $key => $value) {
             $normalizer = $normalizers[$key] ?? NormalizerFactory::noop();
 
             if (!\is_callable($normalizer)) {

--- a/src/Builder/AbstractBuilder.php
+++ b/src/Builder/AbstractBuilder.php
@@ -153,7 +153,7 @@ abstract class AbstractBuilder implements BuilderAsyncInterface, BuilderFileInte
 
     private function buildPayload(): Payload
     {
-        /** @var array<string, false|(\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, string>>)> $bodyNormalizers */
+        /** @var array<string, false|(\Closure(string, mixed, Version, LoggerInterface|null): list<array<string, string>>)> $bodyNormalizers */
         $bodyNormalizers = [];
         /** @var array<string, false|(\Closure(string, mixed, Version, LoggerInterface|null): list<array<string, mixed>>)> $headerNormalizers */
         $headerNormalizers = [];

--- a/src/Builder/Attributes/NormalizeGotenbergHeaders.php
+++ b/src/Builder/Attributes/NormalizeGotenbergHeaders.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sensiolabs\GotenbergBundle\Builder\Attributes;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class NormalizeGotenbergHeaders
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/Builder/Behaviors/WebhookTrait.php
+++ b/src/Builder/Behaviors/WebhookTrait.php
@@ -2,10 +2,12 @@
 
 namespace Sensiolabs\GotenbergBundle\Builder\Behaviors;
 
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergHeaders;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\WithConfigurationNode;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\UrlGeneratorAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\Behaviors\Dependencies\WebhookConfigurationRegistryAwareTrait;
 use Sensiolabs\GotenbergBundle\Builder\HeadersBag;
+use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
 use Sensiolabs\GotenbergBundle\NodeBuilder\ArrayNodeBuilder;
 use Sensiolabs\GotenbergBundle\NodeBuilder\EnumNodeBuilder;
@@ -210,7 +212,7 @@ trait WebhookTrait
      */
     public function webhookExtraHeaders(array $extraHttpHeaders): static
     {
-        $this->getHeadersBag()->set('Gotenberg-Webhook-Extra-Http-Headers', json_encode($extraHttpHeaders));
+        $this->getHeadersBag()->set('Gotenberg-Webhook-Extra-Http-Headers', $extraHttpHeaders);
 
         return $this;
     }
@@ -228,10 +230,15 @@ trait WebhookTrait
             return $this;
         }
 
-        $current = $this->getHeadersBag()->get('Gotenberg-Webhook-Extra-Http-Headers');
-        $current = null !== $current ? json_decode($current, true) : [];
+        $current = $this->getHeadersBag()->get('Gotenberg-Webhook-Extra-Http-Headers', []);
 
         return $this->webhookExtraHeaders(array_merge($current, $extraHttpHeaders));
+    }
+
+    #[NormalizeGotenbergHeaders]
+    private function normalizeWebhookHeaders(): \Generator
+    {
+        yield 'Gotenberg-Webhook-Extra-Http-Headers' => NormalizerFactory::json();
     }
 
     /**

--- a/src/Builder/Util/NormalizerFactory.php
+++ b/src/Builder/Util/NormalizerFactory.php
@@ -17,11 +17,11 @@ use Symfony\Component\Routing\RequestContext;
 class NormalizerFactory
 {
     /**
-     * @return (\Closure(string, mixed): list<array<string, mixed>>)
+     * @return (\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, mixed>>)
      */
     public static function noop(): \Closure
     {
-        return static fn (string $key, mixed $value) => yield [$key => $value];
+        return static fn (string $key, mixed $value, Version|null $version = null, LoggerInterface|null $logger = null) => yield [$key => $value];
     }
 
     /**

--- a/src/Builder/Util/NormalizerFactory.php
+++ b/src/Builder/Util/NormalizerFactory.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\RequestContext;
 class NormalizerFactory
 {
     /**
-     * @return (\Closure(string, mixed, Version=, LoggerInterface|null=): list<array<string, mixed>>)
+     * @return (\Closure(string, mixed): list<array<string, mixed>>)
      */
     public static function noop(): \Closure
     {

--- a/src/Builder/Util/NormalizerFactory.php
+++ b/src/Builder/Util/NormalizerFactory.php
@@ -21,7 +21,7 @@ class NormalizerFactory
      */
     public static function noop(): \Closure
     {
-        return static fn (string $key, mixed $value, Version|null $version = null, LoggerInterface|null $logger = null) => yield [$key => $value];
+        return static fn (string $key, mixed $value) => yield [$key => $value];
     }
 
     /**

--- a/src/PHPStanRules/AlwaysUsedMethodRule.php
+++ b/src/PHPStanRules/AlwaysUsedMethodRule.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Methods\AlwaysUsedMethodExtension;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergHeaders;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 
 final class AlwaysUsedMethodRule implements AlwaysUsedMethodExtension
@@ -34,8 +35,10 @@ final class AlwaysUsedMethodRule implements AlwaysUsedMethodExtension
 
         try {
             $refMethod = new \ReflectionMethod($className, $methodReflection->getName());
-            if ([] !== $refMethod->getAttributes(NormalizeGotenbergPayload::class)) {
-                return true;
+            foreach ([NormalizeGotenbergPayload::class, NormalizeGotenbergHeaders::class] as $attribute) {
+                if ([] !== $refMethod->getAttributes($attribute)) {
+                    return true;
+                }
             }
         } catch (\ReflectionException) {
         }

--- a/tests/Builder/AbstractBuilderNormalizeTest.php
+++ b/tests/Builder/AbstractBuilderNormalizeTest.php
@@ -24,4 +24,24 @@ final class AbstractBuilderNormalizeTest extends GotenbergBuilderTestCase
 
         $this->assertGotenbergFormData('feature', 'true');
     }
+
+    public function testNormalizeHeadersFromTraitUsedInAbstractParent(): void
+    {
+        $this->getBuilder()
+            ->enableHeaderFeature()
+            ->generate()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Feature', 'true');
+    }
+
+    public function testNormalizeHeadersForAsyncRequest(): void
+    {
+        $this->getBuilder()
+            ->enableHeaderFeature()
+            ->generateAsync()
+        ;
+
+        $this->assertGotenbergHeader('Gotenberg-Feature', 'true');
+    }
 }

--- a/tests/Builder/Behaviors/WebhookTestCaseTrait.php
+++ b/tests/Builder/Behaviors/WebhookTestCaseTrait.php
@@ -5,6 +5,7 @@ namespace Sensiolabs\GotenbergBundle\Tests\Builder\Behaviors;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Sensiolabs\GotenbergBundle\Builder\BuilderInterface;
 use Sensiolabs\GotenbergBundle\Exception\InvalidBuilderConfiguration;
+use Sensiolabs\GotenbergBundle\Exception\JsonEncodingException;
 use Sensiolabs\GotenbergBundle\Webhook\WebhookConfigurationRegistryInterface;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\RequestContext;
@@ -226,6 +227,16 @@ trait WebhookTestCaseTrait
         $this->assertGotenbergHeader('Gotenberg-Webhook-Extra-Http-Headers', '{"my_header":"value"}');
     }
 
+    public function testWebhookExtraHeadersRejectInvalidUtf8(): void
+    {
+        $this->expectException(JsonEncodingException::class);
+
+        $this->getDefaultBuilder()
+            ->webhookExtraHeaders(['my_header' => "\xB1"])
+            ->generate()
+        ;
+    }
+
     public function testWebhookEventsUrl(): void
     {
         $this->getDefaultBuilder()
@@ -386,7 +397,7 @@ trait WebhookTestCaseTrait
         self::assertSame('POST', $builder->getHeadersBag()->get('Gotenberg-Webhook-Error-Method'));
 
         self::assertArrayHasKey('Gotenberg-Webhook-Extra-Http-Headers', $builder->getHeadersBag()->all());
-        self::assertSame('{"my_header":"value"}', $builder->getHeadersBag()->get('Gotenberg-Webhook-Extra-Http-Headers'));
+        self::assertSame(['my_header' => 'value'], $builder->getHeadersBag()->get('Gotenberg-Webhook-Extra-Http-Headers'));
 
         self::assertArrayHasKey('Gotenberg-Webhook-Events-Url', $builder->getHeadersBag()->all());
         self::assertSame('https://my.webhook.url/events', $builder->getHeadersBag()->get('Gotenberg-Webhook-Events-Url'));

--- a/tests/Builder/Fixtures/BehaviorTestTrait.php
+++ b/tests/Builder/Fixtures/BehaviorTestTrait.php
@@ -2,13 +2,11 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Builder\Fixtures;
 
-use Psr\Log\LoggerInterface;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergHeaders;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
 use Sensiolabs\GotenbergBundle\Builder\HeadersBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
-use Sensiolabs\GotenbergBundle\Version\Version;
 
 trait BehaviorTestTrait
 {

--- a/tests/Builder/Fixtures/BehaviorTestTrait.php
+++ b/tests/Builder/Fixtures/BehaviorTestTrait.php
@@ -39,7 +39,7 @@ trait BehaviorTestTrait
     #[NormalizeGotenbergHeaders]
     private function normalizeHeaderFeature(): \Generator
     {
-        yield 'Gotenberg-Feature' => static function (string $key, bool $value, Version $version, LoggerInterface|null $logger): \Generator {
+        yield 'Gotenberg-Feature' => static function (string $key, bool $value): \Generator {
             yield [$key => $value ? 'true' : 'false'];
         };
     }

--- a/tests/Builder/Fixtures/BehaviorTestTrait.php
+++ b/tests/Builder/Fixtures/BehaviorTestTrait.php
@@ -2,13 +2,19 @@
 
 namespace Sensiolabs\GotenbergBundle\Tests\Builder\Fixtures;
 
+use Psr\Log\LoggerInterface;
+use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergHeaders;
 use Sensiolabs\GotenbergBundle\Builder\Attributes\NormalizeGotenbergPayload;
 use Sensiolabs\GotenbergBundle\Builder\BodyBag;
+use Sensiolabs\GotenbergBundle\Builder\HeadersBag;
 use Sensiolabs\GotenbergBundle\Builder\Util\NormalizerFactory;
+use Sensiolabs\GotenbergBundle\Version\Version;
 
 trait BehaviorTestTrait
 {
     abstract protected function getBodyBag(): BodyBag;
+
+    abstract protected function getHeadersBag(): HeadersBag;
 
     public function enableFeature(): static
     {
@@ -21,5 +27,20 @@ trait BehaviorTestTrait
     private function normalizeFeature(): \Generator
     {
         yield 'feature' => NormalizerFactory::bool();
+    }
+
+    public function enableHeaderFeature(): static
+    {
+        $this->getHeadersBag()->set('Gotenberg-Feature', true);
+
+        return $this;
+    }
+
+    #[NormalizeGotenbergHeaders]
+    private function normalizeHeaderFeature(): \Generator
+    {
+        yield 'Gotenberg-Feature' => static function (string $key, bool $value, Version $version, LoggerInterface|null $logger): \Generator {
+            yield [$key => $value ? 'true' : 'false'];
+        };
     }
 }


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes      |
| New feature ?           | no       |
| BC break ?              | no       |
| Issues                  | Fix #272 |

## Description

Webhook extra headers were JSON-encoded as soon as they entered the builder. Adding more values therefore required decoding and re-encoding the stored header, and encoding failures could silently produce an empty value.

This adds a header-specific normalization attribute, parallel to the existing request-body normalization mechanism. Webhook extra headers now remain arrays while the builder is configured, merge directly, and are encoded once when the payload is created. The outbound JSON format remains unchanged, while invalid JSON input now raises the bundle's existing `JsonEncodingException`.

Both synchronous and asynchronous request paths use the same header normalization step. The PHPStan always-used extension also recognizes private header normalizers.

## Validation

- PHPUnit: 1,085 tests and 2,199 assertions on Symfony 6.4.42, 7.4.14, and 8.1.1
- PHP CS Fixer: 245 files, no changes required
- Composer dependency analyser: no issues
- Documentation generation and `git diff --check`: passed
- PHPStan: no new diagnostics; the two existing `WebhookTrait` diagnostics reproduce on the unchanged base
