### PR TITLE
fix(docs): keep @example tags when a method is seen through several traits

### DIFF
--- a/docs/generate.php
+++ b/docs/generate.php
@@ -361,6 +361,10 @@ class BuilderParser
                     $parsedDocBlock['tags']['see'],
                 )));
             }
+
+            if (isset($parsedDocBlock['tags']['example']) && [] !== $parsedDocBlock['tags']['example']) {
+                $this->parts['methods']['@'][$method->getShortName()]['tags']['example'] = $parsedDocBlock['tags']['example'];
+            }
         }
     }
 

--- a/docs/pdf/HtmlPdfBuilder.md
+++ b/docs/pdf/HtmlPdfBuilder.md
@@ -509,6 +509,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -518,7 +527,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/MarkdownPdfBuilder.md
+++ b/docs/pdf/MarkdownPdfBuilder.md
@@ -573,6 +573,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -582,7 +591,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
     ->generate()
     ->stream()
 ;

--- a/docs/pdf/UrlPdfBuilder.md
+++ b/docs/pdf/UrlPdfBuilder.md
@@ -506,6 +506,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -515,7 +524,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/HtmlScreenshotBuilder.md
+++ b/docs/screenshot/HtmlScreenshotBuilder.md
@@ -151,6 +151,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -160,7 +169,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/MarkdownScreenshotBuilder.md
+++ b/docs/screenshot/MarkdownScreenshotBuilder.md
@@ -240,6 +240,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -249,7 +258,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
     ->generate()
     ->stream()
 ;

--- a/docs/screenshot/UrlScreenshotBuilder.md
+++ b/docs/screenshot/UrlScreenshotBuilder.md
@@ -166,6 +166,15 @@ Adds a file, like an image, font, stylesheet, and so on.<br /><br />By default, 
 > [!TIP]
 > See: [https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets](https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets)
 
+```php
+return $gotenberg
+    // Your builder call as ->html() and the rest of your configuration code
+    ->addAsset('../img/ceo.jpeg')
+    ->generate()
+    ->stream()
+;
+```
+
 ### assets(Stringable|string ...\$paths)
 Adds additional files, like images, fonts, stylesheets, and so on (overrides any previous files).<br /><br />By default, the assets files are fetch in the assets folder of your application.<br />If your assets are in another folder, you can override the default value of assets_directory in your<br />configuration file config/sensiolabs_gotenberg.yml.<br />
 
@@ -175,7 +184,7 @@ Adds additional files, like images, fonts, stylesheets, and so on (overrides any
 ```php
 return $gotenberg
     // Your builder call as ->html() and the rest of your configuration code
-    ->assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+    ->assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
     ->generate()
     ->stream()
 ;

--- a/src/Builder/Behaviors/Chromium/AssetTrait.php
+++ b/src/Builder/Behaviors/Chromium/AssetTrait.php
@@ -25,7 +25,7 @@ trait AssetTrait
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets
      *
-     * @example assets('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+     * @example assets('../img/ceo.jpeg', __DIR__.'/../../public/admin.jpeg')
      */
     public function assets(string|\Stringable ...$paths): static
     {
@@ -49,7 +49,7 @@ trait AssetTrait
      *
      * @see https://gotenberg.dev/docs/convert-with-chromium/convert-html-to-pdf#assets
      *
-     * @example addAsset('../img/ceo.jpeg', __DIR__'/../../public/admin.jpeg')
+     * @example addAsset('../img/ceo.jpeg')
      */
     public function addAsset(string|\Stringable $path): static
     {


### PR DESCRIPTION
| Q                       | A        |
|-------------------------|----------|
| Gotenberg API version ? | 8.x      |
| Bug fix ?               | yes      |
| New feature ?           | no       |
| BC break ?              | no       |
| Issues                  | -        |

## Description

`BuilderParser::prepareBuilderFromClass()` walks parents, interfaces and traits, then the class
itself, merging what it finds along the way. The merge branch propagated `package`, `description`,
`param` and `see` — but not `example`.

So as soon as a method was reached a second time (which happens for every method a builder gets
through an aggregate trait such as `ChromiumPdfTrait`), its `@example` tag was replaced by the empty
one coming from the later pass, and the code sample silently disappeared from the generated
documentation.

The six Chromium builders were affected: `addAsset()` lost its sample in all of them. Regenerating
brings it back.

The two `AssetTrait` samples that come back were not valid PHP — `__DIR__'/../../public/admin.jpeg'`
is a syntax error — and the `addAsset()` one passed two paths where the method takes a single one
(`addAsset(string|\Stringable $path)`). Both are fixed here, otherwise this PR would put broken code
back into the docs.

## Test plan

- `php ./docs/generate.php` — the only diff is the six restored samples, nothing else moves
- `./vendor/bin/phpunit` — 1095 tests, 2217 assertions, green
- `./vendor/bin/phpstan analyse` — no errors
- `./vendor/bin/php-cs-fixer check` — clean