### PR TITLE
Fix content encoding issue that arises when using a reverse proxy

### DIFF
--- a/src/Builder/Result/GotenbergFileResult.php
+++ b/src/Builder/Result/GotenbergFileResult.php
@@ -114,6 +114,7 @@ class GotenbergFileResult extends AbstractGotenbergResult
         $filename = $this->getFileName();
 
         $headers = $this->getHeaders();
+        unset($headers['content-encoding'], $headers['content-length'], $headers['transfer-encoding'], $headers['connection']);
         $headers['X-Accel-Buffering'] = ['no']; // See https://symfony.com/doc/current/components/http_foundation.html#streaming-a-json-response
         if ($filename) {
             $headers['Content-Disposition'] = [HeaderUtils::makeDisposition($this->disposition, $filename)];

--- a/tests/Builder/Result/GotenbergFileResultTest.php
+++ b/tests/Builder/Result/GotenbergFileResultTest.php
@@ -95,6 +95,33 @@ class GotenbergFileResultTest extends TestCase
         self::assertSame('firstsecondlast', $output);
     }
 
+    public function testStreamDoesNotForwardStaleTransportHeaders(): void
+    {
+        $mockResponse = new MockResponse('decompressed pdf content', [
+            'response_headers' => [
+                'content-type' => 'application/pdf',
+                'content-disposition' => 'inline; filename=test.pdf',
+                'content-encoding' => 'gzip',
+                'content-length' => '42',
+                'transfer-encoding' => 'chunked',
+                'connection' => 'keep-alive',
+            ],
+        ]);
+
+        $client = new MockHttpClient([$mockResponse]);
+        $stream = $client->stream($client->request('GET', '/dummy'));
+
+        $fileResult = new GotenbergFileResult($stream, new InMemoryProcessor(), HeaderUtils::DISPOSITION_ATTACHMENT);
+
+        $headers = $fileResult->stream()->headers;
+
+        self::assertFalse($headers->has('content-encoding'));
+        self::assertFalse($headers->has('content-length'));
+        self::assertFalse($headers->has('transfer-encoding'));
+        self::assertFalse($headers->has('connection'));
+        self::assertSame('application/pdf', $headers->get('content-type'));
+    }
+
     public function testCannotProcessedAnAlreadyProcessedQuery(): void
     {
         $fileResult = $this->getGotenbergFileResult();


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes   |
| New feature ?           | no   |
| BC break ?              | no   |
| Issues                  | N/A |

## Description

This is a fix for a problem I ran into earlier today, namely Firefox showing me:

```
Content Encoding Error

The page you are trying to view cannot be shown because it uses an invalid or unsupported form of compression.
```

The cause:

We configured an external Gotenberg server behind a reverse proxy (long story as to why). Symfony tells this server to gzip the response and decompresses the PDF when it receives it back from the Gotenberg server. So far so good.

Then, when I stream the response back to the client, the response header still contains the metadata of the gzipped response, which is wrong. The `content-encoding` and `content-length` of the gzipped response is not the same as those of the streamed response.

```
#[Route('/{myEntity}/pdf', methods: ['GET'])]
public function pdf(Entity $myEntity): StreamedResponse
{
    // more logic here

    return $this->gotenberg
        ->html()
        ->content(...)
        ->generate()
        ->stream();
}
```

The workaround to add `Accept-Encoding` also worked for me:

```
framework:
    http_client:
        scoped_clients:
            gotenberg.client:
                base_uri: '%env(GOTENBERG_DSN)%'
                headers:
                    Accept-Encoding: 'identity'
```

But it relies on the proxy server honoring this setting.

The fix removes these two `content-*` headers, because `Content-Encoding: gzip` is wrong for the streamed response and `Content-Length` is irrelevant for a streamed response.
